### PR TITLE
Admin Cache Entry Management

### DIFF
--- a/src/app/common/paging.module.ts
+++ b/src/app/common/paging.module.ts
@@ -33,7 +33,7 @@ import { DirectivesModule } from './directives.module';
 })
 export class PagingModule { }
 
-export { Pager, PageChange, PagingOptions, PagingResults, NULL_PAGING_RESULTS } from './paging/pager/pager.component';
+export { Pager, PageChange, PagingOptions, PagingComponent, PagingResults, NULL_PAGING_RESULTS } from './paging/pager/pager.component';
 export { SortDirection, SortDisplayOption } from './paging/sorting.model';
 export { SortControls, TableSortOptions } from './paging/sort-controls/sort-controls.component';
 export { SortableTableHeaderComponent, SortableTableHeader } from './paging/sortable-table-header/sortable-table-header.component';

--- a/src/app/common/paging/pager/pager.component.ts
+++ b/src/app/common/paging/pager/pager.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, SimpleChange, EventEmitter, OnInit, OnChanges
 
 import isNumber from 'lodash/isNumber';
 
-import { SortDirection } from '../sorting.model';
+import { SortDirection, SortDisplayOption } from '../sorting.model';
 
 export interface PagingResults {
 	pageNumber: number;
@@ -67,6 +67,30 @@ export class PagingOptions {
 			dir: this.sortDir || null
 		};
 	}
+}
+
+export abstract class PagingComponent {
+
+	pagingOpts: PagingOptions;
+
+	abstract loadData();
+
+	applySearch() {
+		this.pagingOpts.setPageNumber(0);
+		this.loadData();
+	}
+
+	goToPage(event: any) {
+		this.pagingOpts.update(event.pageNumber, event.pageSize);
+		this.loadData();
+	}
+
+	setSort(sortOpt: SortDisplayOption) {
+		this.pagingOpts.sortField = sortOpt.sortField;
+		this.pagingOpts.sortDir = sortOpt.sortDir;
+		this.loadData();
+	}
+
 }
 
 @Component({

--- a/src/app/core/admin/admin-routing.module.ts
+++ b/src/app/core/admin/admin-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { AdminListUsersComponent } from './user-management/admin-list-users.component';
 import { AdminUpdateUserComponent } from './user-management/admin-edit-user.component';
 import { AdminCreateEuaComponent, AdminListEuasComponent, AdminUpdateEuaComponent } from './end-user-agreement/admin-eua.module';
+import { CacheEntriesComponent } from './cache-entries/cache-entries.module';
 import { AdminComponent } from './admin.component';
 import { AuthGuard } from '../auth/auth.guard';
 
@@ -52,6 +53,14 @@ import { AuthGuard } from '../auth/auth.guard';
 					{
 						path: 'eua/:id',
 						component: AdminUpdateEuaComponent
+					},
+
+					/**
+					 * Admin Access Checker Cache Entries Route
+					 */
+					{
+						path: 'cacheEntries',
+						component: CacheEntriesComponent
 					}
 				]
 			}])

--- a/src/app/core/admin/admin-topic.model.spec.ts
+++ b/src/app/core/admin/admin-topic.model.spec.ts
@@ -1,0 +1,67 @@
+import { AdminTopics } from './admin-topic.model';
+
+describe('AdminTopics', () => {
+
+	describe('registerTopic', () => {
+
+		const specFirst = { id: '1', ordinal: 1, title: 'Test', path: 'test' };
+		const specUpdate = { id: '1', ordinal: 5, title: 'Update', path: 'new-test' };
+		const specSecond = { id: '2', ordinal: 0, title: 'Second', path: 'second' };
+		const specThird = { id: '3', ordinal: 0, title: 'Third', path: 'third' };
+		const specNoOrdinal = { id: 'none', title: 'None', path: 'none' };
+
+		let existingTopics;
+
+		beforeAll(() => {
+			existingTopics = AdminTopics.getTopics();
+			AdminTopics.clearTopics();
+		});
+
+		afterAll(() => {
+			existingTopics.forEach((topic) => {
+				AdminTopics.registerTopic(topic);
+			});
+		});
+
+		it('should start with no topics', () => {
+			const topics = AdminTopics.getTopics();
+			expect(topics).toEqual([]);
+		});
+		it('can register a topic', () => {
+			AdminTopics.registerTopic(specFirst);
+		});
+		it('can find registered topic', () => {
+			const topics = AdminTopics.getTopics();
+			expect(topics).toEqual([ specFirst ]);
+		});
+		it('can re-register the same topic id', () => {
+			AdminTopics.registerTopic(specUpdate);
+			const topics = AdminTopics.getTopics();
+			expect(topics).toEqual([ specUpdate ]);
+		});
+
+		it('can register a new topic', () => {
+			AdminTopics.registerTopic(specSecond);
+			const topics = AdminTopics.getTopics();
+			expect(topics).toEqual([ specSecond, specUpdate ]);
+		});
+
+		it('can register a new topic with the same ordinal and sort by title', () => {
+			AdminTopics.registerTopic(specThird);
+			const topics = AdminTopics.getTopics();
+			expect(topics).toEqual([ specSecond, specThird, specUpdate ]);
+		});
+
+		it('can register without an ordinal to use default of 1', () => {
+			AdminTopics.registerTopic(specNoOrdinal);
+			const topics = AdminTopics.getTopics();
+			expect(topics).toEqual([ specSecond, specThird, specNoOrdinal, specUpdate ]);
+		});
+
+		it('can clear topics', () => {
+			AdminTopics.clearTopics();
+			expect(AdminTopics.getTopics()).toEqual([]);
+		});
+	});
+
+});

--- a/src/app/core/admin/admin-topic.model.ts
+++ b/src/app/core/admin/admin-topic.model.ts
@@ -1,27 +1,21 @@
 import values from 'lodash/values';
-import { StringUtils } from '../../common/string-utils.service';
 
 export class AdminTopic {
 	id: string;
+	ordinal?: number = 1;
+	path: string;
 	title: string;
 }
 
 export class AdminTopics {
-	private static topicOrder: any = {};
+	private static topics: { [s: string]: AdminTopic } = {};
 
-	static registerTopic(key: string, ordinal?: number) {
-		this.topicOrder[key] = { key: key, ordinal: ordinal };
-	}
-
-	static getTopicList(): string[] {
-		return values(this.topicOrder).sort((a, b) => a.ordinal - b.ordinal).map((v) => v.key);
+	static registerTopic(topic: AdminTopic) {
+		this.topics[topic.id] = topic;
 	}
 
 	static getTopics(): AdminTopic[] {
-		return AdminTopics.getTopicList().map((topic: string) => ({ id: topic, title: AdminTopics.getTopicTitle(topic, true) }));
+		return values(this.topics).sort((a, b) => a.ordinal - b.ordinal);
 	}
 
-	static getTopicTitle(title: string, short: boolean = false): string {
-		return StringUtils.hyphenToHuman(title);
-	}
 }

--- a/src/app/core/admin/admin-topic.model.ts
+++ b/src/app/core/admin/admin-topic.model.ts
@@ -1,8 +1,10 @@
+import isNil from 'lodash/isNil';
 import values from 'lodash/values';
+import sortBy from 'lodash/sortBy';
 
 export class AdminTopic {
 	id: string;
-	ordinal?: number = 1;
+	ordinal?: number;
 	path: string;
 	title: string;
 }
@@ -10,12 +12,20 @@ export class AdminTopic {
 export class AdminTopics {
 	private static topics: { [s: string]: AdminTopic } = {};
 
+	static clearTopics() {
+		this.topics = {};
+	}
+
 	static registerTopic(topic: AdminTopic) {
+		if (isNil(topic.ordinal)) {
+			topic.ordinal = 1;
+		}
 		this.topics[topic.id] = topic;
 	}
 
 	static getTopics(): AdminTopic[] {
-		return values(this.topics).sort((a, b) => a.ordinal - b.ordinal);
+		const topics = values(this.topics);
+		return sortBy(topics, ['ordinal', 'title', 'path']);
 	}
 
 }

--- a/src/app/core/admin/admin.component.html
+++ b/src/app/core/admin/admin.component.html
@@ -3,7 +3,7 @@
 	<ul class="nav nav-tabs">
 		<li *ngFor="let topic of helpTopics" class="nav-item" role="presentation">
 			<a class="nav-link"
-			   [routerLink]="['/admin/' + topic.id, {clearCachedFilter: true}]"
+			   [routerLink]="['/admin/' + topic.path, {clearCachedFilter: true}]"
 			   routerLinkActive="active">
 				{{ topic.title }}
 			</a>

--- a/src/app/core/admin/admin.module.ts
+++ b/src/app/core/admin/admin.module.ts
@@ -7,6 +7,7 @@ import { AdminComponent } from './admin.component';
 import { AdminRoutingModule } from './admin-routing.module';
 import { AdminUserModule } from './user-management/admin-user.module';
 import { AdminEuaModule } from './end-user-agreement/admin-eua.module';
+import { CacheEntriesModule } from './cache-entries/cache-entries.module';
 import { PagingModule } from '../../common/paging.module';
 
 import { AdminTopics } from './admin-topic.model';
@@ -18,6 +19,7 @@ import { AdminTopics } from './admin-topic.model';
 		// App Admin Modules
 		AdminUserModule,
 		AdminEuaModule,
+		CacheEntriesModule,
 
 		CommonModule,
 		FormsModule,

--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -39,10 +39,19 @@
 			<td class="hide-overflow" style="max-width: 300px;">{{cacheEntry.entry.value | json}}</td>
 			<td><span [attr.title]="cacheEntry.entry.ts | utcDate">{{cacheEntry.entry.ts | agoDate:false}}</span></td>
 			<td style="width: 120px;">
-				<div class="pull-right">
-					<button title="View Entry" type="button" class="btn btn-default btn-sm" (click)="viewCacheEntry(cacheEntry)"><span class="fa fa-eye"></span></button>
-					<button title="Refresh Entry" type="button" class="btn btn-default btn-sm" [disabled]="cacheEntry.isRefreshing" (click)="refreshCacheEntry(cacheEntry)"><span class="fa fa-refresh"></span></button>
-					<button title="Delete Entry" type="button" class="btn btn-danger btn-sm" (click)="confirmDeleteEntry(cacheEntry)"><span class="fa fa-trash-o"></span></button>
+				<div class="btn-group btn-group-sm pull-right">
+					<button title="View Entry" (click)="viewCacheEntry(cacheEntry)"
+						type="button" class="btn btn-outline-secondary">
+						<span class="fa fa-eye"></span>
+					</button>
+					<button title="Refresh Entry" (click)="refreshCacheEntry(cacheEntry)" [disabled]="cacheEntry.isRefreshing"
+						type="button" class="btn btn-outline-secondary">
+						<span class="fa fa-refresh"></span>
+					</button>
+					<button title="Delete Entry" (click)="confirmDeleteEntry(cacheEntry)"
+						type="button" class="btn btn-danger">
+						<span class="fa fa-trash-o"></span>
+					</button>
 				</div>
 			</td>
 		</ng-template>

--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -1,0 +1,58 @@
+<section>
+
+	<h3 class="page-header">
+		Cache Entries
+		<small>Administer Cache Entries</small>
+	</h3>
+
+	<!-- Search Input -->
+	<div class="row">
+		<div class="col-md-12">
+			<div class="input-group input-group-sm">
+				<input placeholder="Search key and value..." type="text" class="form-control" [(ngModel)]="search" (keyup.enter)="applySearch()">
+				<span class="input-group-btn">
+					<button class="btn btn-primary btn-sm" type="button" (click)="applySearch()">
+						<i class="fa fa-search"></i>
+					</button>
+				</span>
+			</div>
+		</div>
+	</div>
+
+	<sort-controls [sortOptions]="sortOpts">
+	</sort-controls>
+
+	<pageable-table [items]="cacheEntries"
+		[pagingOptions]="pagingOpts"
+		(onPageChange)="goToPage($event)"
+		(onSortChange)="setSort($event)">
+
+		<ng-template named-template="table-header">
+			<th>Key</th>
+			<th>Value</th>
+			<th>Timestamp</th>
+			<th>&nbsp;</th>
+		</ng-template>
+
+		<ng-template named-template="table-row" let-cacheEntry>
+			<td>{{cacheEntry.entry.key}}</td>
+			<td class="hide-overflow" style="max-width: 300px;">{{cacheEntry.entry.value | json}}</td>
+			<td><span [attr.title]="cacheEntry.entry.ts | utcDate">{{cacheEntry.entry.ts | agoDate:false}}</span></td>
+			<td style="width: 120px;">
+				<div class="pull-right">
+					<button title="View Entry" type="button" class="btn btn-default btn-sm" (click)="viewCacheEntry(cacheEntry)"><span class="fa fa-eye"></span></button>
+					<button title="Refresh Entry" type="button" class="btn btn-default btn-sm" [disabled]="cacheEntry.isRefreshing" (click)="refreshCacheEntry(cacheEntry)"><span class="fa fa-refresh"></span></button>
+					<button title="Delete Entry" type="button" class="btn btn-danger btn-sm" (click)="confirmDeleteEntry(cacheEntry)"><span class="fa fa-trash-o"></span></button>
+				</div>
+			</td>
+		</ng-template>
+
+		<ng-template named-template="empty-table">
+			<h3>
+				<small>No Cache Entries matched your search</small>
+			</h3>
+		</ng-template>
+
+	</pageable-table>
+
+</section>

--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -10,11 +10,11 @@
 		<div class="col-md-12">
 			<div class="input-group input-group-sm">
 				<input placeholder="Search key and value..." type="text" class="form-control" [(ngModel)]="search" (keyup.enter)="applySearch()">
-				<span class="input-group-btn">
-					<button class="btn btn-primary btn-sm" type="button" (click)="applySearch()">
-						<i class="fa fa-search"></i>
+				<div class="input-group-append">
+					<button class="btn btn-outline-secondary" type="button" (click)="applySearch()">
+						<span class="fa fa-search"></span>
 					</button>
-				</span>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/app/core/admin/cache-entries/cache-entries.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.component.ts
@@ -1,0 +1,134 @@
+import { Component } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+
+import { BsModalRef, BsModalService } from 'ngx-bootstrap';
+
+import { filter, first, switchMap } from 'rxjs/operators';
+
+import { CacheEntry } from './cache-entry.model';
+import { CacheEntriesService } from './cache-entries.service';
+import { PagingOptions, SortDirection, SortDisplayOption, TableSortOptions } from '../../../common/paging.module';
+import { ModalAction, ModalService } from '../../../common/modal.module';
+import { CacheEntryModalComponent } from './cache-entry-modal.component';
+
+import { AdminTopics } from '../admin-topic.model';
+
+@Component({
+	selector: 'cache-entries',
+	templateUrl: './cache-entries.component.html'
+})
+export class CacheEntriesComponent {
+
+	cacheEntries: any[] = [];
+
+	search: string = '';
+
+	pagingOpts: PagingOptions;
+
+	sortOpts: TableSortOptions = {
+		key: new SortDisplayOption('Key', 'key', SortDirection.asc),
+		timestamp: new SortDisplayOption('Timestamp', 'ts', SortDirection.desc)
+	};
+
+	constructor(
+		private cacheEntriesService: CacheEntriesService,
+		private modalService: ModalService,
+		private bsModalService: BsModalService
+	) {}
+
+	ngOnInit() {
+		this.pagingOpts = new PagingOptions();
+		this.pagingOpts.sortField = this.sortOpts['key'].sortField;
+		this.pagingOpts.sortDir = this.sortOpts['key'].sortDir;
+
+		this.loadCacheEntries();
+	}
+
+	applySearch() {
+		this.pagingOpts.setPageNumber(0);
+		this.loadCacheEntries();
+	}
+
+	goToPage(event: any) {
+		this.pagingOpts.update(event.pageNumber, event.pageSize);
+		this.loadCacheEntries();
+	}
+
+	setSort(sortOpt: SortDisplayOption) {
+		this.pagingOpts.sortField = sortOpt.sortField;
+		this.pagingOpts.sortDir = sortOpt.sortDir;
+		this.loadCacheEntries();
+	}
+
+	confirmDeleteEntry(cacheEntry: any) {
+		const entryToDelete = cacheEntry.entry;
+
+		this.modalService
+			.confirm('Delete cache entry?', `Are you sure you want to delete entry: ${cacheEntry.entry.key}?`, 'Delete')
+			.pipe(
+				first(),
+				filter((action: ModalAction) => action === ModalAction.OK),
+				switchMap(() => {
+					return this.cacheEntriesService.remove(entryToDelete.key);
+				})
+			)
+			.subscribe(() => {
+				// this.alertService.addAlert(`Deleted cache entry: ${entryToDelete.key}`, 'success');
+				this.loadCacheEntries();
+			}, (response: Response) => {
+				// this.alertService.addAlert(response.json().message);
+			});
+	}
+
+	viewCacheEntry(cacheEntry: any) {
+		const cacheEntryModalRef = this.bsModalService.show(CacheEntryModalComponent, { ignoreBackdropClick: true, class: 'modal-lg' });
+		cacheEntryModalRef.content.cacheEntry = cacheEntry.entry;
+	}
+
+	refreshCacheEntry(cacheEntry: any) {
+		// temporary flag to show that the entry is refreshing
+		cacheEntry.isRefreshing = true;
+
+		let key = cacheEntry.entry.key;
+		this.cacheEntriesService.refresh(key).subscribe(
+			() => {
+				// this.alertService.addAlert(`Refreshed cache entry: ${key}`, 'success');
+				cacheEntry.isRefreshing = false;
+				this.applySearch();
+			},
+			(response: Response) => {
+				// this.alertService.addAlert(response.json().message);
+				cacheEntry.isRefreshing = false;
+			}
+		);
+	}
+
+
+	private loadCacheEntries() {
+		this.cacheEntriesService.match({}, this.search, this.pagingOpts).subscribe(
+			(result: any) => {
+				if (result && Array.isArray(result.elements)) {
+					this.cacheEntries = result.elements.map((element: any) => {
+						return {
+							entry: new CacheEntry(element.key, element.value, element.ts),
+							isRefreshing: false
+						};
+					});
+					this.pagingOpts.set(result.pageNumber, result.pageSize, result.totalPages, result.totalSize);
+				} else {
+					this.pagingOpts.reset();
+				}
+			},
+			(response: Response) => {
+				// this.alertService.addAlert(response.json().message);
+			});
+	}
+
+}
+
+AdminTopics.registerTopic({
+	id: 'cache-entries',
+	title: 'Cache Entries',
+	ordinal: 1,
+	path: 'cacheEntries'
+});

--- a/src/app/core/admin/cache-entries/cache-entries.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
@@ -7,7 +7,7 @@ import { filter, first, switchMap } from 'rxjs/operators';
 
 import { CacheEntry } from './cache-entry.model';
 import { CacheEntriesService } from './cache-entries.service';
-import { PagingOptions, SortDirection, SortDisplayOption, TableSortOptions } from '../../../common/paging.module';
+import { PagingComponent, PagingOptions, SortDirection, SortDisplayOption, TableSortOptions } from '../../../common/paging.module';
 import { ModalAction, ModalService } from '../../../common/modal.module';
 import { CacheEntryModalComponent } from './cache-entry-modal.component';
 
@@ -17,13 +17,11 @@ import { AdminTopics } from '../admin-topic.model';
 	selector: 'cache-entries',
 	templateUrl: './cache-entries.component.html'
 })
-export class CacheEntriesComponent {
+export class CacheEntriesComponent extends PagingComponent implements OnInit {
 
 	cacheEntries: any[] = [];
 
 	search: string = '';
-
-	pagingOpts: PagingOptions;
 
 	sortOpts: TableSortOptions = {
 		key: new SortDisplayOption('Key', 'key', SortDirection.asc),
@@ -34,7 +32,7 @@ export class CacheEntriesComponent {
 		private cacheEntriesService: CacheEntriesService,
 		private modalService: ModalService,
 		private bsModalService: BsModalService
-	) {}
+	) { super(); }
 
 	ngOnInit() {
 		this.pagingOpts = new PagingOptions();
@@ -44,19 +42,7 @@ export class CacheEntriesComponent {
 		this.loadCacheEntries();
 	}
 
-	applySearch() {
-		this.pagingOpts.setPageNumber(0);
-		this.loadCacheEntries();
-	}
-
-	goToPage(event: any) {
-		this.pagingOpts.update(event.pageNumber, event.pageSize);
-		this.loadCacheEntries();
-	}
-
-	setSort(sortOpt: SortDisplayOption) {
-		this.pagingOpts.sortField = sortOpt.sortField;
-		this.pagingOpts.sortDir = sortOpt.sortDir;
+	loadData() {
 		this.loadCacheEntries();
 	}
 
@@ -129,6 +115,6 @@ export class CacheEntriesComponent {
 AdminTopics.registerTopic({
 	id: 'cache-entries',
 	title: 'Cache Entries',
-	ordinal: 1,
+	ordinal: 2,
 	path: 'cacheEntries'
 });

--- a/src/app/core/admin/cache-entries/cache-entries.module.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { ModalModule } from 'ngx-bootstrap';
+import { ModalModule, TooltipModule } from 'ngx-bootstrap';
 
 import { CacheEntryModalComponent } from './cache-entry-modal.component';
 import { CacheEntriesService } from './cache-entries.service';
@@ -19,7 +19,8 @@ import { PipesModule } from '../../../common/pipes.module';
 		DirectivesModule,
 		FormsModule,
 		PagingModule,
-		PipesModule
+		PipesModule,
+		TooltipModule
 	],
 	entryComponents: [
 		CacheEntryModalComponent

--- a/src/app/core/admin/cache-entries/cache-entries.module.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { ModalModule } from 'ngx-bootstrap';
+
+import { CacheEntryModalComponent } from './cache-entry-modal.component';
+import { CacheEntriesService } from './cache-entries.service';
+import { CacheEntriesComponent } from './cache-entries.component';
+
+import { DirectivesModule } from '../../../common/directives.module';
+import { PagingModule } from '../../../common/paging.module';
+import { PipesModule } from '../../../common/pipes.module';
+
+@NgModule({
+	imports: [
+		ModalModule.forRoot(),
+		CommonModule,
+		DirectivesModule,
+		FormsModule,
+		PagingModule,
+		PipesModule
+	],
+	entryComponents: [
+		CacheEntryModalComponent
+	],
+	declarations: [
+		CacheEntriesComponent,
+		CacheEntryModalComponent
+	],
+	exports: [
+		CacheEntriesComponent
+	],
+	providers: [
+		CacheEntriesService
+	]
+})
+export class CacheEntriesModule { }
+
+export { CacheEntriesComponent } from './cache-entries.component';

--- a/src/app/core/admin/cache-entries/cache-entries.service.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+
+import { PagingOptions } from '../../../common/paging.module';
+import { CacheEntry } from './cache-entry.model';
+
+@Injectable()
+export class CacheEntriesService {
+
+	constructor(private http: HttpClient) {}
+
+	public match(query: any, search: string, paging: PagingOptions): Observable<any> {
+		return this.http.post(
+			'api/access-checker/entries/match',
+			{ s: search, q: query },
+			{ params: paging.toObj() }
+		);
+	}
+
+	public remove(key: string): Observable<any> {
+		return this.http.delete(
+			`api/access-checker/entry/${ encodeURIComponent(key) }`,
+			{ params: { key } } // query parameter 'key'
+		);
+	}
+
+	public refresh(key: string): Observable<any> {
+		return this.http.post(
+			`api/access-checker/entry/${ encodeURIComponent(key) }`,
+			{}, // empty POST body
+			{ params: { key } } // query parameter 'key'
+		);
+	}
+
+	public refreshCurrentUser(): Observable<any> {
+		return this.http.post(
+			`api/access-checker/user`,
+			{} // empty POST body
+		);
+	}
+
+}

--- a/src/app/core/admin/cache-entries/cache-entry-modal.component.html
+++ b/src/app/core/admin/cache-entries/cache-entry-modal.component.html
@@ -1,15 +1,15 @@
 <section class="modal-header">
 	<h3>
-		<span>Cache Entry Details</span>
-		<span class="pull-right">
-				<a class="btn-icon no-href"
-				   (click)="modalRef.hide()"
-				   data-tooltip="Close"
-				   data-tooltip-placement="bottom">
-					<i class="fa fa-times"></i>
-				</a>
-			</span>
+		Cache Entry Details
 	</h3>
+	<span class="pull-right">
+		<button type="button" class="btn btn-link"
+			(click)="modalRef.hide()"
+			data-tooltip="Close"
+			data-tooltip-placement="bottom">
+			<span class="fa fa-times"></span>
+		</button>
+	</span>
 </section>
 
 <section class="modal-body">
@@ -28,5 +28,8 @@
 </section>
 
 <section class="modal-footer">
-	<button class="btn btn-link" (click)="modalRef.hide()">Close</button>
+	<button class="btn btn-outline-secondary" (click)="modalRef.hide()">
+		<span class="fa fa-times"></span>
+		Close
+	</button>
 </section>

--- a/src/app/core/admin/cache-entries/cache-entry-modal.component.html
+++ b/src/app/core/admin/cache-entries/cache-entry-modal.component.html
@@ -1,0 +1,32 @@
+<section class="modal-header">
+	<h3>
+		<span>Cache Entry Details</span>
+		<span class="pull-right">
+				<a class="btn-icon no-href"
+				   (click)="modalRef.hide()"
+				   data-tooltip="Close"
+				   data-tooltip-placement="bottom">
+					<i class="fa fa-times"></i>
+				</a>
+			</span>
+	</h3>
+</section>
+
+<section class="modal-body">
+	<div class="row">
+		<div class="col-md-12">
+			<label>Key</label>
+			<div>{{ cacheEntry?.key}}</div>
+
+			<label>Last Updated</label>
+			<div>{{ cacheEntry?.date | utcDate }} ({{ cacheEntry?.date | agoDate:false }})</div>
+
+			<label>Value</label>
+			<pre>{{ cacheEntry?.value | json}}</pre>
+		</div>
+	</div>
+</section>
+
+<section class="modal-footer">
+	<button class="btn btn-link" (click)="modalRef.hide()">Close</button>
+</section>

--- a/src/app/core/admin/cache-entries/cache-entry-modal.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entry-modal.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+import { BsModalRef } from 'ngx-bootstrap';
+
+import { CacheEntry } from './cache-entry.model';
+
+@Component({
+	templateUrl: 'cache-entry-modal.component.html'
+})
+export class CacheEntryModalComponent {
+
+	cacheEntry: CacheEntry;
+
+	constructor(
+		public modalRef: BsModalRef
+	) {}
+}

--- a/src/app/core/admin/cache-entries/cache-entry.model.ts
+++ b/src/app/core/admin/cache-entries/cache-entry.model.ts
@@ -1,0 +1,11 @@
+export class CacheEntry {
+	date: Date;
+
+	constructor(
+		public key: string,
+		public value: any,
+		public ts: number
+	) {
+		this.date = new Date(ts);
+	}
+}

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.html
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.html
@@ -4,7 +4,7 @@
 		EUAs
 		<small>Administer End User Agreements</small>
 		<button [routerLink]="['/admin/eua']" type="button" class="btn btn-sm btn-primary pull-right">
-			<i class="fa fa-plus"></i> Create EUA
+			<span class="fa fa-plus"></span> Create EUA
 		</button>
 	</h3>
 
@@ -27,7 +27,7 @@
 						<input placeholder="Enter a search..." type="text" class="form-control" [(ngModel)]="search" (keyup.enter)="applySearch()">
 						<div class="input-group-append">
 							<button class="btn btn-outline-secondary" type="button" (click)="applySearch()">
-								<i class="fa fa-search"></i>
+								<span class="fa fa-search"></span>
 							</button>
 						</div>
 					</div>

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
@@ -157,4 +157,10 @@ export class AdminListEuasComponent implements OnInit {
 	}
 
 }
-AdminTopics.registerTopic('euas', 0);
+
+AdminTopics.registerTopic({
+	id: 'end-user-agreements',
+	title: 'EUAs',
+	ordinal: 0,
+	path: 'euas'
+});

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
@@ -9,16 +9,14 @@ import { keys, toString } from 'lodash';
 import { EndUserAgreement } from './eua.model';
 import { EuaService } from './eua.service';
 import { ModalAction, ModalService } from '../../../common/modal.module';
-import { PagingOptions, SortDisplayOption, SortDirection, TableSortOptions } from '../../../common/paging.module';
+import { PagingComponent, PagingOptions, SortDisplayOption, SortDirection, TableSortOptions } from '../../../common/paging.module';
 import { AdminTopics } from '../admin-topic.model';
 
 @Component({
 	selector: 'admin-list-euas',
 	templateUrl: './admin-list-euas.component.html'
 })
-export class AdminListEuasComponent implements OnInit {
-
-	pagingOpts: PagingOptions;
+export class AdminListEuasComponent extends PagingComponent implements OnInit {
 
 	euas: EndUserAgreement[] = [];
 
@@ -48,7 +46,7 @@ export class AdminListEuasComponent implements OnInit {
 		private modalService: ModalService,
 		private euaService: EuaService,
 		private route: ActivatedRoute
-	) {}
+	) { super(); }
 
 	ngOnInit() {
 		this.route.params.subscribe( (params: Params) => {
@@ -62,19 +60,7 @@ export class AdminListEuasComponent implements OnInit {
 		this.loadEuas();
 	}
 
-	applySearch() {
-		this.pagingOpts.setPageNumber(0);
-		this.loadEuas();
-	}
-
-	goToPage(event: any) {
-		this.pagingOpts.update(event.pageNumber, event.pageSize);
-		this.loadEuas();
-	}
-
-	setSort(sortOpt: SortDisplayOption) {
-		this.pagingOpts.sortField = sortOpt.sortField;
-		this.pagingOpts.sortDir = sortOpt.sortDir;
+	loadData() {
 		this.loadEuas();
 	}
 
@@ -161,6 +147,6 @@ export class AdminListEuasComponent implements OnInit {
 AdminTopics.registerTopic({
 	id: 'end-user-agreements',
 	title: 'EUAs',
-	ordinal: 0,
+	ordinal: 1,
 	path: 'euas'
 });

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { Response } from '@angular/http';
 import { ActivatedRoute, Params } from '@angular/router';
 
@@ -11,14 +11,14 @@ import { User } from '../../auth/user.model';
 import { Role } from '../../auth/role.model';
 import { ConfigService } from '../../config.service';
 import { AdminUsersService } from './admin-users.service';
-import { Pager, PagingOptions, SortDirection,
+import { Pager, PagingComponent, PagingOptions, SortDirection,
 	SortDisplayOption, SortControls, TableSortOptions } from '../../../common/paging.module';
 import { AdminTopics } from '../admin-topic.model';
 
 @Component({
 	templateUrl: './admin-list-users.component.html'
 })
-export class AdminListUsersComponent {
+export class AdminListUsersComponent extends PagingComponent implements OnInit {
 
 	users: any[] = [];
 
@@ -47,8 +47,6 @@ export class AdminListUsersComponent {
 
 	columnMode: string = 'default';
 
-	pagingOpts: PagingOptions;
-
 	sortOpts: TableSortOptions = {
 		name: new SortDisplayOption('Name', 'name', SortDirection.asc),
 		username: new SortDisplayOption('Username', 'username', SortDirection.asc),
@@ -70,7 +68,7 @@ export class AdminListUsersComponent {
 		private route: ActivatedRoute,
 		private configService: ConfigService,
 		private adminUsersService: AdminUsersService
-	) {}
+	) { super(); }
 
 	ngOnInit() {
 		this.sub = this.route.params.subscribe((params: Params) => {
@@ -95,19 +93,7 @@ export class AdminListUsersComponent {
 		this.sub.unsubscribe();
 	}
 
-	applySearch() {
-		this.pagingOpts.setPageNumber(0);
-		this.loadUsers();
-	}
-
-	goToPage(event: any) {
-		this.pagingOpts.update(event.pageNumber, event.pageSize);
-		this.loadUsers();
-	}
-
-	setSort(sortOpt: SortDisplayOption) {
-		this.pagingOpts.sortField = sortOpt.sortField;
-		this.pagingOpts.sortDir = sortOpt.sortDir;
+	loadData() {
 		this.loadUsers();
 	}
 

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -250,4 +250,10 @@ export class AdminListUsersComponent {
 	}
 
 }
-AdminTopics.registerTopic('users', 0);
+
+AdminTopics.registerTopic({
+	id: 'users',
+	title: 'User',
+	ordinal: 0,
+	path: 'users'
+});

--- a/src/app/core/feedback/admin/admin-list-feedback.component.ts
+++ b/src/app/core/feedback/admin/admin-list-feedback.component.ts
@@ -76,4 +76,9 @@ export class AdminListFeedbackComponent implements OnInit {
 	}
 }
 
-AdminTopics.registerTopic('feedback', 0);
+AdminTopics.registerTopic({
+	id: 'feedback',
+	title: 'Feedback',
+	ordinal: 3,
+	path: 'feedback'
+});

--- a/src/app/core/site-navbar/site-navbar.component.html
+++ b/src/app/core/site-navbar/site-navbar.component.html
@@ -93,7 +93,7 @@
 			<ng-template #adminNav>
 				<ul class="popover-menu" role="menu">
 					<li *ngFor="let adminItem of adminMenuItems">
-						<a [routerLink]="['admin/' + adminItem.id, { clearCachedFilter: true }]"
+						<a [routerLink]="['admin/' + adminItem.path, { clearCachedFilter: true }]"
 							(click)="adminNavPopover.hide()">
 							{{ adminItem.title }}
 						</a>


### PR DESCRIPTION
Addresses #19 

- Added consistent styling for the Cache Entries module
- Updated the AdminTopics registration in order to allow components to specify the Path, Title, and Ordinal, in addition to their unique identifier. This allows us to fully customize the display entries and their URL paths