### PR TITLE
Display the returned error if/when PKI authentication fails

### DIFF
--- a/src/app/core/signin/signin.component.html
+++ b/src/app/core/signin/signin.component.html
@@ -4,7 +4,13 @@
 
 		<!-- PKI Authentication Strategy -->
 		<div class="signin-loading-container" *ngIf="pkiMode">
-			<loading-spinner message="Signing In..."></loading-spinner>
+			<loading-spinner [hidden]="error"
+				message="Signing In...">
+			</loading-spinner>
+			<div [hidden]="!error" class="text-center text-danger">
+				<p>Unable to authenticate:</p>
+				<strong>{{error}}</strong>
+			</div>
 		</div>
 
 		<!-- Username/Password Authentication Strategy -->


### PR DESCRIPTION
This PR should resolve any issues where the call to authenticate a user with PKI fails.

Without this change, the spinner and "Signing in..." text appears indefinitely. This will alert the user to the issue and provide any details returned by the server for the issue. For example:

<img width="490" alt="screen shot 2018-11-05 at 2 52 38 pm" src="https://user-images.githubusercontent.com/297404/48022932-7691f680-e10a-11e8-83e2-885cf44bab43.png">
