### PR TITLE
bug(team): Add role check to create team button

### DIFF
--- a/src/app/core/teams/list-teams/list-teams.component.html
+++ b/src/app/core/teams/list-teams/list-teams.component.html
@@ -11,7 +11,7 @@
 
 		<div class="d-flex mb-3 align-items-center">
 			<asy-search-input placeholder="Search teams..." (applySearch)="searchEvent$.next($event)"></asy-search-input>
-			<button routerLink="/team/create" type="button" class="btn btn-primary ml-auto">
+			<button routerLink="/team/create" type="button" class="btn btn-primary ml-auto" *ngIf="canCreateTeam">
 				<span class="fa fa-plus"></span> Create Team
 			</button>
 		</div>

--- a/src/app/core/teams/list-teams/list-teams.component.ts
+++ b/src/app/core/teams/list-teams/list-teams.component.ts
@@ -12,12 +12,15 @@ import {
 	SortableTableHeader,
 	SortChange, AbstractPageableDataComponent
 } from '../../../common/paging.module';
+import { AuthorizationService } from '../../auth/authorization.service';
 
 @Component({
 	templateUrl: './list-teams.component.html',
 	styleUrls: ['./list-teams.component.scss']
 })
 export class ListTeamsComponent extends AbstractPageableDataComponent<Team> implements OnInit {
+
+	canCreateTeam = false;
 
 	headers: SortableTableHeader[] = [
 		{ name: 'Name', sortable: true, sortField: 'name', sortDir: SortDirection.asc, tooltip: 'Sort by Team Name', default: true },
@@ -27,7 +30,8 @@ export class ListTeamsComponent extends AbstractPageableDataComponent<Team> impl
 
 	constructor(
 		private teamsService: TeamsService,
-		private alertService: SystemAlertService
+		private alertService: SystemAlertService,
+		private authorizationService: AuthorizationService
 	) {
 		super();
 	}
@@ -36,6 +40,8 @@ export class ListTeamsComponent extends AbstractPageableDataComponent<Team> impl
 		this.alertService.clearAllAlerts();
 
 		this.sortEvent$.next(this.headers.find((header: any) => header.default) as SortChange);
+
+		this.canCreateTeam = this.authorizationService.hasSomeRoles(['editor', 'admin']);
 
 		super.ngOnInit();
 	}


### PR DESCRIPTION
REST api requires that user have 'editor' or 'admin' access to create a team.  Update UI to hide create button if user does not have either of those roles.
Ideally we would have used the AuthorizationDirective for this, but doing so would require moving it to a SharedModule since team is a submodule of core.