### PR TITLE
update access component to pass data via history state vs. url params

### DIFF
--- a/src/app/core/access.component.ts
+++ b/src/app/core/access.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
 	template: `
@@ -16,26 +16,21 @@ import { ActivatedRoute } from '@angular/router';
 	`,
 	styles: [ '' ]
 })
-export class AccessComponent implements OnInit {
-
-	loaded = false;
+export class AccessComponent {
 
 	status: string;
 	message: string;
 
 
 	constructor(
-		private activatedRoute: ActivatedRoute
-	) {}
+		private router: Router
+	) {
+		const navigation = this.router.getCurrentNavigation();
+		const state = navigation.extras.state;
 
-
-	ngOnInit() {
-		this.activatedRoute.params.subscribe((routeParams) => {
-			this.loaded = true;
-
-			this.status = routeParams.status;
-			this.message = routeParams.message;
-		});
+		if (state) {
+			this.status = state.status;
+			this.message = state.message;
+		}
 	}
-
 }

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -30,7 +30,7 @@ export class AuthInterceptor implements HttpInterceptor {
 				const url = get(err, 'url', '');
 				const message = get(err, 'error.message', '');
 
-				const routeObject = { status, type, message, url };
+				const stateObject = { status, type, message, url };
 
 				// Go to signin if the user isn't logged in and wasn't already on the signin page
 				if (401 === status && !url.endsWith('auth/signin')) {
@@ -44,7 +44,7 @@ export class AuthInterceptor implements HttpInterceptor {
 						this.router.navigate(['/eua']);
 					}
 					else {
-						this.router.navigate(['/access', routeObject]);
+						this.router.navigate(['/access'], {state: stateObject});
 					}
 				}
 


### PR DESCRIPTION
This is a small change but fixes a pain point.  Previously when redirecting to the AccessComponent on error, the data was passed a url parameters and could be seen in the browser url.  This takes advantage of a new feature in Angular 7.2 to instead pass the data using browser history state.