### PR TITLE
Fix for login error message not being display

### DIFF
--- a/src/app/core/auth/session.service.ts
+++ b/src/app/core/auth/session.service.ts
@@ -45,9 +45,6 @@ export class SessionService {
 
 	reloadSession(): Observable<any> {
 		return this.authService.reloadCurrentUser().pipe(
-			catchError(() => {
-				return of(null);
-			}),
 			this.mapUserModelToSession,
 			tap((session) => {
 				this.sessionSubject.next(session);
@@ -57,9 +54,6 @@ export class SessionService {
 
 	signin(username: string, password: string): Observable<any> {
 		return this.authService.signin(username, password).pipe(
-			catchError(() => {
-				return of(null);
-			}),
 			this.mapUserModelToSession,
 			tap((session) => {
 				this.sessionSubject.next(session);


### PR DESCRIPTION
session service was suppressing the error and preventing the signin component from rendering the error message