### PR TITLE
feat: Admin Page Updates

### DIFF
--- a/src/app/core/admin/cache-entries/cache-entries.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.component.ts
@@ -95,6 +95,6 @@ export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEn
 AdminTopics.registerTopic({
 	id: 'cache-entries',
 	title: 'Cache Entries',
-	ordinal: 2,
+	ordinal: 1,
 	path: 'cacheEntries'
 });

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
@@ -148,6 +148,6 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 AdminTopics.registerTopic({
 	id: 'end-user-agreements',
 	title: 'EUAs',
-	ordinal: 1,
+	ordinal: 2,
 	path: 'euas'
 });

--- a/src/app/core/admin/user-management/admin-list-users.component.html
+++ b/src/app/core/admin/user-management/admin-list-users.component.html
@@ -71,7 +71,11 @@
 
 					<td [hidden]="!columns.roles.show" style="max-width:200px;">
 						<ng-container *ngFor="let role of possibleRoles">
-							<div *ngIf="user.userModel.roles && user.userModel.roles[role.role]">
+							<div *ngIf="user.userModel.roles && user.userModel.roles[role.role]" class="user-role"
+								 [ngClass]="{
+									'user-role-external': user.userModel.localRoles && !user.userModel.localRoles[role.role]
+								}"
+							>
 								{{ role.role | titlecase }}
 							</div>
 						</ng-container>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -69,3 +69,7 @@ div, span, h1, h2, h3, h4, h5, h6 {
 		outline: 0;
 	}
 }
+
+.user-role-external::after {
+	content: '(external)'
+}


### PR DESCRIPTION
Conditionally add `user-role-external` class to role display in admin users page.  Allows alternate styling of external roles when roleStrategy=hybrid
Update order of admin tabs