### PR TITLE
added non-html5 browser support for sectioning elements

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,5 +60,23 @@
 		</div>
 
 	</app-root>
+
+	<!--[if lt IE 9]>
+		<script>
+			document.createElement("article");
+			document.createElement("aside");
+			document.createElement("footer");
+			document.createElement("header");
+			document.createElement("nav");
+			document.createElement("section");
+			document.createElement("time");
+		</script>
+	<![endif]-->
+	<noscript>
+		<p><strong>This web page requires JavaScript to be enabled.</strong></p>
+		<p>JavaScript is an object-oriented computer programming language
+		  commonly used to create interactive effects within web browsers.</p>
+		<p><a href="https://goo.gl/koeeaJ">How to enable JavaScript?</a></p>
+	</noscript>
 </body>
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -29,10 +29,6 @@ html {
 	min-height: 100%;
 }
 
-article, aside, footer, header, nav, section {
-	display: block;
-}
-
 @if $form-required == before {
 	.form-required:before {
 		content: '*';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -29,6 +29,10 @@ html {
 	min-height: 100%;
 }
 
+article, aside, footer, header, nav, section {
+	display: block;
+}
+
 @if $form-required == before {
 	.form-required:before {
 		content: '*';


### PR DESCRIPTION
per https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines#Using_HTML5_elements_in_non-HTML5_browsers

this will allow us to use html5 sectioning elements (`<header>`, `<nav>`, `<article>`, etc) even in browsers that do not support them