### PR TITLE
use clientUrl vs baseUrl; fix setting of currentRoute for old feedback modal

### DIFF
--- a/src/app/core/feedback/feedback-flyout/feedback-flyout.component.ts
+++ b/src/app/core/feedback/feedback-flyout/feedback-flyout.component.ts
@@ -35,7 +35,7 @@ export class FeedbackFlyoutComponent implements OnInit {
 
 	ngOnInit() {
 		this.configService.getConfig().pipe(first()).subscribe((config: any) => {
-			this.baseUrl = `${config.app.baseUrl || ''}`;
+			this.baseUrl = config.app.clientUrl || '';
 
 			if (Array.isArray(config.feedback.classificationOpts) && !isEmpty(config.feedback.classificationOpts)) {
 				this.classificationOptions = config.feedback.classificationOpts;

--- a/src/app/core/feedback/feedback-modal.component.ts
+++ b/src/app/core/feedback/feedback-modal.component.ts
@@ -23,6 +23,8 @@ export class FeedbackModalComponent implements OnInit {
 
 	classificationOptions: any[];
 
+	baseUrl: string = '';
+
 	feedback: Feedback = new Feedback();
 
 	constructor(
@@ -34,7 +36,7 @@ export class FeedbackModalComponent implements OnInit {
 
 	ngOnInit() {
 		this.configService.getConfig().pipe(first()).subscribe((config: any) => {
-			this.feedback.currentRoute = `${config.app.baseUrl}${this.router.url}`;
+			this.baseUrl = config.app.clientUrl || '';
 
 			if (Array.isArray(config.feedback.classificationOpts) && !isEmpty(config.feedback.classificationOpts)) {
 				this.classificationOptions = config.feedback.classificationOpts;
@@ -45,6 +47,10 @@ export class FeedbackModalComponent implements OnInit {
 	submit() {
 		this.error = null;
 		this.submitting = true;
+
+		// Get the current URL from the router at the time of submission.
+		this.feedback.currentRoute = `${this.baseUrl}${this.router.url}`;
+
 		this.feedbackService.submit(this.feedback).subscribe(() => {
 			this.success = 'Feedback successfully submitted!';
 			setTimeout(() => this.modalRef.hide(), 1500);


### PR DESCRIPTION
Small changed due to Asymmetrik/node-rest-starter#34

Also noticed that fix for feedback currentRoute was applied only to feedback flyout, not the modal.