### PR TITLE
WIP bootstrap style cleanup

### DIFF
--- a/src/styles/_ngx-bootstrap.scss
+++ b/src/styles/_ngx-bootstrap.scss
@@ -1,3 +1,5 @@
+@import './ngx-bootstrap/variables';
+
 @import '../../node_modules/bootstrap/scss/bootstrap';
 
 /**

--- a/src/styles/ngx-bootstrap/_cards.scss
+++ b/src/styles/ngx-bootstrap/_cards.scss
@@ -1,11 +1,6 @@
 @import '../globals';
 @import '../colors';
 
-$card-border-color: map-get($color-background, 'darker');
-$card-border-radius: $border-radius;
-
 .card {
-	border-color: $card-border-color;
-	border-radius: $card-border-radius;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, .3);
 }

--- a/src/styles/ngx-bootstrap/_dropdowns.scss
+++ b/src/styles/ngx-bootstrap/_dropdowns.scss
@@ -3,25 +3,11 @@
 
 @import '../typography';
 
-$dropdown-border-color: map-get($color-background, 'darker');
-$dropdown-border-radius: $border-radius;
-$dropdown-background-color: map-get($color-background, 'lightest');
 $dropdown-element-font-color: map-get($color-background, 'lightest-contrast');
-$dropdown-element-hover-background-color: map-get($color-background, 'lighter');
-
 
 ul.dropdown-menu {
 	@include font-normal();
 	@include font-color-dark($dropdown-element-font-color);
-
-	background-color: $dropdown-background-color;
-
-	border-color: $dropdown-border-color;
-	border-radius: $dropdown-border-radius;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
-
-	padding: 0;
-	margin: 0;
 
 	&.full-width-menu {
 		margin-left: 15px;
@@ -29,13 +15,9 @@ ul.dropdown-menu {
 	}
 
 	li > a.dropdown-item {
-		padding: 10px 24px;
-
 		&:hover {
-			background-color: $dropdown-element-hover-background-color;
 			cursor: pointer;
 		}
-
 
 		&:active {
 			color: inherit;

--- a/src/styles/ngx-bootstrap/_variables.scss
+++ b/src/styles/ngx-bootstrap/_variables.scss
@@ -1,0 +1,18 @@
+@import '../globals';
+@import '../colors';
+
+// Bootstrap Card
+$card-border-radius:                $border-radius;
+$card-border-color:                 map-get($color-background, 'darker');
+
+// Bootstrap Dropdown
+$dropdown-padding-y:				0;
+$dropdown-spacer:					0;
+$dropdown-bg:						map-get($color-background, 'lightest');
+$dropdown-border-color:             map-get($color-background, 'darker');
+$dropdown-border-radius:            $border-radius;
+$dropdown-box-shadow: 				0 1px 4px rgba(0, 0, 0, .3);
+$dropdown-link-hover-bg:			map-get($color-background, 'lighter');
+
+$dropdown-item-padding-y:           10px;
+$dropdown-item-padding-x:			24px;


### PR DESCRIPTION
I was reading about [bootstrap theming](https://getbootstrap.com/docs/4.0/getting-started/theming/#variable-defaults) and discovered that some of our bootstrap scss could be simplified by overriding the bootstrap variable defaults vs. redefining styles.  Setting bootstrap styles this way should result in smaller total css.  If we want to proceed with this change, I still need to go through the rest of our bootstrap styles and see what can be replaced with overriding variables.