### PR TITLE
fix issue caused by duplicate placeholder selectors

### DIFF
--- a/src/styles/_ng-select.scss
+++ b/src/styles/_ng-select.scss
@@ -18,7 +18,7 @@ $ng-select-placeholder: $input-placeholder-color !default;
 $ng-select-height: $input-height !default;
 $ng-select-value-padding-left: $input-padding-x;
 
-@import '~@ng-select/ng-select/scss/default.theme';
+@import '../../node_modules/@ng-select/ng-select/scss/default.theme';
 
 .ng-select {
 	.ng-placeholder {

--- a/src/styles/ngx-bootstrap/_grid.scss
+++ b/src/styles/ngx-bootstrap/_grid.scss
@@ -4,7 +4,7 @@
 // Creates 'col-na' classes vs 'col'.
 @mixin make-nav-aware-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
 	// Common properties for all breakpoints
-	%grid-column {
+	%na-grid-column {
 		position: relative;
 		width: 100%;
 		padding-right: $gutter / 2;
@@ -18,12 +18,12 @@
 		// Allow columns to stretch full width below their breakpoints
 		@for $i from 1 through $columns {
 			.col#{$infix}-#{$i} {
-				@extend %grid-column;
+				@extend %na-grid-column;
 			}
 		}
 		.col#{$infix},
 		.col#{$infix}-auto {
-			@extend %grid-column;
+			@extend %na-grid-column;
 		}
 
 		@include media-breakpoint-up($breakpoint, $breakpoints) {


### PR DESCRIPTION
This fixes a minor issue introduced in #84.  A sass placeholder selector was defined in 2 places.  Needed to rename one instance.