### PR TITLE
Updating lint rules and fixing errors

### DIFF
--- a/src/app/core/auth/session.model.ts
+++ b/src/app/core/auth/session.model.ts
@@ -1,3 +1,3 @@
 export class Session {
-	name: string
+	name: string;
 }

--- a/src/app/core/auth/session.service.ts
+++ b/src/app/core/auth/session.service.ts
@@ -13,11 +13,11 @@ import { Session } from './session.model';
 @Injectable()
 export class SessionService {
 
-	// Previous url to store in case we want to redirect there later
-	private previousUrl: string;
-
 	// The current session information
 	sessionSubject = new BehaviorSubject<Session>(null);
+
+	// Previous url to store in case we want to redirect there later
+	private previousUrl: string;
 
 	constructor(
 		private authService: AuthenticationService,

--- a/src/app/core/config.model.ts
+++ b/src/app/core/config.model.ts
@@ -1,19 +1,19 @@
 interface AppConfig {
-	title: string
+	title: string;
 }
 
 interface BannerConfig {
-	html: string,
-	style: string
+	html: string;
+	style: string;
 }
 
 export interface Config {
-	auth: string,
+	auth: string;
 
-	app: AppConfig,
-	version: string,
-	contactEmail: string,
+	app: AppConfig;
+	version: string;
+	contactEmail: string;
 
-	banner: BannerConfig,
-	copyright: BannerConfig
+	banner: BannerConfig;
+	copyright: BannerConfig;
 }

--- a/src/app/core/page-title.service.ts
+++ b/src/app/core/page-title.service.ts
@@ -24,7 +24,7 @@ export class PageTitleService {
 			let appTitle = _.get(config, 'app.title', null);
 
 			this.router.events.pipe(
-				filter(event => event instanceof NavigationEnd),
+				filter((event) => event instanceof NavigationEnd),
 				map(() => this.activatedRoute),
 				map((route) => {
 					// Get to the leaf route

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -2,13 +2,11 @@
 	"extends": "../tslint.json",
 	"rules": {
 		"directive-selector": [
-			true,
 			"attribute",
 			"app",
 			"camelCase"
 		],
 		"component-selector": [
-			true,
 			"element",
 			"app",
 			"kebab-case"

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,9 @@
 {
 	"extends": "tslint:recommended",
 	"rules": {
-		"ban-types": false,
-		"interface-over-type-literal": false,
+    "ban-types": false,
+    "interface-name" : [true, "never-prefix"],
+    "interface-over-type-literal": false,
 		"indent": [ true, "tabs" ],
 		"trailing-comma": false,
 		"quotemark": [ true, "single" ],


### PR DESCRIPTION
1. Fixed directive-selector and component-selector to match current codelyzer spec (per http://codelyzer.com/rules/component-selector/)
1. Fixing lint errors in TS files
1. Adding lint rule to allow interfaces without the "I" prefix

Now, running `npm run lint` completes without errors successfully