### PR TITLE
build: add option to run in dev mode with es5 vs es2015

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -57,6 +57,9 @@
                   "maximumError": "5mb"
                 }
               ]
+            },
+            "es5": {
+              "tsConfig": "./src/tsconfig-es5.app.json"
             }
           }
         },
@@ -68,6 +71,9 @@
           "configurations": {
             "production": {
               "browserTarget": "ngx-starter:build:production"
+            },
+            "es5": {
+              "browserTarget": "ngx-starter:build:es5"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
+    "start:es5": "ng serve --proxy-config proxy.conf.json --configuration es5",
     "start:prod": "ng serve --proxy-config proxy.conf.json --prod",
     "build": "npm run lint && ng build",
     "build:prod": "npm run lint && ng build --prod",

--- a/src/tsconfig-es5.app.json
+++ b/src/tsconfig-es5.app.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
With the upgrade to Angular 8, angular will now generate 2 different builds, modern (es2015) and legacy (es5).  However, only the modern bundle is generated when using `ng serve`.  Add additional option to run dev build with legacy bundle vs modern.