### PR TITLE
BUG: set initial admin when creating team

### DIFF
--- a/src/app/core/teams/create-team/create-team.component.ts
+++ b/src/app/core/teams/create-team/create-team.component.ts
@@ -107,7 +107,7 @@ export class CreateTeamComponent implements OnInit {
 	save() {
 		this.submitting = true;
 		this.teamsService
-			.create(this.team, (this.defaultTeamAdmin._id !== this.user.userModel._id) ? this.defaultTeamAdmin : null)
+			.create(this.team, (this.defaultTeamAdmin._id !== this.user.userModel._id) ? this.defaultTeamAdmin._id : null)
 			.pipe(
 				tap(() => this.authenticationService.reloadCurrentUser())
 			)

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -42,7 +42,10 @@ export class TeamsService {
 	create(team: Team, firstAdmin?: any): Observable<any> {
 		return this.http.put(
 			`api/team`,
-			JSON.stringify(team),
+			JSON.stringify({
+				team: team,
+				firstAdmin: null === firstAdmin ? null : firstAdmin._id || firstAdmin
+			}),
 			{ headers: this.headers }
 		).pipe(
 			catchError((error: HttpErrorResponse) => {

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -39,12 +39,12 @@ export class TeamsService {
 	// 	return this.asyHttp.put(new HttpOptions('team', () => { }, { team, firstAdmin }));
 	// }
 
-	create(team: Team, firstAdmin?: any): Observable<any> {
+	create(team: Team, firstAdmin?: string): Observable<any> {
 		return this.http.put(
 			`api/team`,
 			JSON.stringify({
 				team: team,
-				firstAdmin: null === firstAdmin ? null : firstAdmin._id || firstAdmin
+				firstAdmin: firstAdmin ? firstAdmin : null
 			}),
 			{ headers: this.headers }
 		).pipe(


### PR DESCRIPTION
Currently, initial admin will be current user, regardless of who is specified.
