### PR TITLE
refactor(common): Update multi-select-input to simplify ControlValueAccessor implementation

### DIFF
--- a/src/app/common/multi-select-input/multi-select-input.component.html
+++ b/src/app/common/multi-select-input/multi-select-input.component.html
@@ -5,8 +5,8 @@
 	[hideSelected]="true"
 	[isOpen]="autocompleteOpen"
 	(add)="onAdd()"
-	[searchFn]="noResults"
 	(search)="onSearch($event)"
+	(focus)="onTouched()"
 	placeholder="{{ placeholder }}"
 	[(ngModel)]="value">
 </ng-select>

--- a/src/app/common/multi-select-input/multi-select-input.component.ts
+++ b/src/app/common/multi-select-input/multi-select-input.component.ts
@@ -20,8 +20,9 @@ export class MultiSelectInputComponent implements ControlValueAccessor {
 	autocompleteOpen = false;
 
 	private innerValue: string[];
-	private changed = new Array<(value: string[]) => void>();
-	private touched = new Array<() => void>();
+
+	onChange = (_: any) => {};
+	onTouched = () => {};
 
 	constructor() {}
 
@@ -37,10 +38,6 @@ export class MultiSelectInputComponent implements ControlValueAccessor {
 		this.autocompleteOpen = false;
 	}
 
-	noResults(term: string, item: string) {
-		return false;
-	}
-
 	get value(): string[] {
 		return this.innerValue;
 	}
@@ -48,7 +45,7 @@ export class MultiSelectInputComponent implements ControlValueAccessor {
 	set value(value: string[]) {
 		if (this.innerValue !== value) {
 			this.innerValue = value;
-			this.changed.forEach((f) => f(value));
+			this.onChange(value);
 		}
 	}
 
@@ -56,16 +53,8 @@ export class MultiSelectInputComponent implements ControlValueAccessor {
 		this.innerValue = value;
 	}
 
-	registerOnChange(fn: (value: string[]) => void) {
-		this.changed.push(fn);
-	}
+	registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }
 
-	registerOnTouched(fn: () => void) {
-		this.touched.push(fn);
-	}
-
-	touch() {
-		this.touched.forEach((f) => f());
-	}
+	registerOnTouched(fn: () => void): void { this.onTouched = fn; }
 
 }


### PR DESCRIPTION
onChange and onTouch events for ControlValueAccessor where implemented to handle multiple event listeners.  Discovered that this is unnecessary while looking at source for angular built in value accessors.  Updating to match angular approach of only supporting single listener for each event.