### PR TITLE
#64 - Feedback Flyover now allows for optional classification.

### DIFF
--- a/src/app/core/feedback/feedback.model.ts
+++ b/src/app/core/feedback/feedback.model.ts
@@ -1,3 +1,8 @@
+export class Classification {
+	prefix: string;
+	level: string;
+}
+
 export class Feedback {
 	text: string;
 
@@ -7,7 +12,7 @@ export class Feedback {
 
 	otherText: string;
 
-	classification: any;
+	classification?: Classification;
 
 	currentRoute: string;
 

--- a/src/app/core/feedback/feedback.service.spec.ts
+++ b/src/app/core/feedback/feedback.service.spec.ts
@@ -1,5 +1,5 @@
-import { FeedbackService } from './feedback.service.js';
-import { Feedback } from './feedback.model.js';
+import { FeedbackService } from './feedback.service';
+import { Feedback } from './feedback.model';
 
 describe('FeedbackService', () => {
 

--- a/src/app/core/feedback/feedback.service.spec.ts
+++ b/src/app/core/feedback/feedback.service.spec.ts
@@ -1,7 +1,5 @@
 import { FeedbackService } from './feedback.service.js';
-import { TestBed } from '@angular/core/testing';
 import { Feedback } from './feedback.model.js';
-import { FeedbackModalComponent } from './feedback-modal.component.js';
 
 describe('FeedbackService', () => {
 

--- a/src/app/core/feedback/feedback.service.spec.ts
+++ b/src/app/core/feedback/feedback.service.spec.ts
@@ -5,48 +5,48 @@ import { FeedbackModalComponent } from './feedback-modal.component.js';
 
 describe('FeedbackService', () => {
 
-    it('should exist', () => {
-        expect(new FeedbackService(<any>{}, <any>{})).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(new FeedbackService({} as any, {} as any)).toBeDefined();
+	});
 
-    describe('feedback formatting', () => {
-        it('should repeat back out normal feedback text without any options', () => {
-            const service = new FeedbackService(<any>{}, <any>{});
-            const feedback = new Feedback();
-            feedback.text = 'hello there'
-            expect(service.getFormattedText(feedback)).toEqual(feedback.text);
-        });
-        it('should include subtype on a newline, and include otherText if subtype is other', () => {
-            const service = new FeedbackService(<any>{}, <any>{});
-            const feedback = new Feedback();
-            feedback.text = 'hello there'
-            feedback.subType = 'words'
-            expect(service.getFormattedText(feedback)).toEqual('words\nhello there');
-            feedback.subType = 'Other';
-            feedback.otherText = 'testing';
-            expect(service.getFormattedText(feedback)).toEqual('Other - testing\nhello there');
-        });
+	describe('feedback formatting', () => {
+		it('should repeat back out normal feedback text without any options', () => {
+			const service = new FeedbackService({} as any, {} as any);
+			const feedback = new Feedback();
+			feedback.text = 'hello there';
+			expect(service.getFormattedText(feedback)).toEqual(feedback.text);
+		});
+		it('should include subtype on a newline, and include otherText if subtype is other', () => {
+			const service = new FeedbackService({} as any, {} as any);
+			const feedback = new Feedback();
+			feedback.text = 'hello there';
+			feedback.subType = 'words';
+			expect(service.getFormattedText(feedback)).toEqual('words\nhello there');
+			feedback.subType = 'Other';
+			feedback.otherText = 'testing';
+			expect(service.getFormattedText(feedback)).toEqual('Other - testing\nhello there');
+		});
 
-        it('should prefix a message with a classification prefix, if applicable', () => {
-            const service = new FeedbackService(<any>{}, <any>{});
-            const feedback = new Feedback();
-            feedback.text = 'hello there';
-            feedback.classification = { prefix: 'K', level: 'K' };
-            expect(service.getFormattedText(feedback)).toEqual('K hello there');
-        });
+		it('should prefix a message with a classification prefix, if applicable', () => {
+			const service = new FeedbackService({} as any, {} as any);
+			const feedback = new Feedback();
+			feedback.text = 'hello there';
+			feedback.classification = { prefix: 'K', level: 'K' };
+			expect(service.getFormattedText(feedback)).toEqual('K hello there');
+		});
 
-        it('should include classification prefix on every line', () => {
-            const service = new FeedbackService(<any>{}, <any>{});
-            const feedback = new Feedback();
-            feedback.text = 'hello there';
-            feedback.subType = 'Other';
-            feedback.otherText = 'yes';
-            feedback.classification = {prefix: 'K', level: 'OK'};
-            expect(service.getFormattedText(feedback)).toEqual(
-                'K Other - yes\n' +
-                'K hello there'
-            );
-        })
-    });
+		it('should include classification prefix on every line', () => {
+			const service = new FeedbackService({} as any, {} as any);
+			const feedback = new Feedback();
+			feedback.text = 'hello there';
+			feedback.subType = 'Other';
+			feedback.otherText = 'yes';
+			feedback.classification = {prefix: 'K', level: 'OK'};
+			expect(service.getFormattedText(feedback)).toEqual(
+				'K Other - yes\n' +
+				'K hello there'
+			);
+		});
+	});
 
 });

--- a/src/app/core/feedback/feedback.service.spec.ts
+++ b/src/app/core/feedback/feedback.service.spec.ts
@@ -1,0 +1,52 @@
+import { FeedbackService } from './feedback.service.js';
+import { TestBed } from '@angular/core/testing';
+import { Feedback } from './feedback.model.js';
+import { FeedbackModalComponent } from './feedback-modal.component.js';
+
+describe('FeedbackService', () => {
+
+    it('should exist', () => {
+        expect(new FeedbackService(<any>{}, <any>{})).toBeDefined();
+    });
+
+    describe('feedback formatting', () => {
+        it('should repeat back out normal feedback text without any options', () => {
+            const service = new FeedbackService(<any>{}, <any>{});
+            const feedback = new Feedback();
+            feedback.text = 'hello there'
+            expect(service.getFormattedText(feedback)).toEqual(feedback.text);
+        });
+        it('should include subtype on a newline, and include otherText if subtype is other', () => {
+            const service = new FeedbackService(<any>{}, <any>{});
+            const feedback = new Feedback();
+            feedback.text = 'hello there'
+            feedback.subType = 'words'
+            expect(service.getFormattedText(feedback)).toEqual('words\nhello there');
+            feedback.subType = 'Other';
+            feedback.otherText = 'testing';
+            expect(service.getFormattedText(feedback)).toEqual('Other - testing\nhello there');
+        });
+
+        it('should prefix a message with a classification prefix, if applicable', () => {
+            const service = new FeedbackService(<any>{}, <any>{});
+            const feedback = new Feedback();
+            feedback.text = 'hello there';
+            feedback.classification = { prefix: 'K', level: 'K' };
+            expect(service.getFormattedText(feedback)).toEqual('K hello there');
+        });
+
+        it('should include classification prefix on every line', () => {
+            const service = new FeedbackService(<any>{}, <any>{});
+            const feedback = new Feedback();
+            feedback.text = 'hello there';
+            feedback.subType = 'Other';
+            feedback.otherText = 'yes';
+            feedback.classification = {prefix: 'K', level: 'OK'};
+            expect(service.getFormattedText(feedback)).toEqual(
+                'K Other - yes\n' +
+                'K hello there'
+            );
+        })
+    });
+
+});

--- a/src/app/core/feedback/feedback.service.ts
+++ b/src/app/core/feedback/feedback.service.ts
@@ -31,14 +31,15 @@ export class FeedbackService {
 
 	getFormattedText(feedback: Feedback): string {
 		let text: string = '';
+		const prefix = `${feedback.classification ? feedback.classification.prefix + ' ' : ''}`;
 		if (feedback.subType !== undefined) {
-			text += `${feedback.classification.prefix} ${feedback.subType}`;
+			text += `${prefix}${feedback.subType}`;
 			if (feedback.subType === 'Other') {
 				text += ` - ${feedback.otherText}`;
 			}
 			text += '\n';
 		}
-		text += `${feedback.classification.prefix} ${feedback.text}`;
+		text += `${prefix}${feedback.text}`;
 		return text;
 	}
 
@@ -48,7 +49,7 @@ export class FeedbackService {
 			JSON.stringify({
 				body: this.getFormattedText(feedback),
 				type: feedback.type.toLowerCase(),
-				classification: feedback.classification.level,
+				classification: feedback.classification ? feedback.classification.level : '',
 				url: feedback.currentRoute
 			}),
 			{ headers: this.headers }


### PR DESCRIPTION
Fix for #64 

The feedback service had some message generation based on `feedback.classification.(prefix|level)`, while the feedback modal allowed for optional classification.

- Created a `Classification` class to ensure we set prefix/level.
- Made the `Feedback` class's classification property a `Classification`, and allowed it to be optional.
- Included feedback format tests.