### PR TITLE
add nav-aware bootstrap grid classes

### DIFF
--- a/src/app/core/site-navbar/_shared.scss
+++ b/src/app/core/site-navbar/_shared.scss
@@ -3,8 +3,8 @@
 
 // Specify these
 $nav-background-color: $ux-color-primary !default;
-$nav-closed-width: 54px !default;
-$nav-open-width: 238px !default;
+$nav-closed-width: $ux-nav-closed-width !default;
+$nav-open-width: $ux-nav-open-width !default;
 
 $nav-element-font-color: $ux-color-light-gray !default;
 $nav-element-font-size: 16px !default;

--- a/src/app/core/site-navbar/site-navbar.component.html
+++ b/src/app/core/site-navbar/site-navbar.component.html
@@ -1,5 +1,5 @@
 <div class="navbar-left d-flex flex-column align-items-start"
-  [ngClass]="{'navbar-open': navbarOpen}">
+  [ngClass]="{'navbar-open': navbarOpen, 'navbar-close': !navbarOpen}">
 
 	<!-- Logo -->
 	<ul class="nav nav-logo flex-shrink-0">
@@ -234,6 +234,6 @@
 </div>
 
 <div class="navbar-content"
-     [ngClass]="{'navbar-open': navbarOpen}">
+     [ngClass]="{'navbar-open': navbarOpen, 'navbar-close': !navbarOpen}">
 	<ng-content></ng-content>
 </div>

--- a/src/app/site/example/example-routing.module.ts
+++ b/src/app/site/example/example-routing.module.ts
@@ -6,6 +6,7 @@ import { ExploreComponent } from './explore.component';
 import { FormsComponent } from './forms/forms.component';
 import { SearchComponent } from './search.component';
 import { WelcomeComponent } from './welcome.component';
+import { GridComponent } from './grid/grid.component';
 
 
 @NgModule({
@@ -34,6 +35,11 @@ import { WelcomeComponent } from './welcome.component';
 			{
 				path: 'forms',
 				component: FormsComponent,
+				canActivate: [ AuthGuard ]
+			},
+			{
+				path: 'grid',
+				component: GridComponent,
 				canActivate: [ AuthGuard ]
 			}
 		])

--- a/src/app/site/example/example.module.ts
+++ b/src/app/site/example/example.module.ts
@@ -10,6 +10,7 @@ import { ExploreComponent } from './explore.component';
 import { WelcomeComponent } from './welcome.component';
 import { ExampleHelpComponent } from './help/example-help.component';
 import { FormsComponent } from './forms/forms.component';
+import { GridComponent } from './grid/grid.component';
 
 
 @NgModule({
@@ -27,7 +28,8 @@ import { FormsComponent } from './forms/forms.component';
 		SearchComponent,
 		WelcomeComponent,
 		ExampleHelpComponent,
-		FormsComponent
+		FormsComponent,
+		GridComponent
 	],
 	providers: [
 		AuthGuard

--- a/src/app/site/example/grid/grid.component.html
+++ b/src/app/site/example/grid/grid.component.html
@@ -1,0 +1,71 @@
+<h3>Stacked to horizontal</h3>
+<h5>Standard</h5>
+<div class="container">
+	<div class="row">
+		<div class="col-lg-8">col-lg-8</div>
+		<div class="col-lg-4">col-lg-4</div>
+	</div>
+	<div class="row">
+		<div class="col-lg">col-lg</div>
+		<div class="col-lg">col-lg</div>
+		<div class="col-lg">col-lg</div>
+	</div>
+</div>
+
+<h5>Nav Aware</h5>
+<div class="container">
+	<div class="row">
+		<div class="col-na-lg-8">col-na-lg-8</div>
+		<div class="col-na-lg-4">col-na-lg-4</div>
+	</div>
+	<div class="row">
+		<div class="col-na-lg">col-na-lg</div>
+		<div class="col-na-lg">col-na-lg</div>
+		<div class="col-na-lg">col-na-lg</div>
+	</div>
+</div>
+
+<h3>Mix and Match</h3>
+<h5>Standard</h5>
+<div class="container">
+	<!-- Stack the columns on mobile by making one full-width and the other half-width -->
+	<div class="row">
+		<div class="col-12 col-md-8">.col-12 .col-md-8</div>
+		<div class="col-6 col-md-4">.col-6 .col-md-4</div>
+	</div>
+
+	<!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
+	<div class="row">
+		<div class="col-6 col-md-4">.col-6 .col-md-4</div>
+		<div class="col-6 col-md-4">.col-6 .col-md-4</div>
+		<div class="col-6 col-md-4">.col-6 .col-md-4</div>
+	</div>
+
+	<!-- Columns are always 50% wide, on mobile and desktop -->
+	<div class="row">
+		<div class="col-6">.col-6</div>
+		<div class="col-6">.col-6</div>
+	</div>
+</div>
+
+<h5>Nav Aware</h5>
+<div class="container">
+	<!-- Stack the columns on mobile by making one full-width and the other half-width -->
+	<div class="row">
+		<div class="col-na-12 col-na-md-8">.col-na-12 .col-na-md-8</div>
+		<div class="col-na-6 col-na-md-4">.col-na-6 .col-na-md-4</div>
+	</div>
+
+	<!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
+	<div class="row">
+		<div class="col-na-6 col-na-md-4">.col-na-6 .col-na-md-4</div>
+		<div class="col-na-6 col-na-md-4">.col-na-6 .col-na-md-4</div>
+		<div class="col-na-6 col-na-md-4">.col-na-6 .col-na-md-4</div>
+	</div>
+
+	<!-- Columns are always 50% wide, on mobile and desktop -->
+	<div class="row">
+		<div class="col-na-6">.col-na-6</div>
+		<div class="col-na-6">.col-na-6</div>
+	</div>
+</div>

--- a/src/app/site/example/grid/grid.component.scss
+++ b/src/app/site/example/grid/grid.component.scss
@@ -1,0 +1,17 @@
+.row {
+	> .col,
+	> [class^="col-"] {
+		padding-top: .75rem;
+		padding-bottom: .75rem;
+		background-color: rgba(86, 61, 124, .15);
+		border: 1px solid rgba(86, 61, 124, .2);
+	}
+}
+
+.row+.row {
+	margin-top: 1rem;
+}
+
+.container, .container-fluid {
+	margin: 1rem 0;
+}

--- a/src/app/site/example/grid/grid.component.ts
+++ b/src/app/site/example/grid/grid.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { NavbarTopics } from '../../../core/core.module';
+
+@Component({
+	selector: 'app-grid',
+	templateUrl: './grid.component.html',
+	styleUrls: ['./grid.component.scss']
+})
+export class GridComponent {
+}
+
+
+NavbarTopics.registerTopic({
+	id: 'grid',
+	title: 'Grid',
+	ordinal: 4,
+	path: 'grid',
+	iconClass: 'fa-th',
+	hasSomeRoles: ['user']
+});

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -1,2 +1,6 @@
+$enable-nav-aware-grid-classes: true !default;
 $form-required: after !default;
 $border-radius: 2px !default;
+
+$ux-nav-closed-width: 54px !default;
+$ux-nav-open-width: 238px !default;

--- a/src/styles/_ngx-bootstrap.scss
+++ b/src/styles/_ngx-bootstrap.scss
@@ -15,6 +15,7 @@
 @import './ngx-bootstrap/cards';
 @import './ngx-bootstrap/dropdowns';
 @import './ngx-bootstrap/forms';
+@import './ngx-bootstrap/grid';
 @import './ngx-bootstrap/popovers';
 @import './ngx-bootstrap/tooltips';
 @import './ngx-bootstrap/nav';

--- a/src/styles/ngx-bootstrap/_grid.scss
+++ b/src/styles/ngx-bootstrap/_grid.scss
@@ -1,0 +1,85 @@
+@import 'shared';
+
+// Modified copy of make-grid-columns from Bootstrap (node_modules/bootstrap/scss/mixins/_grid-framework.scss).
+// Creates 'col-na' classes vs 'col'.
+@mixin make-nav-aware-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
+	// Common properties for all breakpoints
+	%grid-column {
+		position: relative;
+		width: 100%;
+		padding-right: $gutter / 2;
+		padding-left: $gutter / 2;
+	}
+
+	@each $breakpoint in map-keys($breakpoints) {
+		$infix: breakpoint-infix($breakpoint, $breakpoints);
+		$infix: -na#{$infix};
+
+		// Allow columns to stretch full width below their breakpoints
+		@for $i from 1 through $columns {
+			.col#{$infix}-#{$i} {
+				@extend %grid-column;
+			}
+		}
+		.col#{$infix},
+		.col#{$infix}-auto {
+			@extend %grid-column;
+		}
+
+		@include media-breakpoint-up($breakpoint, $breakpoints) {
+			// Provide basic `.col-{bp}` classes for equal-width flexbox columns
+			.col#{$infix} {
+				flex-basis: 0;
+				flex-grow: 1;
+				max-width: 100%;
+			}
+			.col#{$infix}-auto {
+				flex: 0 0 auto;
+				width: auto;
+				max-width: 100%; // Reset earlier grid tiers
+			}
+
+			@for $i from 1 through $columns {
+				.col#{$infix}-#{$i} {
+					@include make-col($i, $columns);
+				}
+			}
+
+			.order#{$infix}-first { order: -1; }
+
+			.order#{$infix}-last { order: $columns + 1; }
+
+			@for $i from 0 through $columns {
+				.order#{$infix}-#{$i} { order: $i; }
+			}
+
+			// `$columns - 1` because offsetting by the width of an entire row isn't possible
+			@for $i from 0 through ($columns - 1) {
+				@if not ($infix == "" and $i == 0) { // Avoid emitting useless .offset-0
+					.offset#{$infix}-#{$i} {
+						@include make-col-offset($i, $columns);
+					}
+				}
+			}
+		}
+	}
+}
+
+@if $enable-nav-aware-grid-classes and $enable-grid-classes {
+
+	$nav-opened-grid-breakpoints: ();
+
+	@each $key, $value in $grid-breakpoints {
+		$bp: $value + $ux-nav-open-width - $ux-nav-closed-width;
+		@if $value == 0 {
+			$bp: 0;
+		}
+		$nav-opened-grid-breakpoints: map-merge($nav-opened-grid-breakpoints, ($key: $bp));
+	}
+
+	@include make-nav-aware-grid-columns($grid-columns, $grid-gutter-width, $nav-opened-grid-breakpoints);
+
+	.navbar-close {
+		@include make-nav-aware-grid-columns($grid-columns, $grid-gutter-width, $grid-breakpoints);
+	}
+}


### PR DESCRIPTION
This adds an additional set of `col-na-*` classes that have adjusted breakpoints based on if the navbar is expanded or not.  Similar to how bootstrap handles the grid classes, they can be disabled using a sass variable.