### PR TITLE
added a skip navigation link

### DIFF
--- a/src/app/common/directives.module.ts
+++ b/src/app/common/directives.module.ts
@@ -2,16 +2,19 @@ import { NgModule } from '@angular/core';
 
 import { Transclusion } from './directives/transclusion.directive';
 import { NamedTemplate } from './directives/named-template.directive';
+import { SkipToDirective } from './directives/skip-to.directive';
 
 @NgModule({
 	imports: [],
 	exports: [
 		Transclusion,
 		NamedTemplate,
+		SkipToDirective
 	],
 	declarations: [
 		Transclusion,
 		NamedTemplate,
+		SkipToDirective
 	],
 	providers: []
 })

--- a/src/app/common/directives/skip-to.directive.ts
+++ b/src/app/common/directives/skip-to.directive.ts
@@ -1,0 +1,20 @@
+import { Directive, ElementRef, Renderer2 } from '@angular/core';
+
+/**
+ * Used to mark where in a page the "Skip to main content" link
+ * should skip to. It is ideally placed on the page's main heading:
+ * the h1 element. This directive should only be used once per page
+ */
+@Directive({
+	selector: '[skipTo]'
+})
+export class SkipToDirective {
+	constructor(
+		private elRef: ElementRef,
+		private renderer: Renderer2
+	) {
+		const el = elRef.nativeElement;
+		renderer.setAttribute(el, 'id', 'skip-to');
+		renderer.setAttribute(el, 'tabindex', '-1');
+	}
+}

--- a/src/app/common/directives/skip-to.directive.ts
+++ b/src/app/common/directives/skip-to.directive.ts
@@ -14,7 +14,7 @@ export class SkipToDirective {
 		private renderer: Renderer2
 	) {
 		const el = elRef.nativeElement;
-		renderer.setAttribute(el, 'id', 'skip-to');
+		renderer.addClass(el, 'skip-to');
 		renderer.setAttribute(el, 'tabindex', '-1');
 	}
 }

--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -1,8 +1,8 @@
 <section>
-	<h2>
+	<h1 skipTo>
 		Cache Entries
 		<small>Administer Cache Entries</small>
-	</h2>
+	</h1>
 
 	<!-- Alert Notifications -->
 	<system-alert></system-alert>

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.html
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.html
@@ -1,8 +1,8 @@
 <section>
-	<h2>
+	<h1 skipTo>
 		EUAs
 		<small>Administer End User Agreements</small>
-	</h2>
+	</h1>
 
 	<!-- Alert Notifications -->
 	<system-alert></system-alert>

--- a/src/app/core/admin/user-management/admin-list-users.component.html
+++ b/src/app/core/admin/user-management/admin-list-users.component.html
@@ -1,8 +1,8 @@
 <section>
-	<h2>
+	<h1 skipTo>
 		Users
 		<small>Administer User Accounts</small>
-	</h2>
+	</h1>
 
 	<!-- Alert Notifications -->
 	<system-alert></system-alert>

--- a/src/app/core/feedback/admin/admin-list-feedback.component.html
+++ b/src/app/core/feedback/admin/admin-list-feedback.component.html
@@ -1,7 +1,7 @@
 <section>
-	<h2>
+	<h1 skipTo>
 		System Feedback
-	</h2>
+	</h1>
 
 	<!-- Alert Notifications -->
 	<system-alert></system-alert>

--- a/src/app/core/messages/admin/list-messages.component.html
+++ b/src/app/core/messages/admin/list-messages.component.html
@@ -1,9 +1,9 @@
 <section>
 
-	<h2>
+	<h1 skipTo>
 		Messages
 		<small>Administer Messages</small>
-	</h2>
+	</h1>
 
 	<!-- Alert Notifications -->
 	<system-alert></system-alert>

--- a/src/app/core/site-container/site-container.component.html
+++ b/src/app/core/site-container/site-container.component.html
@@ -1,3 +1,7 @@
+<a class="skip-link" href="#" (click)="skipToMainContent($event)">
+	Skip to main content
+</a>
+
 <!-- Site Header -->
 <header class="site-header">
 
@@ -14,7 +18,7 @@
 
 	<site-navbar>
 
-		<section class="site-content">
+		<section class="site-content" id="app-content" tabindex="-1">
 			<ng-content></ng-content>
 		</section>
 

--- a/src/app/core/site-container/site-container.component.scss
+++ b/src/app/core/site-container/site-container.component.scss
@@ -2,19 +2,21 @@
 @import '../../../styles/shared';
 @import './shared';
 
+$banner-z-index: 10002;
+
 header.site-header {
-	z-index: 2147483647;
+	z-index: $banner-z-index;
 }
 
 footer.site-footer {
-	z-index: 2147483647;
+	z-index: $banner-z-index;
 }
 
 .site-banner {
 	text-align: center;
 
 	width: 100%;
-	z-index: 2147483647;
+	z-index: $banner-z-index;
 }
 
 .copyright-banner {
@@ -70,6 +72,21 @@ footer.site-footer {
 	.copyright-active.footer-active &{
 		margin-bottom: $footer-banner-height + $copyright-banner-height;
 	}
+}
 
+a.skip-link {
+	position: absolute;
+	top: -1000em;
 
+	&:focus {
+		position: fixed;
+		top: 0;
+		left: 0;
+		z-index: $banner-z-index + 1;
+
+		padding: 10px;
+		background-color: $ux-color-primary;
+		color: $color-white;
+		text-decoration: underline;
+	}
 }

--- a/src/app/core/site-container/site-container.component.ts
+++ b/src/app/core/site-container/site-container.component.ts
@@ -28,12 +28,14 @@ export class SiteContainerComponent {
 	skipToMainContent(e: any) {
 		e.preventDefault();
 
-		const skipTo = document.getElementById('skip-to');
+		// querySelector gets the first matched element
+		const skipTo = document.querySelector('.skip-to') as HTMLElement;
 		const appContent = document.getElementById('app-content');
 
 		if (skipTo) {
 			skipTo.focus();
 		} else {
+			// fall back to main content area if no .skip-to elements are found
 			appContent.focus();
 			window.scrollTo(0, 0);
 		}

--- a/src/app/core/site-container/site-container.component.ts
+++ b/src/app/core/site-container/site-container.component.ts
@@ -24,4 +24,18 @@ export class SiteContainerComponent {
 		});
 	}
 
+
+	skipToMainContent(e: any) {
+		e.preventDefault();
+
+		const skipTo = document.getElementById('skip-to');
+		const appContent = document.getElementById('app-content');
+
+		if (skipTo) {
+			skipTo.focus();
+		} else {
+			appContent.focus();
+			window.scrollTo(0, 0);
+		}
+	}
 }

--- a/src/app/core/site-navbar/site-navbar.component.html
+++ b/src/app/core/site-navbar/site-navbar.component.html
@@ -1,6 +1,5 @@
-<div
-		 class="navbar-left d-flex flex-column align-items-start"
-		 [ngClass]="{'navbar-open': navbarOpen}">
+<div class="navbar-left d-flex flex-column align-items-start"
+  [ngClass]="{'navbar-open': navbarOpen}">
 
 	<!-- Logo -->
 	<ul class="nav nav-logo flex-shrink-0">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -61,3 +61,11 @@ html {
 		top: inherit;
 	}
 }
+
+// when the .skip-to class is applied to non-interactive
+// elements it should not have a style when focused
+div, span, h1, h2, h3, h4, h5, h6 {
+	&.skip-to:focus {
+		outline: 0;
+	}
+}


### PR DESCRIPTION
The skip link appears in the upper left hand corner only when focused and when activated, it skips over the page's navigation links and focuses on the main content of the page.