### PR TITLE
default page title, ignore anything in route path after ';'

### DIFF
--- a/src/app/core/page-title.service.ts
+++ b/src/app/core/page-title.service.ts
@@ -43,7 +43,8 @@ export class PageTitleService {
 
 						// If there wasn't a path title, try to generate one
 						if (null == pathTitle) {
-							pathTitle = this.router.url.split('/')
+							pathTitle = this.router.url.split(';')[0]
+								.split('/')
 								.slice(1)
 								.map((frag) => capitalize(frag))
 								.join(' > ');


### PR DESCRIPTION
Small tweak to page title service.  Noticable on admin pages, but could effect other locations.
For users admin page:
Before:
`Moniker - Admin > Users;clearcachedfilter=true`
After:
`Moniker - Admin > Users`