### PR TITLE
Prettier Integration

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,4 @@
+---
+printWidth: 100
+singleQuote: true
+...

--- a/package-lock.json
+++ b/package-lock.json
@@ -638,7 +638,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -797,99 +797,153 @@
       }
     },
     "@babel/core": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
-      "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.6",
-        "@babel/helpers": "^7.1.5",
-        "@babel/parser": "^7.1.6",
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6",
-        "convert-source-map": "^1.1.0",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helpers": "^7.8.4",
+        "@babel/parser": "^7.8.4",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
-          "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.1.6",
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+          "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
-          "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+          "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
           "dev": true
         },
-        "@babel/traverse": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
-          "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.1.6",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.6",
-            "@babel/types": "^7.1.6",
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+          "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.4",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.4",
+            "@babel/types": "^7.8.3",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
-          "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
         },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
-        "globals": {
-          "version": "11.9.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-          "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "dev": true
         },
         "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -897,35 +951,20 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.5"
-          }
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
       }
@@ -1446,12 +1485,25 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-wrap-function": {
@@ -1517,100 +1569,138 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.5.tgz",
-      "integrity": "sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.1.5"
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
-          "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+        "@babel/code-frame": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.1.6",
+            "@babel/highlight": "^7.8.3"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+          "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.10",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.8.3",
+            "@babel/template": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
-          "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+          "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
           "dev": true
         },
-        "@babel/traverse": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
-          "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+        "@babel/template": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+          "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.1.6",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.1.6",
-            "@babel/types": "^7.1.6",
+            "@babel/code-frame": "^7.8.3",
+            "@babel/parser": "^7.8.3",
+            "@babel/types": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+          "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.8.4",
+            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-split-export-declaration": "^7.8.3",
+            "@babel/parser": "^7.8.4",
+            "@babel/types": "^7.8.3",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
-          "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
-            "lodash": "^4.17.10",
+            "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
-        "globals": {
-          "version": "11.9.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-          "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "dev": true
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
       }
@@ -2304,6 +2394,15 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -2434,16 +2533,6 @@
         }
       }
     },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      }
-    },
     "@ng-select/ng-select": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-3.0.7.tgz",
@@ -2476,11 +2565,31 @@
         }
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
     "@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
       "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
     },
     "@schematics/angular": {
       "version": "8.3.21",
@@ -2525,6 +2634,12 @@
         }
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2563,10 +2678,28 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
     "@types/node": {
       "version": "8.9.5",
       "resolved": "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
       "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/q": {
@@ -2591,6 +2724,32 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@types/vfile": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/unist": "*",
+        "@types/vfile-message": "*"
+      }
+    },
+    "@types/vfile-message": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
+      "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
+      "dev": true,
+      "requires": {
+        "vfile-message": "*"
+      }
     },
     "@types/webpack-sources": {
       "version": "0.1.5",
@@ -3048,12 +3207,6 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -3163,6 +3316,12 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
@@ -3196,17 +3355,65 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.5.tgz",
-      "integrity": "sha512-kk4Zb6RUc58ld7gdosERHMF3DzIYJc2fp5sX46qEsGXQQy5bXsu8qyLjoxuY1NuQ/cJuCYnx99BfjwnRggrYIw==",
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+      "integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.1.0",
-        "caniuse-lite": "^1.0.30000884",
+        "browserslist": "^4.8.3",
+        "caniuse-lite": "^1.0.30001020",
+        "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.2",
-        "postcss-value-parser": "^3.2.3"
+        "postcss": "^7.0.26",
+        "postcss-value-parser": "^4.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "postcss": {
+          "version": "7.0.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "postcss-value-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+          "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "aws-sign2": {
@@ -3404,9 +3611,9 @@
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "bail": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
@@ -3776,14 +3983,14 @@
       }
     },
     "browserslist": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
-      "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+      "version": "4.8.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+      "integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000899",
-        "electron-to-chromium": "^1.3.82",
-        "node-releases": "^1.0.1"
+        "caniuse-lite": "^1.0.30001023",
+        "electron-to-chromium": "^1.3.341",
+        "node-releases": "^1.1.47"
       }
     },
     "browserstack": {
@@ -3962,12 +4169,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
-    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -4003,10 +4204,21 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.2.tgz",
+      "integrity": "sha512-QfFrU0CIw2oltVvpndW32kuJ/9YOJwUnmWrjlXt1nnJZHCaS9i6bfOpg9R4Lw8aZjStkJWM+jc0cdXjWBgVJSw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-lite": {
-      "version": "1.0.30000899",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000899.tgz",
-      "integrity": "sha512-enC3zKfUCJxxwvUIsBkbHd54CtJw1KtIWvrK0JZxWD/fEN2knHaai45lndJ4xXAkyRAPyk60J3yagkKDWhfeMA==",
+      "version": "1.0.30001023",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+      "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
       "dev": true
     },
     "canonical-path": {
@@ -4028,9 +4240,9 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
       "dev": true
     },
     "chalk": {
@@ -4045,27 +4257,27 @@
       }
     },
     "character-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
       "dev": true
     },
     "character-entities-html4": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
-      "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
       "dev": true
     },
     "character-entities-legacy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "dev": true
     },
     "character-reference-invalid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
     "chardet": {
@@ -4245,13 +4457,12 @@
       }
     },
     "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "^2.0.0"
       }
     },
     "co": {
@@ -4298,9 +4509,9 @@
       }
     },
     "collapse-white-space": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
       "dev": true
     },
     "collection-visit": {
@@ -4907,15 +5118,6 @@
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
-    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -4978,6 +5180,14 @@
       "requires": {
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
       }
     },
     "decode-uri-component": {
@@ -5290,19 +5500,25 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
           "dev": true
         }
       }
@@ -5314,9 +5530,9 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -5394,9 +5610,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
-      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew==",
+      "version": "1.3.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.344.tgz",
+      "integrity": "sha512-tvbx2Wl8WBR+ym3u492D0L6/jH+8NoQXqe46+QhbWH3voVPauGuZYeb1QAXYoOAWuiP2dbSvlBx0kQ1F3hu/Mw==",
       "dev": true
     },
     "elliptic": {
@@ -5627,6 +5843,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint-plugin-prettier": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+      "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -5728,12 +5954,12 @@
       }
     },
     "execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "^2.1.0"
       }
     },
     "exit": {
@@ -5775,15 +6001,6 @@
             "is-extendable": "^0.1.0"
           }
         }
-      }
-    },
-    "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "^1.0.1"
       }
     },
     "express": {
@@ -5958,18 +6175,86 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-glob": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-      "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
@@ -5983,6 +6268,15 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -6009,13 +6303,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-loader": {
@@ -6193,31 +6486,42 @@
       }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
       }
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       },
       "dependencies": {
-        "circular-json": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-          "dev": true
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -6930,10 +7234,22 @@
       "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
     "get-stream": {
@@ -6992,12 +7308,6 @@
         }
       }
     },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-      "dev": true
-    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -7008,27 +7318,23 @@
       }
     },
     "global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "^3.0.0"
       }
     },
     "global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
       }
     },
     "globals": {
@@ -7058,9 +7364,9 @@
       "dev": true
     },
     "gonzales-pe": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
-      "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
+      "integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
       "dev": true,
       "requires": {
         "minimist": "1.1.x"
@@ -7068,7 +7374,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -7185,6 +7491,12 @@
         }
       }
     },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7298,15 +7610,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "^1.0.0"
-      }
-    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -7338,29 +7641,29 @@
       "dev": true
     },
     "html-tags": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6"
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7602,6 +7905,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -7804,9 +8113,9 @@
       }
     },
     "is-alphabetical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "dev": true
     },
     "is-alphanumeric": {
@@ -7816,9 +8125,9 @@
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
@@ -7903,9 +8212,9 @@
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-descriptor": {
@@ -7970,9 +8279,9 @@
       }
     },
     "is-hexadecimal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
     "is-installed-globally": {
@@ -8078,9 +8387,9 @@
       }
     },
     "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
       "dev": true
     },
     "is-retry-allowed": {
@@ -8093,12 +8402,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
-    "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-symbol": {
@@ -8117,9 +8420,9 @@
       "dev": true
     },
     "is-whitespace-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-      "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
       "dev": true
     },
     "is-windows": {
@@ -8129,9 +8432,9 @@
       "dev": true
     },
     "is-word-character": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-      "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "is-wsl": {
@@ -8529,6 +8832,12 @@
       "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
       "dev": true
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
     "jest-worker": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
@@ -8835,9 +9144,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.9.0.tgz",
-      "integrity": "sha512-2G/A/8XPhH6MmuVgl079wYsgdqfXE3cfm62txk/ajS4wvRWo6tEHcgQCJCHOOy12Fse1Sxlbf7/IJBpR9hnVew==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.17.0.tgz",
+      "integrity": "sha512-Vi3nxDGMm/z+lAaCjvAR1u+7fiv+sG6gU/iYDj5QOF8h76ytK9EW/EKfF0NeTyiGBi8Jy6Hklty/vxISrLox3w==",
       "dev": true
     },
     "latest-version": {
@@ -8904,9 +9213,9 @@
       }
     },
     "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
     "license-webpack-plugin": {
@@ -8928,6 +9237,12 @@
         "immediate": "~3.0.5"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -8946,13 +9261,12 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
@@ -8974,12 +9288,25 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "log4js": {
@@ -9019,9 +9346,9 @@
       "dev": true
     },
     "longest-streak": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
-      "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
       "dev": true
     },
     "loose-envify": {
@@ -9031,16 +9358,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -9175,9 +9492,9 @@
       "dev": true
     },
     "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
       "dev": true
     },
     "map-visit": {
@@ -9190,21 +9507,21 @@
       }
     },
     "markdown-escapes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-      "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
     "markdown-table": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
-      "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
       "dev": true
     },
     "mathml-tag-names": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
-      "integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
     },
     "md5.js": {
@@ -9219,9 +9536,9 @@
       }
     },
     "mdast-util-compact": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
-      "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
+      "integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
@@ -9254,6 +9571,49 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "meow": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-6.0.0.tgz",
+      "integrity": "sha512-x4rYsjigPBDAxY+BGuK83YLhUIqui5wYyZoqb6QJCUOs+0fiYq+i/NV4Jt8OgIfObZFxG9iTyvLDu4UTohGTFw==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.1.1",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.0.0",
+        "minimist-options": "^4.0.1",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.0",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.8.1",
+        "yargs-parser": "^16.1.0"
+      },
+      "dependencies": {
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -9267,9 +9627,9 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
       "dev": true
     },
     "methods": {
@@ -9336,6 +9696,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
+    },
     "mini-css-extract-plugin": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
@@ -9376,9 +9742,9 @@
       "dev": true
     },
     "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
+      "integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
       "dev": true,
       "requires": {
         "arrify": "^1.0.1",
@@ -9605,12 +9971,20 @@
       }
     },
     "node-releases": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.1.tgz",
-      "integrity": "sha512-/kOv7jA26OBwkBPx6B9xR/FzJzs2OkMtcWjS8uPQRMHE7IELdSfN0QKZvmiWnf5P1QJ8oYq/e9qe0aCZISB1pQ==",
+      "version": "1.1.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+      "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "nodemon": {
@@ -10060,21 +10434,21 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.2.0"
       }
     },
     "p-map": {
@@ -10093,9 +10467,9 @@
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "package-json": {
@@ -10212,6 +10586,23 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        }
+      }
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -10227,9 +10618,9 @@
       }
     },
     "parse-entities": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
-      "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -10249,12 +10640,6 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
-    },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
     },
     "parse5": {
       "version": "4.0.0",
@@ -10364,6 +10749,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
     "pify": {
@@ -10495,12 +10886,12 @@
       }
     },
     "postcss-html": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.34.0.tgz",
-      "integrity": "sha512-BIW982Kbf9/RikInNhNS3/GA6x/qY/+jhVS9KumqXZtU9ss8Yq15HhPJ6mnaXcU5bFq2ULxpOv96mHPAErpGMQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+      "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
       "dev": true,
       "requires": {
-        "htmlparser2": "^3.9.2"
+        "htmlparser2": "^3.10.0"
       }
     },
     "postcss-import": {
@@ -10516,22 +10907,71 @@
       }
     },
     "postcss-jsx": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.35.0.tgz",
-      "integrity": "sha512-AU2/9QDmHYJRxTiniMt2bJ9fwCzVF6n00VnR4gdnFGHeXRW2mGwoptpuPgYjfivkdI8LlNIuo+w8TyS6a4JhJw==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.4.tgz",
+      "integrity": "sha512-jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.2",
-        "postcss-styled": ">=0.34.0"
+        "@babel/core": ">=7.2.2"
       }
     },
     "postcss-less": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.0.2.tgz",
-      "integrity": "sha512-+JBOampmDnuaf4w8OIEqkCiF+sOm/nWukDsC+1FTrYcIstptOISzGpYZk24Qh+Ewlmzmi53sRyiTbiGvMCDRwA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+      "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.3"
+        "postcss": "^7.0.14"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "7.0.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-load-config": {
@@ -10557,12 +10997,12 @@
       }
     },
     "postcss-markdown": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.34.0.tgz",
-      "integrity": "sha512-cKPggF9OMOKPoqDm5YpYszCqMsImFh78FK6P8p6IsEKZB6IkUJYKz0/QgadYy4jLb60jcFIHJ6v6jsMH7/ZQrA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.36.0.tgz",
+      "integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
       "dev": true,
       "requires": {
-        "remark": "^9.0.0",
+        "remark": "^10.0.1",
         "unist-util-find-all-after": "^1.0.2"
       }
     },
@@ -10573,15 +11013,76 @@
       "dev": true
     },
     "postcss-reporter": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.0.tgz",
-      "integrity": "sha512-5xQXm1UPWuFObjbtyQzWvQaupru8yFcFi4HUlm6OPo1o2bUszYASuqRJ7bVArb3svGCdbYtqdMBKrqR1Aoy+tw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+      "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "postcss": "^7.0.2"
+        "chalk": "^2.4.1",
+        "lodash": "^4.17.11",
+        "log-symbols": "^2.2.0",
+        "postcss": "^7.0.7"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
+        "postcss": {
+          "version": "7.0.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-resolve-nested-selector": {
@@ -10600,13 +11101,63 @@
       }
     },
     "postcss-sass": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
-      "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.2.tgz",
+      "integrity": "sha512-hcRgnd91OQ6Ot9R90PE/khUDCJHG8Uxxd3F7Y0+9VHjBiJgNv7sK5FxyHMCBtoLmmkzVbSj3M3OlqUfLJpq0CQ==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.2.3",
-        "postcss": "^7.0.1"
+        "gonzales-pe": "^4.2.4",
+        "postcss": "^7.0.21"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "7.0.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-scss": {
@@ -10629,16 +11180,10 @@
         "uniq": "^1.0.1"
       }
     },
-    "postcss-styled": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.34.0.tgz",
-      "integrity": "sha512-Uaeetr/xOiQWGJgzPFOr32/Bwykpfh9TVE26OpmwDb8eEN205TS/gqkt9ri+C6otQzQKXqbMfeZNbKYi7QpeNA==",
-      "dev": true
-    },
     "postcss-syntax": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.34.0.tgz",
-      "integrity": "sha512-L36NZwq2UK743US+vl1CRMdBRZCBmFYfThP9n9jCFhX1Wfk6BqnRSgt0Fy8q44IwxPee/GCzlo7T1c1JIeUDlQ==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
       "dev": true
     },
     "postcss-value-parser": {
@@ -10651,6 +11196,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "private": {
@@ -10980,9 +11531,9 @@
       "dev": true
     },
     "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
     "randombytes": {
@@ -11117,6 +11668,61 @@
         "util-promisify": "^2.1.0"
       }
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -11153,6 +11759,16 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "reflect-metadata": {
@@ -11265,20 +11881,20 @@
       }
     },
     "remark": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
-      "integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+      "integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
       "dev": true,
       "requires": {
-        "remark-parse": "^5.0.0",
-        "remark-stringify": "^5.0.0",
-        "unified": "^6.0.0"
+        "remark-parse": "^6.0.0",
+        "remark-stringify": "^6.0.0",
+        "unified": "^7.0.0"
       }
     },
     "remark-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
       "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.2",
@@ -11299,9 +11915,9 @@
       }
     },
     "remark-stringify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
-      "integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
       "dev": true,
       "requires": {
         "ccount": "^1.0.0",
@@ -11417,16 +12033,6 @@
         "resolve-from": "^3.0.0"
       }
     },
-    "resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
-      }
-    },
     "resolve-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
@@ -11459,6 +12065,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
     "rfdc": {
@@ -11499,6 +12111,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -11815,20 +12433,14 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
       }
     },
     "smart-buffer": {
@@ -12401,9 +13013,9 @@
       }
     },
     "state-toggle": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-      "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
       "dev": true
     },
     "static-extend": {
@@ -12591,6 +13203,15 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -12638,370 +13259,459 @@
       "dev": true
     },
     "stylelint": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.8.0.tgz",
-      "integrity": "sha512-qYYgP9UnZ6S4uaXrfEGPIMeNv21gP4t3E7BtnYfJIiHKvz7AbrCP0vj1wPgD6OFyxLT5txQxtoznfSkm2vsUkQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.0.0.tgz",
+      "integrity": "sha512-6sjgOJbM3iLhnUtmRO0J1vvxie9VnhIZX/2fCehjylv9Gl9u0ytehGCTm9Lhw2p1F8yaNZn5UprvhCB8C3g/Tg==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^9.0.0",
+        "autoprefixer": "^9.7.3",
         "balanced-match": "^1.0.0",
-        "chalk": "^2.4.1",
-        "cosmiconfig": "^5.0.0",
-        "debug": "^4.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^2.0.0",
-        "get-stdin": "^6.0.0",
-        "global-modules": "^1.0.0",
-        "globby": "^8.0.0",
+        "chalk": "^3.0.0",
+        "cosmiconfig": "^6.0.0",
+        "debug": "^4.1.1",
+        "execall": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^7.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.0.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^5.0.4",
-        "import-lazy": "^3.1.0",
+        "html-tags": "^3.1.0",
+        "ignore": "^5.1.4",
+        "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.9.0",
-        "leven": "^2.1.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
-        "meow": "^5.0.0",
-        "micromatch": "^3.1.10",
+        "known-css-properties": "^0.17.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "log-symbols": "^3.0.0",
+        "mathml-tag-names": "^2.1.1",
+        "meow": "^6.0.0",
+        "micromatch": "^4.0.2",
         "normalize-selector": "^0.2.0",
-        "pify": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-html": "^0.34.0",
-        "postcss-jsx": "^0.35.0",
-        "postcss-less": "^3.0.1",
-        "postcss-markdown": "^0.34.0",
+        "postcss": "^7.0.26",
+        "postcss-html": "^0.36.0",
+        "postcss-jsx": "^0.36.3",
+        "postcss-less": "^3.1.4",
+        "postcss-markdown": "^0.36.0",
         "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^6.0.0",
+        "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^4.0.0",
-        "postcss-sass": "^0.3.5",
+        "postcss-safe-parser": "^4.0.1",
+        "postcss-sass": "^0.4.2",
         "postcss-scss": "^2.0.0",
         "postcss-selector-parser": "^3.1.0",
-        "postcss-styled": "^0.34.0",
-        "postcss-syntax": "^0.34.0",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
-        "signal-exit": "^3.0.2",
-        "slash": "^2.0.0",
+        "postcss-syntax": "^0.36.2",
+        "postcss-value-parser": "^4.0.2",
+        "resolve-from": "^5.0.0",
+        "slash": "^3.0.0",
         "specificity": "^0.4.1",
-        "string-width": "^2.1.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.0.0"
+        "table": "^5.4.6",
+        "v8-compile-cache": "^2.1.0",
+        "write-file-atomic": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "cosmiconfig": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-          "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0"
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
           }
         },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
-        },
-        "globby": {
-          "version": "8.0.1",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "fast-glob": "^2.0.2",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "path-type": "^4.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+          "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           },
           "dependencies": {
-            "ignore": {
-              "version": "3.3.10",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-              "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-              "dev": true
-            },
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "resolve-from": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
               "dev": true
             }
           }
         },
-        "ignore": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.4.tgz",
-          "integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==",
-          "dev": true
-        },
         "import-lazy": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-          "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+          "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
-            }
-          }
-        },
-        "map-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
-        "meow": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0",
-            "yargs-parser": "^10.0.0"
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
           "dev": true,
           "requires": {
+            "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
           }
         },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+        "postcss": {
+          "version": "7.0.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "redent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
-          }
+        "postcss-value-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+          "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+          "dev": true
         },
         "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
         "slash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-          "dev": true
-        },
-        "trim-newlines": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         }
       }
     },
+    "stylelint-config-prettier": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-8.0.1.tgz",
+      "integrity": "sha512-RcjNW7MUaNVqONhJH4+rtlAE3ow/9SsAM0YWV0Lgu3dbTKdWTa/pQXRdFWgoHWpzUKn+9oBKR5x8JdH+20wmgw==",
+      "dev": true
+    },
     "stylelint-config-recommended": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz",
-      "integrity": "sha512-ajMbivOD7JxdsnlS5945KYhvt7L/HwN6YeYF2BH6kE4UCLJR0YvXMf+2j7nQpJyYLZx9uZzU5G1ZOSBiWAc6yA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
       "dev": true
     },
     "stylelint-config-recommended-scss": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.2.0.tgz",
-      "integrity": "sha512-M8BFHMRf8KNz5EQPKJd8nMCGmBd2o5coDEObfHVbEkyLDgjIf1V+U5dHjaGgvhm0zToUxshxN+Gc5wpbOOew4g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.2.0.tgz",
+      "integrity": "sha512-4bI5BYbabo/GCQ6LbRZx/ZlVkK65a1jivNNsD+ix/Lw0U3iAch+jQcvliGnnAX8SUPaZ0UqzNVNNAF3urswa7g==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^2.0.0"
+        "stylelint-config-recommended": "^3.0.0"
       }
     },
     "stylelint-scss": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.4.0.tgz",
-      "integrity": "sha512-sM1bsOrbmR35N1ZAg+7uLVI+n2QHqOVMZPRiAIyiOa1ITBrg0hajBH/i1F/ZxbsBUWLAeSq/NREwPw1+xF9exQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.14.2.tgz",
+      "integrity": "sha512-59/BkIEWyFoORiejDIQB2P2kmg0KcqMn7wtj1y5sRvS4N+Qh+Ng3hbKelOzgS+OM2Ezbai0uEev8xckXxkh9TQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^4.0.0",
-        "postcss-value-parser": "^3.3.1"
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
       },
       "dependencies": {
         "cssesc": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-1.0.1.tgz",
-          "integrity": "sha512-S2hzrpWvE6G/rW7i7IxJfWBYn27QWfOIncUW++8Rbo1VB5zsJDSVPcnI+Q8z7rhxT6/yZeLOCja4cZnghJrNGA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
           "dev": true
         },
         "postcss-selector-parser": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-4.0.0.tgz",
-          "integrity": "sha512-5h+MvEjnzu1qy6MabjuoPatsGAjjDV9B24e7Cktjl+ClNtjVjmvAXjOFQr1u7RlWULKNGYaYVE4s+DIIQ4bOGA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
           "dev": true,
           "requires": {
-            "cssesc": "^1.0.1",
+            "cssesc": "^3.0.0",
             "indexes-of": "^1.0.1",
             "uniq": "^1.0.1"
           }
+        },
+        "postcss-value-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+          "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+          "dev": true
         }
       }
     },
@@ -13086,46 +13796,65 @@
       "dev": true
     },
     "table": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.1.0.tgz",
-      "integrity": "sha512-e542in22ZLhD/fOIuXs/8yDZ9W61ltF8daM88rkRNtgTIct+vI2fTnAyu/Db2TCfEcI8i7mjZz6meLq0nW7TYg==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.3",
-        "lodash": "^4.17.10",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -13450,6 +14179,12 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
+    "trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -13457,15 +14192,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
-      "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "tryer": {
@@ -13534,6 +14269,23 @@
         }
       }
     },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
+    "tslint-plugin-prettier": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.1.0.tgz",
+      "integrity": "sha512-nMCpU+QSpXtydcWXeZF+3ljIbG/K8SHVZwB7K/MtuoQQFXxXN6watqTSBpVXCInuPFvmjiWkhxeMoUW4N0zgSg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "^2.2.0",
+        "lines-and-columns": "^1.1.6",
+        "tslib": "^1.7.1"
+      }
+    },
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
@@ -13586,6 +14338,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
@@ -13635,13 +14396,13 @@
       }
     },
     "unherit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -13673,16 +14434,18 @@
       "dev": true
     },
     "unified": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
       "dev": true,
       "requires": {
+        "@types/unist": "^2.0.0",
+        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-plain-obj": "^1.1.0",
         "trough": "^1.0.0",
-        "vfile": "^2.0.0",
+        "vfile": "^3.0.0",
         "x-is-string": "^0.1.0"
       }
     },
@@ -13732,51 +14495,54 @@
       }
     },
     "unist-util-find-all-after": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-      "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz",
+      "integrity": "sha512-lWgIc3rrTMTlK1Y0hEuL+k+ApzFk78h+lsaa2gHf63Gp5Ww+mt11huDniuaoq1H+XMK2lIIjjPkncxXcDp3QDw==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "^3.0.0"
       }
     },
     "unist-util-is": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
       "dev": true
     },
     "unist-util-remove-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-      "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+      "integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
     },
     "unist-util-visit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
         "unist-util-visit-parents": "^2.0.0"
       }
     },
     "unist-util-visit-parents": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.2"
+        "unist-util-is": "^3.0.0"
       }
     },
     "universal-analytics": {
@@ -13993,6 +14759,12 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14030,30 +14802,54 @@
       }
     },
     "vfile": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.4",
+        "is-buffer": "^2.0.0",
         "replace-ext": "1.0.0",
         "unist-util-stringify-position": "^1.0.0",
         "vfile-message": "^1.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+          "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+          "dev": true
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+          "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+          "dev": true,
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        }
       }
     },
     "vfile-location": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-      "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
       "dev": true
     },
     "vfile-message": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.2.tgz",
-      "integrity": "sha512-dNdEXHfPCvzyOlEaaQ+DcXpcxEz+pFvdrebKLiAMjobjaBC2bMeWoHOKPwJ+I8A4jQOEUDH7uoVcLWDLF1qhVQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+      "integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
       "dev": true,
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {
@@ -14829,7 +15625,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -14866,9 +15662,9 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -14954,6 +15750,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.3"
+      }
     },
     "yargs": {
       "version": "12.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -951,7 +951,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -7374,7 +7374,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -11204,6 +11204,15 @@
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -13675,6 +13684,15 @@
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "^3.0.0"
+      }
+    },
+    "stylelint-prettier": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-1.1.2.tgz",
+      "integrity": "sha512-8QZ+EtBpMCXYB6cY0hNE3aCDKMySIx4Q8/malLaqgU/KXXa6Cj2KK8ulG1AJvUMD5XSSP8rOotqaCzR/BW6qAA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "stylelint-scss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,6 +2591,15 @@
         "fastq": "^1.6.0"
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "@schematics/angular": {
       "version": "8.3.21",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.21.tgz",
@@ -3138,6 +3147,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -4405,6 +4420,44 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -5145,6 +5198,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
@@ -5194,6 +5253,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-equal": {
@@ -5613,6 +5678,12 @@
       "version": "1.3.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.344.tgz",
       "integrity": "sha512-tvbx2Wl8WBR+ym3u492D0L6/jH+8NoQXqe46+QhbWH3voVPauGuZYeb1QAXYoOAWuiP2dbSvlBx0kQ1F3hu/Mw==",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "elliptic": {
@@ -6503,6 +6574,15 @@
         }
       }
     },
+    "find-versions": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^2.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -7246,6 +7326,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -7791,6 +7877,12 @@
         }
       }
     },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -7798,6 +7890,150 @@
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
+      }
+    },
+    "husky": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.1.tgz",
+      "integrity": "sha512-Qa0lRreeIf4Tl92sSs42ER6qc3hzoyQPPorzOrFWfPEVbdi6LuvJEqWKPk905fOWIR76iBpp7ECZNIwk+a8xuQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.5.1",
+        "cosmiconfig": "^6.0.0",
+        "find-versions": "^3.2.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "compare-versions": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.5.1.tgz",
+          "integrity": "sha512-9fGPIB7C6AyM18CJJBHt5EnCZDG3oiTJYy0NjfIAGjKpzv0tkxWko7TNQHF5ymqm7IH03tqmeuBxtvD+Izh6mg==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -8325,6 +8561,15 @@
       "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -9243,6 +9488,433 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "lint-staged": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.0.7.tgz",
+      "integrity": "sha512-Byj0F4l7GYUpYYHEqyFH69NiI6ICTg0CeCKbhRorL+ickbzILKUlZLiyCkljZV02wnoh7yH7PmFyYm9PRNwk9g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "commander": "^4.0.1",
+        "cosmiconfig": "^6.0.0",
+        "debug": "^4.1.1",
+        "dedent": "^0.7.0",
+        "execa": "^3.4.0",
+        "listr": "^0.14.3",
+        "log-symbols": "^3.0.0",
+        "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "string-argv": "0.3.1",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+          "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -9305,6 +9977,84 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
           }
         }
       }
@@ -10334,6 +11084,12 @@
         "is-wsl": "^1.1.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
+    },
     "opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
@@ -10830,6 +11586,15 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "portfinder": {
@@ -12265,6 +13030,12 @@
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
@@ -12291,6 +13062,12 @@
       "requires": {
         "semver": "^5.0.0"
       }
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "dev": true
     },
     "send": {
       "version": "0.16.2",
@@ -13129,6 +13906,12 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -13197,6 +13980,25 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "dependencies": {
+        "is-regexp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+          "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+          "dev": true
+        }
+      }
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -13210,6 +14012,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-indent": {
@@ -15579,6 +16387,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "ng test",
     "test:ci": "ng test --watch=false --code-coverage",
     "lint": "ng lint && stylelint './src/**/*.scss'",
+    "lint:fix": "ng lint --fix && stylelint './src/**/*.scss' --fix",
     "e2e": "ng e2e"
   },
   "private": true,
@@ -54,12 +55,16 @@
     "karma-jasmine-html-reporter": "0.2",
     "karma-junit-reporter": "1.2",
     "nodemon": "1.18.6",
+    "prettier": "^1.19.1",
     "protractor": "5.4",
-    "stylelint": "9",
-    "stylelint-config-recommended-scss": "3",
-    "stylelint-scss": "3",
+    "stylelint": "^13.0.0",
+    "stylelint-config-prettier": "^8.0.1",
+    "stylelint-config-recommended-scss": "^4.2.0",
+    "stylelint-scss": "^3.14.2",
     "ts-node": "7.0",
     "tslint": "5.11",
+    "tslint-config-prettier": "^1.18.0",
+    "tslint-plugin-prettier": "^2.1.0",
     "typescript": "3.5.3",
     "webpack-bundle-analyzer": "3.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "stylelint": "^13.0.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-recommended-scss": "^4.2.0",
+    "stylelint-prettier": "^1.1.2",
     "stylelint-scss": "^3.14.2",
     "ts-node": "7.0",
     "tslint": "5.11",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/jasminewd2": "2.0",
     "@types/node": "8.9",
     "codelyzer": "^5.1.1",
+    "husky": "^4.2.1",
     "jasmine-core": "2.99",
     "jasmine-spec-reporter": "4.2",
     "karma": "^4.1.0",
@@ -54,6 +55,7 @@
     "karma-jasmine": "1.1",
     "karma-jasmine-html-reporter": "0.2",
     "karma-junit-reporter": "1.2",
+    "lint-staged": "^10.0.7",
     "nodemon": "1.18.6",
     "prettier": "^1.19.1",
     "protractor": "5.4",
@@ -68,5 +70,14 @@
     "tslint-plugin-prettier": "^2.1.0",
     "typescript": "3.5.3",
     "webpack-bundle-analyzer": "3.3.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{scss, css}": "stylelint --fix",
+    "*.ts": "prettier --write"
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,12 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
-	imports: [
-		RouterModule.forRoot([], { useHash: true })
-	],
-	exports: [
-		RouterModule
-	]
+	imports: [RouterModule.forRoot([], { useHash: true })],
+	exports: [RouterModule]
 })
-
 export class AppRoutingModule {}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,16 +8,8 @@ import { PopoverModule } from 'ngx-bootstrap/popover';
 describe('AppComponent', () => {
 	beforeEach(async(() => {
 		TestBed.configureTestingModule({
-			declarations: [
-				AppComponent
-			],
-			imports: [
-				AppRoutingModule,
-				CoreModule,
-				SiteModule,
-
-				PopoverModule.forRoot()
-			],
+			declarations: [AppComponent],
+			imports: [AppRoutingModule, CoreModule, SiteModule, PopoverModule.forRoot()]
 		}).compileComponents();
 	}));
 	it('should create the app', async(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,9 +3,6 @@ import { Component } from '@angular/core';
 @Component({
 	selector: 'app-root',
 	templateUrl: './app.component.html',
-	styleUrls: [ './app.component.scss' ]
+	styleUrls: ['./app.component.scss']
 })
-
-export class AppComponent {
-
-}
+export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,11 +11,8 @@ import { CoreModule } from './core/core.module';
 import { SessionService } from './core/auth/session.service';
 import { SiteModule } from './site/site.module';
 
-
 @NgModule({
-	declarations: [
-		AppComponent
-	],
+	declarations: [AppComponent],
 	imports: [
 		BrowserModule,
 		HttpClientModule,
@@ -27,9 +24,7 @@ import { SiteModule } from './site/site.module';
 		CoreModule,
 		SiteModule
 	],
-	providers: [
-		SessionService
-	],
-	bootstrap: [ AppComponent ]
+	providers: [SessionService],
+	bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/common/breadcrumb.module.ts
+++ b/src/app/common/breadcrumb.module.ts
@@ -5,15 +5,8 @@ import { RouterModule } from '@angular/router';
 import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
 
 @NgModule({
-	imports: [
-		CommonModule,
-		RouterModule
-	],
-	exports: [
-		BreadcrumbComponent
-	],
-	declarations: [
-		BreadcrumbComponent
-	]
+	imports: [CommonModule, RouterModule],
+	exports: [BreadcrumbComponent],
+	declarations: [BreadcrumbComponent]
 })
 export class BreadcrumbModule {}

--- a/src/app/common/breadcrumb/breadcrumb.component.scss
+++ b/src/app/common/breadcrumb/breadcrumb.component.scss
@@ -5,7 +5,7 @@
 $breadcrumb-header-height: $nav-closed-width !default;
 $breadcrumb-font-size: $font-size !default;
 $breadcrumb-line-height: $font-line-height !default;
-$breadcrumb-item-padding-left: .5rem !default;
+$breadcrumb-item-padding-left: 0.5rem !default;
 $breadcrumb-first-item-padding-left: 1rem !default;
 
 .header {
@@ -16,7 +16,8 @@ $breadcrumb-first-item-padding-left: 1rem !default;
 	background-color: $color-white;
 	height: $breadcrumb-header-height;
 
-	.header-breadcrumb, .header-breadcrumb-separator {
+	.header-breadcrumb,
+	.header-breadcrumb-separator {
 		padding-left: $breadcrumb-item-padding-left;
 		&:first-child {
 			padding-left: $breadcrumb-first-item-padding-left;

--- a/src/app/common/breadcrumb/breadcrumb.component.ts
+++ b/src/app/common/breadcrumb/breadcrumb.component.ts
@@ -9,10 +9,9 @@ import { BreadcrumbService, Breadcrumb } from './breadcrumb.service';
 @Component({
 	selector: 'breadcrumb',
 	templateUrl: 'breadcrumb.component.html',
-	styleUrls: [ 'breadcrumb.component.scss' ]
+	styleUrls: ['breadcrumb.component.scss']
 })
 export class BreadcrumbComponent {
-
 	@Input()
 	set homeBreadcrumb(hb: Breadcrumb) {
 		this._homeBreadcrumb = hb;
@@ -23,15 +22,16 @@ export class BreadcrumbComponent {
 
 	breadcrumbs: Breadcrumb[] = [];
 
-	constructor(
-		private route: ActivatedRoute,
-		private router: Router
-	) {
-		const navEnd$: Observable<Event> = router.events.pipe(filter((event: Event) => event instanceof NavigationEnd));
+	constructor(private route: ActivatedRoute, private router: Router) {
+		const navEnd$: Observable<Event> = router.events.pipe(
+			filter((event: Event) => event instanceof NavigationEnd)
+		);
 		merge(navEnd$, this.homeBreadcrumbChanged$).subscribe(() => {
 			if (null != this._homeBreadcrumb) {
 				this.breadcrumbs = [this._homeBreadcrumb];
-				this.breadcrumbs = this.breadcrumbs.concat(BreadcrumbService.getBreadcrumbs(route.root.snapshot, this._homeBreadcrumb.url));
+				this.breadcrumbs = this.breadcrumbs.concat(
+					BreadcrumbService.getBreadcrumbs(route.root.snapshot, this._homeBreadcrumb.url)
+				);
 			}
 		});
 	}

--- a/src/app/common/breadcrumb/breadcrumb.service.ts
+++ b/src/app/common/breadcrumb/breadcrumb.service.ts
@@ -6,8 +6,11 @@ export interface Breadcrumb {
 }
 
 export class BreadcrumbService {
-
-	static getBreadcrumbs(route: ActivatedRouteSnapshot, url: string = '', breadcrumbs: Breadcrumb[] = []): Breadcrumb[] {
+	static getBreadcrumbs(
+		route: ActivatedRouteSnapshot,
+		url: string = '',
+		breadcrumbs: Breadcrumb[] = []
+	): Breadcrumb[] {
 		const ROUTE_DATA_BREADCRUMB = 'breadcrumb';
 
 		// Get the child routes

--- a/src/app/common/directives.module.ts
+++ b/src/app/common/directives.module.ts
@@ -4,14 +4,10 @@ import { SkipToDirective } from './directives/skip-to.directive';
 
 @NgModule({
 	imports: [],
-	exports: [
-		SkipToDirective
-	],
-	declarations: [
-		SkipToDirective
-	],
+	exports: [SkipToDirective],
+	declarations: [SkipToDirective],
 	providers: []
 })
-export class DirectivesModule { }
+export class DirectivesModule {}
 
 export { SkipToDirective } from './directives/skip-to.directive';

--- a/src/app/common/directives/skip-to.directive.ts
+++ b/src/app/common/directives/skip-to.directive.ts
@@ -9,10 +9,7 @@ import { Directive, ElementRef, Renderer2 } from '@angular/core';
 	selector: '[skipTo]'
 })
 export class SkipToDirective {
-	constructor(
-		private elRef: ElementRef,
-		private renderer: Renderer2
-	) {
+	constructor(private elRef: ElementRef, private renderer: Renderer2) {
 		const el = elRef.nativeElement;
 		renderer.addClass(el, 'skip-to');
 		renderer.setAttribute(el, 'tabindex', '-1');

--- a/src/app/common/flyout.module.ts
+++ b/src/app/common/flyout.module.ts
@@ -3,15 +3,9 @@ import { FlyoutComponent } from './flyout/flyout.component';
 import { CommonModule } from '@angular/common';
 
 @NgModule({
-	imports: [
-		CommonModule
-	],
-	exports: [
-		FlyoutComponent
-	],
-	declarations: [
-		FlyoutComponent
-	],
+	imports: [CommonModule],
+	exports: [FlyoutComponent],
+	declarations: [FlyoutComponent],
 	providers: []
 })
-export class FlyoutModule { }
+export class FlyoutModule {}

--- a/src/app/common/flyout/flyout.component.scss
+++ b/src/app/common/flyout/flyout.component.scss
@@ -5,7 +5,7 @@
 $flyout-btn-color: $ux-color-white !default;
 $flyout-btn-bg-color: $ux-color-highlight !default;
 $flyout-border-top: 10px !default;
-$flyout-box-shadow: 0 .25rem .5rem rgba($ux-color-black, .2) !default;
+$flyout-box-shadow: 0 0.25rem 0.5rem rgba($ux-color-black, 0.2) !default;
 
 $flyout-right-top: 25px !default;
 $flyout-top-top: $font-line-height !default;
@@ -15,20 +15,20 @@ $flyout-bottom-bottom: $font-line-height * 2 !default;
 	position: fixed;
 	right: 0;
 	top: $flyout-right-top;
-	transition: left .15s ease-in-out, right .15s ease-in-out;
+	transition: left 0.15s ease-in-out, right 0.15s ease-in-out;
 
-	&[placement="left"] {
+	&[placement='left'] {
 		right: auto;
 		left: $ux-nav-open-width;
 	}
 
-	&[placement="top"] {
+	&[placement='top'] {
 		right: auto;
 		top: $flyout-top-top;
 		left: $ux-nav-open-width;
 	}
 
-	&[placement="bottom"] {
+	&[placement='bottom'] {
 		right: auto;
 		top: auto;
 		bottom: $flyout-bottom-bottom;
@@ -37,7 +37,9 @@ $flyout-bottom-bottom: $font-line-height * 2 !default;
 }
 
 .navbar-close {
-	:host[placement="left"], :host[placement="top"], :host[placement="bottom"] {
+	:host[placement='left'],
+	:host[placement='top'],
+	:host[placement='bottom'] {
 		left: $ux-nav-closed-width;
 	}
 }
@@ -111,7 +113,8 @@ $flyout-bottom-bottom: $font-line-height * 2 !default;
 	box-shadow: $flyout-box-shadow;
 	width: 0;
 
-	.flyout-top &, .flyout-bottom & {
+	.flyout-top &,
+	.flyout-bottom & {
 		border-top: none;
 		border-left: $flyout-border-top solid $ux-color-highlight;
 		width: auto;

--- a/src/app/common/flyout/flyout.component.ts
+++ b/src/app/common/flyout/flyout.component.ts
@@ -1,11 +1,4 @@
-import {
-	Component,
-	ContentChild,
-	ElementRef,
-	Input,
-	OnInit,
-	ViewChild
-} from '@angular/core';
+import { Component, ContentChild, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 
 @Component({
 	selector: 'app-flyout',
@@ -13,9 +6,8 @@ import {
 	styleUrls: ['./flyout.component.scss']
 })
 export class FlyoutComponent implements OnInit {
-
 	@ViewChild('flyoutContentContainer', { static: false }) container: ElementRef;
-	@ContentChild('flyoutContent', { static: false}) content: ElementRef;
+	@ContentChild('flyoutContent', { static: false }) content: ElementRef;
 
 	@Input()
 	label: string;
@@ -25,28 +17,27 @@ export class FlyoutComponent implements OnInit {
 
 	isOpen = false;
 
-	constructor() {
-	}
+	constructor() {}
 
-	ngOnInit() {
-	}
+	ngOnInit() {}
 
 	toggle() {
 		if (this.placement === 'top' || this.placement === 'bottom') {
 			if (this.isOpen) {
 				this.container.nativeElement.style.height = '0';
 			} else {
-				this.container.nativeElement.style.height = this.content.nativeElement.clientHeight + 'px';
+				this.container.nativeElement.style.height =
+					this.content.nativeElement.clientHeight + 'px';
 			}
 		} else {
 			if (this.isOpen) {
 				this.container.nativeElement.style.width = '0';
 			} else {
-				this.container.nativeElement.style.width = this.content.nativeElement.clientWidth + 'px';
+				this.container.nativeElement.style.width =
+					this.content.nativeElement.clientWidth + 'px';
 			}
 		}
 
 		this.isOpen = !this.isOpen;
 	}
-
 }

--- a/src/app/common/loading-spinner.module.ts
+++ b/src/app/common/loading-spinner.module.ts
@@ -3,14 +3,9 @@ import { NgModule } from '@angular/core';
 import { LoadingSpinnerComponent } from './loading-spinner/loading-spinner.component';
 
 @NgModule({
-	imports: [
-	],
-	exports: [
-		LoadingSpinnerComponent
-	],
-	declarations: [
-		LoadingSpinnerComponent
-	],
+	imports: [],
+	exports: [LoadingSpinnerComponent],
+	declarations: [LoadingSpinnerComponent],
 	providers: []
 })
-export class LoadingSpinnerModule { }
+export class LoadingSpinnerModule {}

--- a/src/app/common/loading-spinner/loading-spinner.component.scss
+++ b/src/app/common/loading-spinner/loading-spinner.component.scss
@@ -6,9 +6,7 @@ $loading-spinner-color: map-get($color-primary, 'darker') !default;
 $loading-spinner-size: 42px !default;
 $loading-spinner-message-font-size: 24px !default;
 
-
 .loading-container {
-
 	.loading-spinner {
 		display: inline-block;
 		float: left;
@@ -16,7 +14,7 @@ $loading-spinner-message-font-size: 24px !default;
 		height: $loading-spinner-size;
 
 		&:after {
-			content: " ";
+			content: ' ';
 			display: block;
 			width: $loading-spinner-size;
 			height: $loading-spinner-size;
@@ -26,7 +24,6 @@ $loading-spinner-message-font-size: 24px !default;
 			border-color: $loading-spinner-color transparent $loading-spinner-color transparent;
 			animation: loading-spinner 1.2s linear infinite;
 		}
-
 	}
 	.loading-message {
 		@include font-normal($loading-spinner-message-font-size);

--- a/src/app/common/loading-spinner/loading-spinner.component.spec.ts
+++ b/src/app/common/loading-spinner/loading-spinner.component.spec.ts
@@ -18,7 +18,6 @@ export class LoadingSpinnerProvidedTestHostComponent {
 }
 
 describe('LoadingSpinnerComponent', () => {
-
 	let defaultFixture: ComponentFixture<LoadingSpinnerDefaultTestHostComponent>;
 	let defaultTestHost: LoadingSpinnerDefaultTestHostComponent;
 	let defaultRootHTMLElement: HTMLElement;
@@ -66,5 +65,4 @@ describe('LoadingSpinnerComponent', () => {
 		providedFixture.detectChanges();
 		expect(providedRootHTMLElement.innerText).toContain(expectedContent);
 	});
-
 });

--- a/src/app/common/loading-spinner/loading-spinner.component.ts
+++ b/src/app/common/loading-spinner/loading-spinner.component.ts
@@ -1,14 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 
-
 @Component({
 	selector: 'loading-spinner',
 	templateUrl: 'loading-spinner.component.html',
-	styleUrls: [ 'loading-spinner.component.scss' ]
+	styleUrls: ['loading-spinner.component.scss']
 })
 export class LoadingSpinnerComponent {
-
 	@Input()
 	message = 'Loading...';
-
 }

--- a/src/app/common/modal.module.ts
+++ b/src/app/common/modal.module.ts
@@ -7,23 +7,13 @@ import { ModalComponent } from './modal/modal.component';
 import { ModalService } from './modal/modal.service';
 
 @NgModule({
-	imports: [
-		BsModalModule.forRoot(),
-		CommonModule
-	],
-	entryComponents: [
-		ModalComponent
-	],
-	exports: [
-		ModalComponent
-	],
-	declarations: [
-		ModalComponent
-	],
-	providers: [
-	]
+	imports: [BsModalModule.forRoot(), CommonModule],
+	entryComponents: [ModalComponent],
+	exports: [ModalComponent],
+	declarations: [ModalComponent],
+	providers: []
 })
-export class ModalModule { }
+export class ModalModule {}
 
 export { ModalComponent } from './modal/modal.component';
 export { ModalAction } from './modal/modal.model';

--- a/src/app/common/modal/modal.component.ts
+++ b/src/app/common/modal/modal.component.ts
@@ -8,9 +8,7 @@ import { ModalAction } from './modal.model';
 @Component({
 	templateUrl: 'modal.component.html'
 })
-
 export class ModalComponent {
-
 	title: string;
 
 	message: string;
@@ -21,9 +19,7 @@ export class ModalComponent {
 
 	onClose: Subject<ModalAction> = new Subject();
 
-	constructor(
-		public modalRef: BsModalRef
-	) {}
+	constructor(public modalRef: BsModalRef) {}
 
 	ok() {
 		this.modalRef.hide();

--- a/src/app/common/modal/modal.model.ts
+++ b/src/app/common/modal/modal.model.ts
@@ -1,4 +1,3 @@
-
 export enum ModalAction {
 	OK = 0,
 	CANCEL

--- a/src/app/common/modal/modal.service.ts
+++ b/src/app/common/modal/modal.service.ts
@@ -8,12 +8,9 @@ import { ModalComponent } from './modal.component';
 
 @Injectable()
 export class ModalService {
-
 	private modalRef: BsModalRef;
 
-	constructor(
-		private modalService: BsModalService
-	) {}
+	constructor(private modalService: BsModalService) {}
 
 	alert(title: string, message: string, okText?: string): Observable<ModalAction> {
 		this.showModalHelper(title, message, okText);
@@ -27,7 +24,10 @@ export class ModalService {
 	}
 
 	private showModalHelper(title: string, message: string, okText?: string) {
-		this.modalRef = this.modalService.show(ModalComponent, { ignoreBackdropClick: true, class: 'modal-lg' });
+		this.modalRef = this.modalService.show(ModalComponent, {
+			ignoreBackdropClick: true,
+			class: 'modal-lg'
+		});
 		this.modalRef.content.title = title;
 		this.modalRef.content.message = message;
 

--- a/src/app/common/multi-select-input.module.ts
+++ b/src/app/common/multi-select-input.module.ts
@@ -7,19 +7,11 @@ import { NgSelectModule } from '@ng-select/ng-select';
 import { MultiSelectInputComponent } from './multi-select-input/multi-select-input.component';
 
 @NgModule({
-	imports: [
-		CommonModule,
-		FormsModule,
-		NgSelectModule
-	],
-	exports: [
-		MultiSelectInputComponent
-	],
-	declarations: [
-		MultiSelectInputComponent
-	],
+	imports: [CommonModule, FormsModule, NgSelectModule],
+	exports: [MultiSelectInputComponent],
+	declarations: [MultiSelectInputComponent],
 	providers: []
 })
-export class MultiSelectInputModule { }
+export class MultiSelectInputModule {}
 
-export  { MultiSelectInputComponent } from './multi-select-input/multi-select-input.component';
+export { MultiSelectInputComponent } from './multi-select-input/multi-select-input.component';

--- a/src/app/common/multi-select-input/multi-select-input.component.scss
+++ b/src/app/common/multi-select-input/multi-select-input.component.scss
@@ -7,7 +7,6 @@ $tag-color: #f9f9f9 !default;
 $tag-bg-color: $ux-color-primary !default;
 
 :host ::ng-deep .ng-select {
-
 	.ng-placeholder {
 		padding-top: 2px;
 		font-weight: 300;
@@ -52,7 +51,7 @@ $tag-bg-color: $ux-color-primary !default;
 		}
 	}
 
-	.ng-select-container .ng-value-container .ng-input>input {
+	.ng-select-container .ng-value-container .ng-input > input {
 		height: 27px;
 		margin-top: -1px;
 	}

--- a/src/app/common/multi-select-input/multi-select-input.component.ts
+++ b/src/app/common/multi-select-input/multi-select-input.component.ts
@@ -14,7 +14,6 @@ import { NG_VALUE_ACCESSOR, NgModel, ControlValueAccessor } from '@angular/forms
 	]
 })
 export class MultiSelectInputComponent implements ControlValueAccessor {
-
 	@Input() placeholder: string;
 	@ViewChild(NgModel, { static: false }) model: NgModel;
 	autocompleteOpen = false;
@@ -27,7 +26,7 @@ export class MultiSelectInputComponent implements ControlValueAccessor {
 	constructor() {}
 
 	onSearch($event) {
-		if ( $event.term.trim().length > 0 ) {
+		if ($event.term.trim().length > 0) {
 			this.autocompleteOpen = true;
 		} else {
 			this.autocompleteOpen = false;
@@ -53,8 +52,11 @@ export class MultiSelectInputComponent implements ControlValueAccessor {
 		this.innerValue = value;
 	}
 
-	registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }
+	registerOnChange(fn: (_: any) => void): void {
+		this.onChange = fn;
+	}
 
-	registerOnTouched(fn: () => void): void { this.onTouched = fn; }
-
+	registerOnTouched(fn: () => void): void {
+		this.onTouched = fn;
+	}
 }

--- a/src/app/common/paging.module.ts
+++ b/src/app/common/paging.module.ts
@@ -6,8 +6,14 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { PipesModule } from './pipes.module';
 import { DirectivesModule } from './directives.module';
-import { SortControlsComponent, TableSortOptions } from './paging/sort-controls/sort-controls.component';
-import { SortableTableHeader, SortableTableHeaderComponent } from './paging/sortable-table-header/sortable-table-header.component';
+import {
+	SortControlsComponent,
+	TableSortOptions
+} from './paging/sort-controls/sort-controls.component';
+import {
+	SortableTableHeader,
+	SortableTableHeaderComponent
+} from './paging/sortable-table-header/sortable-table-header.component';
 import { PagerComponent } from './paging/pager/pager.component';
 import { PageableTableComponent } from './paging/pageable-table/pageable-table.component';
 import { QuickColumnToggleComponent } from './paging/quick-column-toggle/quick-column-toggle.component';
@@ -15,13 +21,7 @@ import { QuickFiltersComponent } from './paging/quick-filters/quick-filters.comp
 import { SearchTableComponent } from './paging/search-table/search-table.component';
 
 @NgModule({
-	imports: [
-		CommonModule,
-		FormsModule,
-		DirectivesModule,
-		TooltipModule,
-		PipesModule
-	],
+	imports: [CommonModule, FormsModule, DirectivesModule, TooltipModule, PipesModule],
 	exports: [
 		PagerComponent,
 		PageableTableComponent,
@@ -42,15 +42,25 @@ import { SearchTableComponent } from './paging/search-table/search-table.compone
 	],
 	providers: []
 })
-export class PagingModule { }
+export class PagingModule {}
 
 export { AbstractPageableDataComponent } from './paging/abstract-pageable-data-component';
 export { PagerComponent, PagingComponent } from './paging/pager/pager.component';
-export { PageChange, PagingOptions, PagingResults, NULL_PAGING_RESULTS } from './paging/paging.model';
+export {
+	PageChange,
+	PagingOptions,
+	PagingResults,
+	NULL_PAGING_RESULTS
+} from './paging/paging.model';
 export { SortChange, SortDirection, SortDisplayOption } from './paging/sorting.model';
-export { SortControlsComponent, TableSortOptions } from './paging/sort-controls/sort-controls.component';
-export { SortableTableHeaderComponent, SortableTableHeader } from './paging/sortable-table-header/sortable-table-header.component';
+export {
+	SortControlsComponent,
+	TableSortOptions
+} from './paging/sort-controls/sort-controls.component';
+export {
+	SortableTableHeaderComponent,
+	SortableTableHeader
+} from './paging/sortable-table-header/sortable-table-header.component';
 export { QuickColumnToggleComponent } from './paging/quick-column-toggle/quick-column-toggle.component';
 export { QuickFiltersComponent } from './paging/quick-filters/quick-filters.component';
 export { SearchTableComponent } from './paging/search-table/search-table.component';
-

--- a/src/app/common/paging/abstract-pageable-data-component.ts
+++ b/src/app/common/paging/abstract-pageable-data-component.ts
@@ -9,7 +9,6 @@ import { PageChange, PagingOptions, PagingResults } from './paging.model';
 import { SortChange } from './sorting.model';
 
 export abstract class AbstractPageableDataComponent<T = any> implements OnInit {
-
 	items: T[] = [];
 	hasItems = false;
 
@@ -23,7 +22,10 @@ export abstract class AbstractPageableDataComponent<T = any> implements OnInit {
 
 	loading = true;
 
-	pageEvent$: BehaviorSubject<PageChange> = new BehaviorSubject({ pageNumber: 0, pageSize: this.pageSize });
+	pageEvent$: BehaviorSubject<PageChange> = new BehaviorSubject({
+		pageNumber: 0,
+		pageSize: this.pageSize
+	});
 
 	sortEvent$: BehaviorSubject<SortChange> = new BehaviorSubject({} as SortChange);
 
@@ -38,18 +40,25 @@ export abstract class AbstractPageableDataComponent<T = any> implements OnInit {
 	ngOnInit() {
 		this.searchEvent$.subscribe((search: string) => {
 			this.search = search;
-			this.pageEvent$.next({pageNumber: 0, pageSize: this.pageSize});
+			this.pageEvent$.next({ pageNumber: 0, pageSize: this.pageSize });
 		});
 
 		this.filterEvent$.subscribe((filters: any) => {
 			this.filters = cloneDeep(filters);
-			this.pageEvent$.next({pageNumber: 0, pageSize: this.pageSize});
+			this.pageEvent$.next({ pageNumber: 0, pageSize: this.pageSize });
 		});
 
 		combineLatest([this.load$, this.pageEvent$, this.sortEvent$])
 			.pipe(
 				map(([, pageChange, sortChange]: [boolean, PageChange, SortChange]) => {
-					return new PagingOptions(pageChange.pageNumber, pageChange.pageSize, 0, 0, sortChange.sortField, sortChange.sortDir);
+					return new PagingOptions(
+						pageChange.pageNumber,
+						pageChange.pageSize,
+						0,
+						0,
+						sortChange.sortField,
+						sortChange.sortDir
+					);
 				}),
 				tap((paging: PagingOptions) => {
 					this.pagingOptions = paging;
@@ -59,10 +68,16 @@ export abstract class AbstractPageableDataComponent<T = any> implements OnInit {
 					this.loading = true;
 					return this.loadData(pagingOpt, this.search, this.getQuery());
 				})
-			).subscribe((result: PagingResults<T>) => {
+			)
+			.subscribe((result: PagingResults<T>) => {
 				this.items = result.elements;
 				if (this.items.length > 0) {
-					this.pagingOptions.set(result.pageNumber, result.pageSize, result.totalPages, result.totalSize);
+					this.pagingOptions.set(
+						result.pageNumber,
+						result.pageSize,
+						result.totalPages,
+						result.totalSize
+					);
 				} else {
 					this.pagingOptions.reset();
 				}
@@ -79,5 +94,9 @@ export abstract class AbstractPageableDataComponent<T = any> implements OnInit {
 		return {};
 	}
 
-	abstract loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<T>>;
+	abstract loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<T>>;
 }

--- a/src/app/common/paging/pageable-table/pageable-table.component.scss
+++ b/src/app/common/paging/pageable-table/pageable-table.component.scss
@@ -1,4 +1,5 @@
-.table-header, .table-footer {
+.table-header,
+.table-footer {
 	display: flex;
 }
 

--- a/src/app/common/paging/pageable-table/pageable-table.component.spec.ts
+++ b/src/app/common/paging/pageable-table/pageable-table.component.spec.ts
@@ -13,33 +13,32 @@ import { DirectivesModule } from '../../directives.module';
 import { PipesModule } from '../../pipes.module';
 
 @Component({
-	template:
-		`
-	<pageable-table [items]="items"
-					[hasItems]="hasItems"
-					[pagingOptions]="pagingOptions"
-					(pageChange)="pageChanged$.next($event)">
+	template: `
+		<pageable-table
+			[items]="items"
+			[hasItems]="hasItems"
+			[pagingOptions]="pagingOptions"
+			(pageChange)="pageChanged$.next($event)"
+		>
+			<ng-template #tableHeader>
+				{{ headerContent }}
+			</ng-template>
 
-		<ng-template #tableHeader>
-			{{ headerContent }}
-		</ng-template>
+			<ng-template #tableRow let-item="item" let-index="index">
+				{{ rowContent }}
+				{{ item }}
+				{{ index }}
+			</ng-template>
 
-		<ng-template #tableRow let-item="item" let-index="index">
-			{{ rowContent }}
-			{{ item }}
-			{{ index }}
-		</ng-template>
+			<ng-template #tableNoData>
+				{{ noDataContent }}
+			</ng-template>
 
-		<ng-template #tableNoData>
-			{{ noDataContent }}
-		</ng-template>
-
-		<ng-template #tableNoResults>
-			{{ noResultsContent }}
-		</ng-template>
-
-	</pageable-table>
-`
+			<ng-template #tableNoResults>
+				{{ noResultsContent }}
+			</ng-template>
+		</pageable-table>
+	`
 })
 export class PageableTableTestHostComponent {
 	@Input() items: Iterable<any>;
@@ -55,19 +54,13 @@ export class PageableTableTestHostComponent {
 }
 
 describe('PageableTableComponent', () => {
-
 	let fixture: ComponentFixture<PageableTableTestHostComponent>;
 	let testHost: PageableTableTestHostComponent;
 	let rootHTMLElement: HTMLElement;
 
 	beforeEach(() => {
 		const testbed = TestBed.configureTestingModule({
-			imports: [
-				TooltipModule.forRoot(),
-				DirectivesModule,
-				FormsModule,
-				PipesModule
-			],
+			imports: [TooltipModule.forRoot(), DirectivesModule, FormsModule, PipesModule],
 			declarations: [
 				PageableTableTestHostComponent,
 				PageableTableComponent,
@@ -125,26 +118,18 @@ describe('PageableTableComponent', () => {
 	});
 
 	it('binds the item to the row template', () => {
-		const items = [
-			'ITEM_A',
-			'ITEM_B',
-			'ITEM_C'
-		];
+		const items = ['ITEM_A', 'ITEM_B', 'ITEM_C'];
 
 		testHost.items = items;
 		fixture.detectChanges();
 
-		items.forEach((item) => {
+		items.forEach(item => {
 			expect(rootHTMLElement.innerText).toContain(item);
 		});
 	});
 
 	it('binds the index of the item to the row template', () => {
-		const items = [
-			'ITEM_A',
-			'ITEM_B',
-			'ITEM_C'
-		];
+		const items = ['ITEM_A', 'ITEM_B', 'ITEM_C'];
 
 		testHost.items = items;
 		fixture.detectChanges();
@@ -160,5 +145,4 @@ describe('PageableTableComponent', () => {
 			fixture.detectChanges();
 		}).not.toThrow();
 	});
-
 });

--- a/src/app/common/paging/pageable-table/pageable-table.component.ts
+++ b/src/app/common/paging/pageable-table/pageable-table.component.ts
@@ -1,16 +1,13 @@
-import {
-	Component, Input, Output, EventEmitter, TemplateRef, ContentChild
-} from '@angular/core';
+import { Component, Input, Output, EventEmitter, TemplateRef, ContentChild } from '@angular/core';
 
 import { PagingOptions, PageChange } from '../paging.model';
 
 @Component({
 	selector: 'pageable-table',
 	templateUrl: './pageable-table.component.html',
-	styleUrls: [ './pageable-table.component.scss' ]
+	styleUrls: ['./pageable-table.component.scss']
 })
 export class PageableTableComponent {
-
 	@Input() pagingOptions: PagingOptions = new PagingOptions();
 	@Input() hasItems = false;
 	@Input() itemIdProperty = '_id';
@@ -31,7 +28,7 @@ export class PageableTableComponent {
 	@Input() set items(data: Array<any>) {
 		this.itemsInternal = data;
 		if (data) {
-			this.itemsExpanded = data.map((i) => false);
+			this.itemsExpanded = data.map(i => false);
 		}
 	}
 	get items() {
@@ -40,11 +37,11 @@ export class PageableTableComponent {
 
 	@Output() readonly pageChange = new EventEmitter<PageChange>();
 
-	@ContentChild('tableActions', {static: true}) actionTemplate: TemplateRef<any>;
-	@ContentChild('tableHeader', {static: true}) headerTemplate: TemplateRef<any>;
-	@ContentChild('tableRow', {static: true}) rowTemplate: TemplateRef<any>;
-	@ContentChild('tableRowExpanded', {static: true}) rowExpandedTemplate: TemplateRef<any>;
-	@ContentChild('tableNoResults', {static: true}) noResultsTableTemplate: TemplateRef<any>;
-	@ContentChild('tableNoData', {static: true}) noDataTableTemplate: TemplateRef<any>;
-	@ContentChild('tableFooterActions', {static: true}) footerActionTemplate: TemplateRef<any>;
+	@ContentChild('tableActions', { static: true }) actionTemplate: TemplateRef<any>;
+	@ContentChild('tableHeader', { static: true }) headerTemplate: TemplateRef<any>;
+	@ContentChild('tableRow', { static: true }) rowTemplate: TemplateRef<any>;
+	@ContentChild('tableRowExpanded', { static: true }) rowExpandedTemplate: TemplateRef<any>;
+	@ContentChild('tableNoResults', { static: true }) noResultsTableTemplate: TemplateRef<any>;
+	@ContentChild('tableNoData', { static: true }) noDataTableTemplate: TemplateRef<any>;
+	@ContentChild('tableFooterActions', { static: true }) footerActionTemplate: TemplateRef<any>;
 }

--- a/src/app/common/paging/pager/pager.component.ts
+++ b/src/app/common/paging/pager/pager.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, Output, SimpleChange, EventEmitter, OnInit, OnChanges } from '@angular/core';
+import {
+	Component,
+	Input,
+	Output,
+	SimpleChange,
+	EventEmitter,
+	OnInit,
+	OnChanges
+} from '@angular/core';
 
 import isNumber from 'lodash/isNumber';
 
@@ -9,7 +17,6 @@ import { PageChange, PagingOptions } from '../paging.model';
  * @deprecated
  */
 export abstract class PagingComponent {
-
 	pagingOpts: PagingOptions;
 
 	abstract loadData();
@@ -29,16 +36,14 @@ export abstract class PagingComponent {
 		this.pagingOpts.sortDir = sortOpt.sortDir;
 		this.loadData();
 	}
-
 }
 
 @Component({
 	selector: 'asy-pager',
 	templateUrl: './pager.component.html',
-	styleUrls: [ './pager.component.scss' ]
+	styleUrls: ['./pager.component.scss']
 })
 export class PagerComponent implements OnInit, OnChanges {
-
 	@Input() pageNumber = 0;
 	@Input() pageSize = 0;
 	@Input() totalSize = 0;
@@ -70,29 +75,37 @@ export class PagerComponent implements OnInit, OnChanges {
 		this.format();
 	}
 
-	ngOnChanges(changes: {[propKey: string]: SimpleChange}) {
-		if (changes.hasOwnProperty('pageNumber') || changes.hasOwnProperty('pageSize') || changes.hasOwnProperty('totalSize')) {
+	ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
+		if (
+			changes.hasOwnProperty('pageNumber') ||
+			changes.hasOwnProperty('pageSize') ||
+			changes.hasOwnProperty('totalSize')
+		) {
 			this.calculateTotalPages();
 			this.format();
 		}
 	}
 
 	isValid() {
-		return isNumber(this.pageSize) && isNumber(this.pageNumber) && isNumber(this.currentSize) && isNumber(this.totalSize);
+		return (
+			isNumber(this.pageSize) &&
+			isNumber(this.pageNumber) &&
+			isNumber(this.currentSize) &&
+			isNumber(this.totalSize)
+		);
 	}
 
 	format() {
 		if (this.isValid()) {
-			this.startFormatted = ((this.pageSize * this.pageNumber) + 1).toLocaleString();
+			this.startFormatted = (this.pageSize * this.pageNumber + 1).toLocaleString();
 
-			let end = (this.pageSize * this.pageNumber) + Math.max(this.pageSize, this.currentSize);
-			end = (end > this.totalSize) ? this.totalSize : end;
+			let end = this.pageSize * this.pageNumber + Math.max(this.pageSize, this.currentSize);
+			end = end > this.totalSize ? this.totalSize : end;
 			this.endFormatted = end.toLocaleString();
 
 			if (this.totalSize !== 0) {
 				this.totalFormatted = this.totalSize.toLocaleString();
 			}
-
 		}
 	}
 
@@ -110,7 +123,7 @@ export class PagerComponent implements OnInit, OnChanges {
 		this.format();
 
 		// Emit change event
-		this.pageChange.emit({pageNumber: this.pageNumber, pageSize: this.pageSize});
+		this.pageChange.emit({ pageNumber: this.pageNumber, pageSize: this.pageSize });
 	}
 
 	setPageSize(pageSize: number) {
@@ -121,6 +134,6 @@ export class PagerComponent implements OnInit, OnChanges {
 		this.pageNumber = 0;
 
 		// Emit change event
-		this.pageChange.emit({pageNumber: this.pageNumber, pageSize: this.pageSize});
+		this.pageChange.emit({ pageNumber: this.pageNumber, pageSize: this.pageSize });
 	}
 }

--- a/src/app/common/paging/quick-column-toggle/quick-column-toggle.component.ts
+++ b/src/app/common/paging/quick-column-toggle/quick-column-toggle.component.ts
@@ -5,17 +5,16 @@ import { QuickFiltersComponent } from '../quick-filters/quick-filters.component'
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	selector: 'quick-column-toggle',
 	templateUrl: '../quick-filters/quick-filters.component.html',
-	styleUrls: [ '../quick-filters/quick-filters.component.scss' ]
+	styleUrls: ['../quick-filters/quick-filters.component.scss']
 })
 export class QuickColumnToggleComponent extends QuickFiltersComponent {
-
 	title = 'Show Columns';
 
 	columnMode = 'default';
 
 	toggleQuickFilter(key: string) {
 		if (key === 'all') {
-			this.filterKeys.forEach((k: string) => this.filters[k].show = true);
+			this.filterKeys.forEach((k: string) => (this.filters[k].show = true));
 		} else if (key === 'default') {
 			this.filters = JSON.parse(JSON.stringify(this.defaultFilters));
 		}
@@ -40,7 +39,7 @@ export class QuickColumnToggleComponent extends QuickFiltersComponent {
 
 		// Check if our default columns are enabled
 		this.columnMode = 'default';
-		this.filterKeys.some( (key: string) => {
+		this.filterKeys.some((key: string) => {
 			if (this.filters[key].show !== this.defaultFilters[key].show) {
 				this.columnMode = 'custom';
 				return true;
@@ -48,4 +47,3 @@ export class QuickColumnToggleComponent extends QuickFiltersComponent {
 		});
 	}
 }
-

--- a/src/app/common/paging/quick-filters/quick-filters.component.scss
+++ b/src/app/common/paging/quick-filters/quick-filters.component.scss
@@ -18,7 +18,7 @@
 		margin-bottom: 0;
 	}
 
-	input[type=checkbox] {
+	input[type='checkbox'] {
 		margin-right: 5px;
 
 		&:checked {
@@ -27,5 +27,4 @@
 			}
 		}
 	}
-
 }

--- a/src/app/common/paging/quick-filters/quick-filters.component.ts
+++ b/src/app/common/paging/quick-filters/quick-filters.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	EventEmitter,
+	Input,
+	OnDestroy,
+	OnInit,
+	Output
+} from '@angular/core';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 
@@ -9,7 +17,6 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
 	styleUrls: ['quick-filters.component.scss']
 })
 export class QuickFiltersComponent implements OnDestroy, OnInit {
-
 	@Input() title = 'Quick Filters';
 
 	@Input() filters: any = {};
@@ -28,10 +35,8 @@ export class QuickFiltersComponent implements OnDestroy, OnInit {
 
 	constructor() {
 		this.toggleFilter$
-			.pipe(
-				debounceTime(100),
-				takeUntil(this.destroy$)
-			).subscribe((key: string) => this.toggleQuickFilter(key));
+			.pipe(debounceTime(100), takeUntil(this.destroy$))
+			.subscribe((key: string) => this.toggleQuickFilter(key));
 	}
 
 	ngOnInit() {

--- a/src/app/common/paging/sort-controls/sort-controls.component.ts
+++ b/src/app/common/paging/sort-controls/sort-controls.component.ts
@@ -12,7 +12,6 @@ export interface TableSortOptions {
 	templateUrl: 'sort-controls.component.html'
 })
 export class SortControlsComponent {
-
 	@Input() showHeader = true;
 
 	@Input() showDirectionControl = false;
@@ -38,9 +37,10 @@ export class SortControlsComponent {
 			this.selectedDir = this.sortOptions[key].sortDir;
 			this.sortChange.emit(this.sortOptions[key]);
 
-		// Otherwise, toggle the sort direction (if direction controls are enabled)
+			// Otherwise, toggle the sort direction (if direction controls are enabled)
 		} else if (this.showDirectionControl) {
-			this.selectedDir = this.selectedDir === SortDirection.desc ? SortDirection.asc : SortDirection.desc;
+			this.selectedDir =
+				this.selectedDir === SortDirection.desc ? SortDirection.asc : SortDirection.desc;
 			this.sortOptions[key].sortDir = this.selectedDir;
 			this.sortChange.emit(this.sortOptions[key]);
 		}

--- a/src/app/common/paging/sortable-table-header/sortable-table-header.component.scss
+++ b/src/app/common/paging/sortable-table-header/sortable-table-header.component.scss
@@ -2,7 +2,7 @@
 @import '../../../../styles/shared';
 
 .low-opacity {
-	opacity: .3;
+	opacity: 0.3;
 }
 
 .sorted {

--- a/src/app/common/paging/sortable-table-header/sortable-table-header.component.ts
+++ b/src/app/common/paging/sortable-table-header/sortable-table-header.component.ts
@@ -13,10 +13,9 @@ export interface SortableTableHeader {
 @Component({
 	selector: 'sortable-table-header',
 	templateUrl: 'sortable-table-header.component.html',
-	styleUrls: [ 'sortable-table-header.component.scss' ]
+	styleUrls: ['sortable-table-header.component.scss']
 })
 export class SortableTableHeaderComponent implements OnInit {
-
 	@Input() header: any;
 
 	@Input() showSort = true;
@@ -37,10 +36,16 @@ export class SortableTableHeaderComponent implements OnInit {
 		if (this.sortable) {
 			// If this header is the currently sorted field, reverse the sort
 			if (this.header.sortField === this.currentSortField) {
-				this.sortChange.emit({ sortField: this.header.sortField, sortDir: this.currentSortDir === 'ASC' ? 'DESC' : 'ASC' } );
+				this.sortChange.emit({
+					sortField: this.header.sortField,
+					sortDir: this.currentSortDir === 'ASC' ? 'DESC' : 'ASC'
+				});
 			} else {
 				// Else select the default sort for this field
-				this.sortChange.emit({ sortField: this.header.sortField, sortDir: this.header.sortDir } );
+				this.sortChange.emit({
+					sortField: this.header.sortField,
+					sortDir: this.header.sortDir
+				});
 			}
 		}
 	}

--- a/src/app/common/pipes.module.ts
+++ b/src/app/common/pipes.module.ts
@@ -7,21 +7,11 @@ import { UtcDatePipe } from './pipes/utc-date-pipe/utc-date.pipe';
 
 @NgModule({
 	imports: [],
-	exports: [
-		AgoDatePipe,
-		KeysPipe,
-		SortObjectKeysPipe,
-		UtcDatePipe
-	],
-	declarations: [
-		AgoDatePipe,
-		KeysPipe,
-		SortObjectKeysPipe,
-		UtcDatePipe
-	],
+	exports: [AgoDatePipe, KeysPipe, SortObjectKeysPipe, UtcDatePipe],
+	declarations: [AgoDatePipe, KeysPipe, SortObjectKeysPipe, UtcDatePipe],
 	providers: []
 })
-export class PipesModule { }
+export class PipesModule {}
 
 export { AgoDatePipe } from './pipes/ago-date.pipe';
 export { KeysPipe } from './pipes/keys.pipe';

--- a/src/app/common/pipes/ago-date.pipe.ts
+++ b/src/app/common/pipes/ago-date.pipe.ts
@@ -1,7 +1,7 @@
-import {Pipe, PipeTransform} from '@angular/core';
+import { Pipe, PipeTransform } from '@angular/core';
 import * as moment from 'moment';
 
-@Pipe({name: 'agoDate'})
+@Pipe({ name: 'agoDate' })
 export class AgoDatePipe implements PipeTransform {
 	transform(date: Date | number, hideAgo?: boolean): string {
 		if (null != date) {

--- a/src/app/common/pipes/keys.pipe.spec.ts
+++ b/src/app/common/pipes/keys.pipe.spec.ts
@@ -1,13 +1,15 @@
 import { KeysPipe } from './keys.pipe';
 
 describe('KeysPipe', () => {
-
 	const keys = new KeysPipe();
 
 	it('transforms object with 2 keys to array of length 2', () => {
-		const transformed = keys.transform({foo: 'bar', one: 'two'});
+		const transformed = keys.transform({ foo: 'bar', one: 'two' });
 		transformed.sort(sortTransformedArray);
-		expect(transformed).toEqual([{key: 'foo', value: 'bar'}, {key: 'one', value: 'two'}]);
+		expect(transformed).toEqual([
+			{ key: 'foo', value: 'bar' },
+			{ key: 'one', value: 'two' }
+		]);
 	});
 
 	it('transforms empty object to empty array', () => {
@@ -21,5 +23,4 @@ describe('KeysPipe', () => {
 		}
 		return obj1.value.localeCompare(obj2.value);
 	}
-
 });

--- a/src/app/common/pipes/keys.pipe.ts
+++ b/src/app/common/pipes/keys.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 import forOwn from 'lodash/forOwn';
 
-@Pipe({name: 'keys'})
+@Pipe({ name: 'keys' })
 export class KeysPipe implements PipeTransform {
 	transform(obj: any): any {
 		const values: any[] = [];

--- a/src/app/common/pipes/sort-object-keys.pipe.spec.ts
+++ b/src/app/common/pipes/sort-object-keys.pipe.spec.ts
@@ -1,7 +1,6 @@
 import { SortObjectKeysPipe } from './sort-object-keys.pipe';
 
 describe('SortObjectKeysPipe', () => {
-
 	const pipe = new SortObjectKeysPipe();
 
 	it('should not transform sorted object with 2 keys to array of length 2', () => {
@@ -9,10 +8,12 @@ describe('SortObjectKeysPipe', () => {
 			foo: 'bar',
 			one: 'two'
 		});
-		expect(JSON.stringify(transformed)).toEqual(JSON.stringify({
-			foo: 'bar',
-			one: 'two'
-		}));
+		expect(JSON.stringify(transformed)).toEqual(
+			JSON.stringify({
+				foo: 'bar',
+				one: 'two'
+			})
+		);
 	});
 
 	it('should transform unsorted object with 2 keys to array of length 2', () => {
@@ -27,30 +28,34 @@ describe('SortObjectKeysPipe', () => {
 				abcd: 1
 			}
 		});
-		expect(JSON.stringify(transformed)).toEqual(JSON.stringify({
-			foo: {
-				abcd: 1,
-				efgh: true,
-				ijhk: [
-					{ a: false, b: false },
-					{ a: true, b: true }
-				]
-			},
-			one: 'two'
-		}));
+		expect(JSON.stringify(transformed)).toEqual(
+			JSON.stringify({
+				foo: {
+					abcd: 1,
+					efgh: true,
+					ijhk: [
+						{ a: false, b: false },
+						{ a: true, b: true }
+					]
+				},
+				one: 'two'
+			})
+		);
 
 		// Make sure stringify is not performing the sorting
-		expect(JSON.stringify(transformed)).not.toEqual(JSON.stringify({
-			one: 'two',
-			foo: {
-				abcd: 1,
-				efgh: true,
-				ijhk: [
-					{ a: false, b: false },
-					{ a: true, b: true }
-				]
-			}
-		}));
+		expect(JSON.stringify(transformed)).not.toEqual(
+			JSON.stringify({
+				one: 'two',
+				foo: {
+					abcd: 1,
+					efgh: true,
+					ijhk: [
+						{ a: false, b: false },
+						{ a: true, b: true }
+					]
+				}
+			})
+		);
 	});
 
 	it('should transform empty object to empty object', () => {
@@ -60,5 +65,4 @@ describe('SortObjectKeysPipe', () => {
 	it('should transform null object to null object', () => {
 		expect(pipe.transform(null)).toEqual(null);
 	});
-
 });

--- a/src/app/common/pipes/sort-object-keys.pipe.ts
+++ b/src/app/common/pipes/sort-object-keys.pipe.ts
@@ -4,9 +4,8 @@ import _isArray from 'lodash/isArray';
 import _isObject from 'lodash/isObject';
 import _keys from 'lodash/keys';
 
-@Pipe({name: 'sortObjectKeys'})
+@Pipe({ name: 'sortObjectKeys' })
 export class SortObjectKeysPipe implements PipeTransform {
-
 	// Derived from http://stackoverflow.com/a/1359808 and http://stackoverflow.com/a/23124958
 	transform(obj: any): any {
 		if (null == obj || !_isObject(obj)) {
@@ -15,7 +14,7 @@ export class SortObjectKeysPipe implements PipeTransform {
 
 		// Maintain the order of arrays, but sort keys of the array elements
 		if (_isArray(obj)) {
-			return obj.map( (o: any) => this.transform(o));
+			return obj.map((o: any) => this.transform(o));
 		}
 
 		const sorted: any = {};
@@ -27,5 +26,4 @@ export class SortObjectKeysPipe implements PipeTransform {
 
 		return sorted;
 	}
-
 }

--- a/src/app/common/pipes/utc-date-pipe/utc-date-utils.service.spec.ts
+++ b/src/app/common/pipes/utc-date-pipe/utc-date-utils.service.spec.ts
@@ -5,7 +5,9 @@ import { UtcDateUtils } from './utc-date-utils.service';
 describe('UtcDateUtils', () => {
 	describe('format', () => {
 		it('transforms date string to requested format', () => {
-			expect(UtcDateUtils.format('2016-01-31T00:00:00.000', 'dddd, MMMM Do YYYY, h:mm:ss a')).toBe('Sunday, January 31st 2016, 12:00:00 am');
+			expect(
+				UtcDateUtils.format('2016-01-31T00:00:00.000', 'dddd, MMMM Do YYYY, h:mm:ss a')
+			).toBe('Sunday, January 31st 2016, 12:00:00 am');
 		});
 
 		it('transforms date string to default format if no format is specified', () => {
@@ -21,11 +23,15 @@ describe('UtcDateUtils', () => {
 		});
 
 		it('transforms milliseconds date to requested format', () => {
-			expect(UtcDateUtils.format(1492440722873, 'dddd, MMMM Do YYYY, h:mm:ss a')).toBe('Monday, April 17th 2017, 2:52:02 pm');
+			expect(UtcDateUtils.format(1492440722873, 'dddd, MMMM Do YYYY, h:mm:ss a')).toBe(
+				'Monday, April 17th 2017, 2:52:02 pm'
+			);
 		});
 
 		it('transforms moment date to requested format', () => {
-			expect(UtcDateUtils.format(utc(1492440722873), 'dddd, MMMM Do YYYY')).toBe('Monday, April 17th 2017');
+			expect(UtcDateUtils.format(utc(1492440722873), 'dddd, MMMM Do YYYY')).toBe(
+				'Monday, April 17th 2017'
+			);
 		});
 
 		it('returns dash if input is invalid', () => {

--- a/src/app/common/pipes/utc-date-pipe/utc-date-utils.service.ts
+++ b/src/app/common/pipes/utc-date-pipe/utc-date-utils.service.ts
@@ -1,8 +1,6 @@
-
 import { Moment, isMoment, utc } from 'moment';
 
 export class UtcDateUtils {
-
 	private static defaultFormat = 'YYYY-MM-DD HH:mm:ss[Z]';
 
 	static format(value: string | number | Moment, format?: string): string {
@@ -11,7 +9,6 @@ export class UtcDateUtils {
 			if (isMoment(value)) {
 				momentDate = value;
 			} else {
-
 				momentDate = utc(value);
 				if (!momentDate.isValid()) {
 					// converts a string of milliseconds into a number
@@ -23,7 +20,9 @@ export class UtcDateUtils {
 			}
 
 			if (momentDate.isValid()) {
-				return momentDate.utc().format((null != format) ? format : UtcDateUtils.defaultFormat);
+				return momentDate
+					.utc()
+					.format(null != format ? format : UtcDateUtils.defaultFormat);
 			}
 		}
 

--- a/src/app/common/pipes/utc-date-pipe/utc-date.pipe.ts
+++ b/src/app/common/pipes/utc-date-pipe/utc-date.pipe.ts
@@ -6,7 +6,6 @@ import { UtcDateUtils } from './utc-date-utils.service';
 	name: 'utcDate'
 })
 export class UtcDatePipe implements PipeTransform {
-
 	transform(value: string | number, format?: string): string {
 		return UtcDateUtils.format(value, format);
 	}

--- a/src/app/common/search-input.module.ts
+++ b/src/app/common/search-input.module.ts
@@ -7,19 +7,11 @@ import { NgSelectModule } from '@ng-select/ng-select';
 import { SearchInputComponent } from './search-input/search-input.component';
 
 @NgModule({
-	imports: [
-		CommonModule,
-		FormsModule,
-		NgSelectModule
-	],
-	exports: [
-		SearchInputComponent
-	],
-	declarations: [
-		SearchInputComponent
-	],
+	imports: [CommonModule, FormsModule, NgSelectModule],
+	exports: [SearchInputComponent],
+	declarations: [SearchInputComponent],
 	providers: []
 })
-export class SearchInputModule { }
+export class SearchInputModule {}
 
-export  { SearchInputComponent } from './search-input/search-input.component';
+export { SearchInputComponent } from './search-input/search-input.component';

--- a/src/app/common/search-input/search-input.component.ts
+++ b/src/app/common/search-input/search-input.component.ts
@@ -6,14 +6,13 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 	styleUrls: ['./search-input.component.scss']
 })
 export class SearchInputComponent {
-
 	@Input() placeholder = 'Search...';
 	@Output() readonly applySearch: EventEmitter<string> = new EventEmitter();
 	@Input() search = '';
 
 	private keyupTimeout;
 
-	constructor() { }
+	constructor() {}
 
 	onKeyup() {
 		clearTimeout(this.keyupTimeout);

--- a/src/app/common/string-utils.service.spec.ts
+++ b/src/app/common/string-utils.service.spec.ts
@@ -1,7 +1,6 @@
 import { StringUtils } from './string-utils.service';
 
 describe('StringUtils', () => {
-
 	describe('isNonEmptyString', () => {
 		it('returns true if input is non-empty string', () => {
 			expect(StringUtils.isNonEmptyString('test-string')).toBe(true);
@@ -11,7 +10,7 @@ describe('StringUtils', () => {
 			expect(StringUtils.isNonEmptyString('')).toBe(false);
 		});
 
-		it ('returns false if input is not a string', () => {
+		it('returns false if input is not a string', () => {
 			expect(StringUtils.isNonEmptyString({})).toBe(false);
 		});
 	});
@@ -25,7 +24,7 @@ describe('StringUtils', () => {
 			expect(StringUtils.isInvalid('')).toBe(true);
 		});
 
-		it ('returns true if input is not a string', () => {
+		it('returns true if input is not a string', () => {
 			expect(StringUtils.isInvalid({})).toBe(true);
 		});
 	});
@@ -68,12 +67,19 @@ describe('StringUtils', () => {
 		});
 
 		it('returns Capitalized on hyphenated word sentence', () => {
-			expect(StringUtils.toTitleCase('hello, test-strings are cool!')).toBe('Hello, Test-strings Are Cool!');
+			expect(StringUtils.toTitleCase('hello, test-strings are cool!')).toBe(
+				'Hello, Test-strings Are Cool!'
+			);
 		});
 
 		it('returns Capitalized on hyphenated word multiple sentences', () => {
-			expect(StringUtils.toTitleCase('hello, test-strings are cool!  I really like how they are capitalized....a lot.')).toBe('Hello, Test-strings Are Cool!  I Really Like How They Are Capitalized....a Lot.');
+			expect(
+				StringUtils.toTitleCase(
+					'hello, test-strings are cool!  I really like how they are capitalized....a lot.'
+				)
+			).toBe(
+				'Hello, Test-strings Are Cool!  I Really Like How They Are Capitalized....a Lot.'
+			);
 		});
 	});
-
 });

--- a/src/app/common/string-utils.service.ts
+++ b/src/app/common/string-utils.service.ts
@@ -2,12 +2,11 @@ import { HttpParams } from '@angular/common/http';
 import isString from 'lodash/isString';
 
 export class StringUtils {
-
 	/**
 	 * Returns true if input is a string and it is not empty.
 	 */
 	public static isNonEmptyString(s: any): boolean {
-		return (isString(s) && s.trim().length > 0);
+		return isString(s) && s.trim().length > 0;
 	}
 
 	/**
@@ -29,7 +28,7 @@ export class StringUtils {
 		if (null == s) {
 			return null;
 		}
-		const result = s.replace( /([A-Z])/g, ' $1' );
+		const result = s.replace(/([A-Z])/g, ' $1');
 		return StringUtils.capitalize(result);
 	}
 
@@ -37,7 +36,7 @@ export class StringUtils {
 		if (null == s) {
 			return null;
 		}
-		const result = s.replace( /-/g, ' ' );
+		const result = s.replace(/-/g, ' ');
 		return StringUtils.toTitleCase(result);
 	}
 
@@ -45,7 +44,7 @@ export class StringUtils {
 		if (null == s) {
 			return null;
 		}
-		const result = s.replace( /_/g, ' ' );
+		const result = s.replace(/_/g, ' ');
 		return StringUtils.toTitleCase(result);
 	}
 
@@ -60,14 +59,17 @@ export class StringUtils {
 			return null;
 		}
 
-		return s.replace(/\b\w\S*/g, (txt) => {
+		return s.replace(/\b\w\S*/g, txt => {
 			return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
 		});
 	}
 
 	public static stripPunctuation(s: string) {
 		if (null != s) {
-			return s.replace(/[\-=_!"#%&'*{},.\/:;?\(\)\[\]@\\$\^*+<>~`\u00a1\u00a7\u00b6\u00b7\u00bf\u037e\u0387\u055a-\u055f\u0589\u05c0\u05c3\u05c6\u05f3\u05f4\u0609\u060a\u060c\u060d\u061b\u061e\u061f\u066a-\u066d\u06d4\u0700-\u070d\u07f7-\u07f9\u0830-\u083e\u085e\u0964\u0965\u0970\u0af0\u0df4\u0e4f\u0e5a\u0e5b\u0f04-\u0f12\u0f14\u0f85\u0fd0-\u0fd4\u0fd9\u0fda\u104a-\u104f\u10fb\u1360-\u1368\u166d\u166e\u16eb-\u16ed\u1735\u1736\u17d4-\u17d6\u17d8-\u17da\u1800-\u1805\u1807-\u180a\u1944\u1945\u1a1e\u1a1f\u1aa0-\u1aa6\u1aa8-\u1aad\u1b5a-\u1b60\u1bfc-\u1bff\u1c3b-\u1c3f\u1c7e\u1c7f\u1cc0-\u1cc7\u1cd3\u2016\u2017\u2020-\u2027\u2030-\u2038\u203b-\u203e\u2041-\u2043\u2047-\u2051\u2053\u2055-\u205e\u2cf9-\u2cfc\u2cfe\u2cff\u2d70\u2e00\u2e01\u2e06-\u2e08\u2e0b\u2e0e-\u2e16\u2e18\u2e19\u2e1b\u2e1e\u2e1f\u2e2a-\u2e2e\u2e30-\u2e39\u3001-\u3003\u303d\u30fb\ua4fe\ua4ff\ua60d-\ua60f\ua673\ua67e\ua6f2-\ua6f7\ua874-\ua877\ua8ce\ua8cf\ua8f8-\ua8fa\ua92e\ua92f\ua95f\ua9c1-\ua9cd\ua9de\ua9df\uaa5c-\uaa5f\uaade\uaadf\uaaf0\uaaf1\uabeb\ufe10-\ufe16\ufe19\ufe30\ufe45\ufe46\ufe49-\ufe4c\ufe50-\ufe52\ufe54-\ufe57\ufe5f-\ufe61\ufe68\ufe6a\ufe6b\uff01-\uff03\uff05-\uff07\uff0a\uff0c\uff0e\uff0f\uff1a\uff1b\uff1f\uff20\uff3c\uff61\uff64\uff65]+/gi, '');
+			return s.replace(
+				/[\-=_!"#%&'*{},.\/:;?\(\)\[\]@\\$\^*+<>~`\u00a1\u00a7\u00b6\u00b7\u00bf\u037e\u0387\u055a-\u055f\u0589\u05c0\u05c3\u05c6\u05f3\u05f4\u0609\u060a\u060c\u060d\u061b\u061e\u061f\u066a-\u066d\u06d4\u0700-\u070d\u07f7-\u07f9\u0830-\u083e\u085e\u0964\u0965\u0970\u0af0\u0df4\u0e4f\u0e5a\u0e5b\u0f04-\u0f12\u0f14\u0f85\u0fd0-\u0fd4\u0fd9\u0fda\u104a-\u104f\u10fb\u1360-\u1368\u166d\u166e\u16eb-\u16ed\u1735\u1736\u17d4-\u17d6\u17d8-\u17da\u1800-\u1805\u1807-\u180a\u1944\u1945\u1a1e\u1a1f\u1aa0-\u1aa6\u1aa8-\u1aad\u1b5a-\u1b60\u1bfc-\u1bff\u1c3b-\u1c3f\u1c7e\u1c7f\u1cc0-\u1cc7\u1cd3\u2016\u2017\u2020-\u2027\u2030-\u2038\u203b-\u203e\u2041-\u2043\u2047-\u2051\u2053\u2055-\u205e\u2cf9-\u2cfc\u2cfe\u2cff\u2d70\u2e00\u2e01\u2e06-\u2e08\u2e0b\u2e0e-\u2e16\u2e18\u2e19\u2e1b\u2e1e\u2e1f\u2e2a-\u2e2e\u2e30-\u2e39\u3001-\u3003\u303d\u30fb\ua4fe\ua4ff\ua60d-\ua60f\ua673\ua67e\ua6f2-\ua6f7\ua874-\ua877\ua8ce\ua8cf\ua8f8-\ua8fa\ua92e\ua92f\ua95f\ua9c1-\ua9cd\ua9de\ua9df\uaa5c-\uaa5f\uaade\uaadf\uaaf0\uaaf1\uabeb\ufe10-\ufe16\ufe19\ufe30\ufe45\ufe46\ufe49-\ufe4c\ufe50-\ufe52\ufe54-\ufe57\ufe5f-\ufe61\ufe68\ufe6a\ufe6b\uff01-\uff03\uff05-\uff07\uff0a\uff0c\uff0e\uff0f\uff1a\uff1b\uff1f\uff20\uff3c\uff61\uff64\uff65]+/gi,
+				''
+			);
 		}
 
 		return null;

--- a/src/app/common/system-alert.module.ts
+++ b/src/app/common/system-alert.module.ts
@@ -10,22 +10,10 @@ import { SystemAlertIconComponent } from './system-alert/system-alert-icon.compo
 import { SystemAlertService } from './system-alert/system-alert.service';
 
 @NgModule({
-	imports: [
-		CommonModule,
-		FormsModule,
-
-		AlertModule.forRoot()
-	],
-	exports: [
-		SystemAlertComponent
-	],
-	declarations: [
-		SystemAlertComponent,
-		SystemAlertIconComponent
-	],
-	providers: [
-		SystemAlertService
-	]
+	imports: [CommonModule, FormsModule, AlertModule.forRoot()],
+	exports: [SystemAlertComponent],
+	declarations: [SystemAlertComponent, SystemAlertIconComponent],
+	providers: [SystemAlertService]
 })
-export class SystemAlertModule { }
+export class SystemAlertModule {}
 export { SystemAlertService } from './system-alert/system-alert.service';

--- a/src/app/common/system-alert/system-alert.component.ts
+++ b/src/app/common/system-alert/system-alert.component.ts
@@ -5,7 +5,7 @@ import { SystemAlertService } from './system-alert.service';
 @Component({
 	selector: 'system-alert',
 	templateUrl: 'system-alert.component.html',
-	styleUrls: [ 'system-alert.component.scss' ]
+	styleUrls: ['system-alert.component.scss']
 })
 export class SystemAlertComponent {
 	constructor(public alertService: SystemAlertService) {}

--- a/src/app/common/system-alert/system-alert.model.ts
+++ b/src/app/common/system-alert/system-alert.model.ts
@@ -3,5 +3,6 @@ export class SystemAlert {
 		public id: number,
 		public type: string,
 		public msg: string,
-		public subtext: string) {}
+		public subtext: string
+	) {}
 }

--- a/src/app/common/system-alert/system-alert.service.spec.ts
+++ b/src/app/common/system-alert/system-alert.service.spec.ts
@@ -2,10 +2,11 @@ import { SystemAlertService } from './system-alert.service';
 import { HttpErrorResponse } from '@angular/common/http';
 
 describe('SystemAlertService', () => {
-
 	let service: SystemAlertService;
 
-	const testAlertMsgs: string[] = Array(5).fill(0).map((v, i) => `test alert ${i}`);
+	const testAlertMsgs: string[] = Array(5)
+		.fill(0)
+		.map((v, i) => `test alert ${i}`);
 
 	beforeEach(() => {
 		service = new SystemAlertService();
@@ -36,7 +37,7 @@ describe('SystemAlertService', () => {
 	describe('clearAlertById', () => {
 		it('clears single alert by Id', () => {
 			const idToClear = 3;
-			const clearedAlertMsg = service.getAlerts().find((alert) => alert.id === idToClear).msg;
+			const clearedAlertMsg = service.getAlerts().find(alert => alert.id === idToClear).msg;
 			service.clearAlertById(idToClear);
 			const alerts = service.getAlerts();
 			expect(alerts.length).toBe(4);
@@ -94,24 +95,28 @@ describe('SystemAlertService', () => {
 	describe('addClientErrorAlert', () => {
 		it('alert is created from client error', () => {
 			const newAlertMsg = 'client error';
-			service.addClientErrorAlert(new HttpErrorResponse({
-				status: 400,
-				error: {
-					message: newAlertMsg
-				}
-			}));
+			service.addClientErrorAlert(
+				new HttpErrorResponse({
+					status: 400,
+					error: {
+						message: newAlertMsg
+					}
+				})
+			);
 			const alerts = service.getAlerts();
 			expect(alerts.length).toBe(6);
 			expect(alerts[alerts.length - 1].msg).toBe(newAlertMsg);
 		});
 
 		it('no alert is created for non-client error', () => {
-			service.addClientErrorAlert(new HttpErrorResponse({
-				status: 500,
-				error: {
-					message: 'not client error'
-				}
-			}));
+			service.addClientErrorAlert(
+				new HttpErrorResponse({
+					status: 500,
+					error: {
+						message: 'not client error'
+					}
+				})
+			);
 			const alerts = service.getAlerts();
 			expect(alerts.length).toBe(5);
 		});
@@ -126,6 +131,4 @@ describe('SystemAlertService', () => {
 			}
 		});
 	});
-
 });
-

--- a/src/app/common/system-alert/system-alert.service.ts
+++ b/src/app/common/system-alert/system-alert.service.ts
@@ -24,17 +24,13 @@ export class SystemAlertService {
 	}
 
 	clearAlertById(id: number) {
-		const index = this.alerts.findIndex((value) => value.id === id);
+		const index = this.alerts.findIndex(value => value.id === id);
 		this.clear(index);
 	}
 
 	addAlert(msg: string, type?: string, ttl?: number, subtext?: string) {
 		type = type || this.defaultType;
-		const alert = new SystemAlert(
-			this.id++,
-			type || this.defaultType,
-			msg,
-			subtext || null);
+		const alert = new SystemAlert(this.id++, type || this.defaultType, msg, subtext || null);
 
 		this.alerts.push(alert);
 

--- a/src/app/core/about.component.ts
+++ b/src/app/core/about.component.ts
@@ -10,24 +10,19 @@ import { Config } from './config.model';
 		<div class="container">
 			<div class="row">
 				<div class="col-md-8 offset-2 jumbotron" style="margin-top: 4rem;">
-
-					<h1>{{appTitle}}</h1>
-					<p>v{{version}}</p>
-
+					<h1>{{ appTitle }}</h1>
+					<p>v{{ version }}</p>
 				</div>
 			</div>
 		</div>
 	`,
-	styles: [ '' ]
+	styles: ['']
 })
 export class AboutComponent implements OnInit {
-
 	appTitle: string = undefined;
 	version: string = undefined;
 
-	constructor(
-		private configService: ConfigService
-	) {}
+	constructor(private configService: ConfigService) {}
 
 	ngOnInit() {
 		this.configService.getConfig().subscribe((config: Config) => {
@@ -35,5 +30,4 @@ export class AboutComponent implements OnInit {
 			this.version = config.version;
 		});
 	}
-
 }

--- a/src/app/core/access.component.ts
+++ b/src/app/core/access.component.ts
@@ -6,25 +6,19 @@ import { Router } from '@angular/router';
 		<div class="container">
 			<div class="row">
 				<div class="col-md-8 offset-2 jumbotron" style="margin-top: 4rem;">
-
-					<h1>{{status}}</h1>
-					<p>{{message}}</p>
-
+					<h1>{{ status }}</h1>
+					<p>{{ message }}</p>
 				</div>
 			</div>
 		</div>
 	`,
-	styles: [ '' ]
+	styles: ['']
 })
 export class AccessComponent {
-
 	status: string;
 	message: string;
 
-
-	constructor(
-		private router: Router
-	) {
+	constructor(private router: Router) {
 		const navigation = this.router.getCurrentNavigation();
 		const state = navigation.extras.state;
 

--- a/src/app/core/admin/admin-routing.module.ts
+++ b/src/app/core/admin/admin-routing.module.ts
@@ -4,7 +4,11 @@ import { RouterModule } from '@angular/router';
 import { AdminCreateUserComponent } from './user-management/admin-create-user.component';
 import { AdminListUsersComponent } from './user-management/admin-list-users.component';
 import { AdminUpdateUserComponent } from './user-management/admin-edit-user.component';
-import { AdminCreateEuaComponent, AdminListEuasComponent, AdminUpdateEuaComponent } from './end-user-agreement/admin-eua.module';
+import {
+	AdminCreateEuaComponent,
+	AdminListEuasComponent,
+	AdminUpdateEuaComponent
+} from './end-user-agreement/admin-eua.module';
 import { CacheEntriesComponent } from './cache-entries/cache-entries.module';
 import { AdminComponent } from './admin.component';
 import { AuthGuard } from '../auth/auth.guard';
@@ -16,7 +20,7 @@ import { AuthGuard } from '../auth/auth.guard';
 				path: 'admin',
 				component: AdminComponent,
 				canActivate: [AuthGuard],
-				data: { roles: [ 'admin' ] },
+				data: { roles: ['admin'] },
 				children: [
 					/**
 					 * Default Route
@@ -67,10 +71,9 @@ import { AuthGuard } from '../auth/auth.guard';
 						component: CacheEntriesComponent
 					}
 				]
-			}])
+			}
+		])
 	],
-	exports: [
-		RouterModule
-	]
+	exports: [RouterModule]
 })
-export class AdminRoutingModule { }
+export class AdminRoutingModule {}

--- a/src/app/core/admin/admin-topic.model.spec.ts
+++ b/src/app/core/admin/admin-topic.model.spec.ts
@@ -1,9 +1,7 @@
 import { AdminTopics } from './admin-topic.model';
 
 describe('AdminTopics', () => {
-
 	describe('registerTopic', () => {
-
 		const specFirst = { id: '1', ordinal: 1, title: 'Test', path: 'test' };
 		const specUpdate = { id: '1', ordinal: 5, title: 'Update', path: 'new-test' };
 		const specSecond = { id: '2', ordinal: 0, title: 'Second', path: 'second' };
@@ -18,7 +16,7 @@ describe('AdminTopics', () => {
 		});
 
 		afterAll(() => {
-			existingTopics.forEach((topic) => {
+			existingTopics.forEach(topic => {
 				AdminTopics.registerTopic(topic);
 			});
 		});
@@ -32,30 +30,30 @@ describe('AdminTopics', () => {
 		});
 		it('can find registered topic', () => {
 			const topics = AdminTopics.getTopics();
-			expect(topics).toEqual([ specFirst ]);
+			expect(topics).toEqual([specFirst]);
 		});
 		it('can re-register the same topic id', () => {
 			AdminTopics.registerTopic(specUpdate);
 			const topics = AdminTopics.getTopics();
-			expect(topics).toEqual([ specUpdate ]);
+			expect(topics).toEqual([specUpdate]);
 		});
 
 		it('can register a new topic', () => {
 			AdminTopics.registerTopic(specSecond);
 			const topics = AdminTopics.getTopics();
-			expect(topics).toEqual([ specSecond, specUpdate ]);
+			expect(topics).toEqual([specSecond, specUpdate]);
 		});
 
 		it('can register a new topic with the same ordinal and sort by title', () => {
 			AdminTopics.registerTopic(specThird);
 			const topics = AdminTopics.getTopics();
-			expect(topics).toEqual([ specSecond, specThird, specUpdate ]);
+			expect(topics).toEqual([specSecond, specThird, specUpdate]);
 		});
 
 		it('can register without an ordinal to use default of 1', () => {
 			AdminTopics.registerTopic(specNoOrdinal);
 			const topics = AdminTopics.getTopics();
-			expect(topics).toEqual([ specSecond, specThird, specNoOrdinal, specUpdate ]);
+			expect(topics).toEqual([specSecond, specThird, specNoOrdinal, specUpdate]);
 		});
 
 		it('can clear topics', () => {
@@ -63,5 +61,4 @@ describe('AdminTopics', () => {
 			expect(AdminTopics.getTopics()).toEqual([]);
 		});
 	});
-
 });

--- a/src/app/core/admin/admin-topic.model.ts
+++ b/src/app/core/admin/admin-topic.model.ts
@@ -27,5 +27,4 @@ export class AdminTopics {
 		const topics = values(this.topics);
 		return sortBy(topics, ['ordinal', 'title', 'path']);
 	}
-
 }

--- a/src/app/core/admin/admin.component.ts
+++ b/src/app/core/admin/admin.component.ts
@@ -3,7 +3,7 @@ import { AdminTopic, AdminTopics } from './admin-topic.model';
 
 @Component({
 	templateUrl: 'admin.component.html',
-	styleUrls: [ 'admin.component.scss' ]
+	styleUrls: ['admin.component.scss']
 })
 export class AdminComponent {
 	helpTopics: AdminTopic[] = [];

--- a/src/app/core/admin/admin.module.ts
+++ b/src/app/core/admin/admin.module.ts
@@ -26,14 +26,9 @@ import { AdminTopics } from './admin-topic.model';
 		PagingModule
 	],
 	exports: [],
-	declarations:   [
-		AdminComponent,
-	],
-	providers:  [
-		AdminTopics,
-		AuthGuard
-	]
+	declarations: [AdminComponent],
+	providers: [AdminTopics, AuthGuard]
 })
-export class AdminModule { }
+export class AdminModule {}
 export { AdminTopic, AdminTopics } from './admin-topic.model';
 export { AdminComponent } from './admin.component';

--- a/src/app/core/admin/cache-entries/cache-entries.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.component.ts
@@ -11,7 +11,8 @@ import {
 	PagingResults,
 	SortDirection,
 	SortableTableHeader,
-	AbstractPageableDataComponent, SortChange
+	AbstractPageableDataComponent,
+	SortChange
 } from '../../../common/paging.module';
 import { SystemAlertService } from '../../../common/system-alert.module';
 
@@ -25,12 +26,25 @@ import { Observable } from 'rxjs';
 	selector: 'cache-entries',
 	templateUrl: './cache-entries.component.html'
 })
-export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEntry> implements OnInit {
-
+export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEntry>
+	implements OnInit {
 	headers: SortableTableHeader[] = [
-		{ name: 'Key', sortable: true, sortField: 'key', sortDir: SortDirection.asc, tooltip: 'Sort by Key', default: true },
+		{
+			name: 'Key',
+			sortable: true,
+			sortField: 'key',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Key',
+			default: true
+		},
 		{ name: 'Value', sortable: false },
-		{ name: 'Timestamp', sortable: true, sortField: 'ts', sortDir: SortDirection.desc, tooltip: 'Sort by Timestamp' }
+		{
+			name: 'Timestamp',
+			sortable: true,
+			sortField: 'ts',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Timestamp'
+		}
 	];
 
 	constructor(
@@ -38,7 +52,9 @@ export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEn
 		private modalService: ModalService,
 		private bsModalService: BsModalService,
 		private alertService: SystemAlertService
-	) { super(); }
+	) {
+		super();
+	}
 
 	ngOnInit() {
 		this.alertService.clearAllAlerts();
@@ -48,13 +64,21 @@ export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEn
 		super.ngOnInit();
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<CacheEntry>> {
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<CacheEntry>> {
 		return this.cacheEntriesService.match(query, search, pagingOptions);
 	}
 
 	confirmDeleteEntry(cacheEntry: CacheEntry) {
 		this.modalService
-			.confirm('Delete cache entry?', `Are you sure you want to delete entry: ${cacheEntry.key}?`, 'Delete')
+			.confirm(
+				'Delete cache entry?',
+				`Are you sure you want to delete entry: ${cacheEntry.key}?`,
+				'Delete'
+			)
 			.pipe(
 				first(),
 				filter((action: ModalAction) => action === ModalAction.OK),
@@ -62,16 +86,22 @@ export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEn
 					return this.cacheEntriesService.remove(cacheEntry.key);
 				})
 			)
-			.subscribe(() => {
-				this.alertService.addAlert(`Deleted cache entry: ${cacheEntry.key}`, 'success');
-				this.load$.next(true);
-			}, (response: HttpErrorResponse) => {
-				this.alertService.addAlert(response.error.message);
-			});
+			.subscribe(
+				() => {
+					this.alertService.addAlert(`Deleted cache entry: ${cacheEntry.key}`, 'success');
+					this.load$.next(true);
+				},
+				(response: HttpErrorResponse) => {
+					this.alertService.addAlert(response.error.message);
+				}
+			);
 	}
 
 	viewCacheEntry(cacheEntry: CacheEntry) {
-		const cacheEntryModalRef = this.bsModalService.show(CacheEntryModalComponent, { ignoreBackdropClick: true, class: 'modal-lg' });
+		const cacheEntryModalRef = this.bsModalService.show(CacheEntryModalComponent, {
+			ignoreBackdropClick: true,
+			class: 'modal-lg'
+		});
 		cacheEntryModalRef.content.cacheEntry = cacheEntry;
 	}
 
@@ -84,7 +114,8 @@ export class CacheEntriesComponent extends AbstractPageableDataComponent<CacheEn
 				this.alertService.addAlert(`Refreshed cache entry: ${cacheEntry.key}`, 'success');
 				cacheEntry.isRefreshing = false;
 				this.load$.next(true);
-			}, (response: HttpErrorResponse) => {
+			},
+			(response: HttpErrorResponse) => {
 				this.alertService.addAlert(response.error.message);
 				cacheEntry.isRefreshing = false;
 			}

--- a/src/app/core/admin/cache-entries/cache-entries.module.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.module.ts
@@ -29,20 +29,11 @@ import { SearchInputModule } from '../../../common/search-input.module';
 		SearchInputModule,
 		TooltipModule
 	],
-	entryComponents: [
-		CacheEntryModalComponent
-	],
-	declarations: [
-		CacheEntriesComponent,
-		CacheEntryModalComponent
-	],
-	exports: [
-		CacheEntriesComponent
-	],
-	providers: [
-		CacheEntriesService
-	]
+	entryComponents: [CacheEntryModalComponent],
+	declarations: [CacheEntriesComponent, CacheEntryModalComponent],
+	exports: [CacheEntriesComponent],
+	providers: [CacheEntriesService]
 })
-export class CacheEntriesModule { }
+export class CacheEntriesModule {}
 
 export { CacheEntriesComponent } from './cache-entries.component';

--- a/src/app/core/admin/cache-entries/cache-entries.service.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.service.ts
@@ -11,35 +11,37 @@ import { SystemAlertService } from '../../../common/system-alert/system-alert.se
 
 @Injectable()
 export class CacheEntriesService {
+	constructor(private http: HttpClient, private alertService: SystemAlertService) {}
 
-	constructor(
-		private http: HttpClient,
-		private alertService: SystemAlertService
-	) {}
-
-	public match(query: any, search: string, paging: PagingOptions): Observable<PagingResults<CacheEntry>> {
-		return this.http.post<PagingResults<CacheEntry>>(
-			'api/access-checker/entries/match',
-			{ s: search, q: query },
-			{ params: paging.toObj() }
-		).pipe(
-			catchError((error) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(NULL_PAGING_RESULTS);
-			})
-		);
+	public match(
+		query: any,
+		search: string,
+		paging: PagingOptions
+	): Observable<PagingResults<CacheEntry>> {
+		return this.http
+			.post<PagingResults<CacheEntry>>(
+				'api/access-checker/entries/match',
+				{ s: search, q: query },
+				{ params: paging.toObj() }
+			)
+			.pipe(
+				catchError(error => {
+					this.alertService.addClientErrorAlert(error);
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 
 	public remove(key: string): Observable<any> {
 		return this.http.delete(
-			`api/access-checker/entry/${ encodeURIComponent(key) }`,
+			`api/access-checker/entry/${encodeURIComponent(key)}`,
 			{ params: { key } } // query parameter 'key'
 		);
 	}
 
 	public refresh(key: string): Observable<any> {
 		return this.http.post(
-			`api/access-checker/entry/${ encodeURIComponent(key) }`,
+			`api/access-checker/entry/${encodeURIComponent(key)}`,
 			{}, // empty POST body
 			{ params: { key } } // query parameter 'key'
 		);
@@ -51,5 +53,4 @@ export class CacheEntriesService {
 			{} // empty POST body
 		);
 	}
-
 }

--- a/src/app/core/admin/cache-entries/cache-entry-modal.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entry-modal.component.ts
@@ -8,10 +8,7 @@ import { CacheEntry } from './cache-entry.model';
 	templateUrl: 'cache-entry-modal.component.html'
 })
 export class CacheEntryModalComponent {
-
 	cacheEntry: CacheEntry;
 
-	constructor(
-		public modalRef: BsModalRef
-	) {}
+	constructor(public modalRef: BsModalRef) {}
 }

--- a/src/app/core/admin/cache-entries/cache-entry.model.ts
+++ b/src/app/core/admin/cache-entries/cache-entry.model.ts
@@ -2,11 +2,7 @@ export class CacheEntry {
 	isRefreshing = false;
 	date: Date;
 
-	constructor(
-		public key: string,
-		public value: any,
-		public ts: number
-	) {
+	constructor(public key: string, public value: any, public ts: number) {
 		this.date = new Date(ts);
 	}
 }

--- a/src/app/core/admin/end-user-agreement/admin-create-eua.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-create-eua.component.ts
@@ -11,12 +11,10 @@ import { ModalService } from '../../../common/modal.module';
 	templateUrl: './manage-eua.component.html'
 })
 export class AdminCreateEuaComponent extends ManageEuaComponent implements OnInit {
-
 	constructor(
 		router: Router,
 		public modalService: ModalService,
 		protected euaService: EuaService
-
 	) {
 		super(router, modalService);
 	}
@@ -34,6 +32,8 @@ export class AdminCreateEuaComponent extends ManageEuaComponent implements OnIni
 			title: this.eua.euaModel.title,
 			text: this.eua.euaModel.text
 		};
-		this.euaService.create(_eua).subscribe(() => this.router.navigate(['/admin/euas', {clearCachedFilter: true}]));
+		this.euaService
+			.create(_eua)
+			.subscribe(() => this.router.navigate(['/admin/euas', { clearCachedFilter: true }]));
 	}
 }

--- a/src/app/core/admin/end-user-agreement/admin-edit-eua.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-edit-eua.component.ts
@@ -11,7 +11,6 @@ import { ModalService } from '../../../common/modal.module';
 	templateUrl: './manage-eua.component.html'
 })
 export class AdminUpdateEuaComponent extends ManageEuaComponent implements OnInit {
-
 	constructor(
 		router: Router,
 		public modalService: ModalService,
@@ -23,7 +22,7 @@ export class AdminUpdateEuaComponent extends ManageEuaComponent implements OnIni
 
 	ngOnInit() {
 		this.title = 'Edit EUA';
-		this.subtitle = 'Make changes to the eua\'s information';
+		this.subtitle = "Make changes to the eua's information";
 		this.submitText = 'Save';
 
 		this.route.params.subscribe((params: Params) => {
@@ -42,6 +41,8 @@ export class AdminUpdateEuaComponent extends ManageEuaComponent implements OnIni
 			text: this.eua.euaModel.text,
 			published: this.eua.euaModel.published
 		};
-		this.euaService.update(_eua).subscribe(() => this.router.navigate(['/admin/euas', {clearCachedFilter: true}]));
+		this.euaService
+			.update(_eua)
+			.subscribe(() => this.router.navigate(['/admin/euas', { clearCachedFilter: true }]));
 	}
 }

--- a/src/app/core/admin/end-user-agreement/admin-eua.module.ts
+++ b/src/app/core/admin/end-user-agreement/admin-eua.module.ts
@@ -31,22 +31,12 @@ import { SearchInputModule } from '../../../common/search-input.module';
 		SystemAlertModule,
 		SearchInputModule
 	],
-	exports: [
-	],
-	entryComponents: [
-	],
-	declarations:   [
-		AdminListEuasComponent,
-		AdminCreateEuaComponent,
-		AdminUpdateEuaComponent
-	],
-	providers:  [
-		AdminUsersService,
-		EuaService,
-		ModalService
-	]
+	exports: [],
+	entryComponents: [],
+	declarations: [AdminListEuasComponent, AdminCreateEuaComponent, AdminUpdateEuaComponent],
+	providers: [AdminUsersService, EuaService, ModalService]
 })
-export class AdminEuaModule { }
+export class AdminEuaModule {}
 
 export { AdminListEuasComponent } from './admin-list-euas.component';
 export { AdminCreateEuaComponent } from './admin-create-eua.component';

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
@@ -25,8 +25,8 @@ import { AdminTopics } from '../admin-topic.model';
 @Component({
 	templateUrl: './admin-list-euas.component.html'
 })
-export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUserAgreement> implements OnDestroy, OnInit {
-
+export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUserAgreement>
+	implements OnDestroy, OnInit {
 	// Columns to show/hide in user table
 	columns = {
 		_id: { show: false, display: 'ID' },
@@ -41,11 +41,36 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 
 	headers: SortableTableHeader[] = [
 		{ name: 'ID', sortable: false, sortField: '_id' },
-		{ name: 'Title', sortable: true, sortField: 'title', sortDir: SortDirection.asc, tooltip: 'Sort by Title', default: true },
+		{
+			name: 'Title',
+			sortable: true,
+			sortField: 'title',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Title',
+			default: true
+		},
 		{ name: 'Text', sortable: false, sortField: 'text' },
-		{ name: 'Created', sortable: true, sortField: 'created', sortDir: SortDirection.desc, tooltip: 'Sort by Create Date' },
-		{ name: 'Published', sortable: true, sortField: 'published', sortDir: SortDirection.desc, tooltip: 'Sort by Publish Date' },
-		{ name: 'Updated', sortable: true, sortField: 'updated', sortDir: SortDirection.asc, tooltip: 'Sort by Title' }
+		{
+			name: 'Created',
+			sortable: true,
+			sortField: 'created',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Create Date'
+		},
+		{
+			name: 'Published',
+			sortable: true,
+			sortField: 'published',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Publish Date'
+		},
+		{
+			name: 'Updated',
+			sortable: true,
+			sortField: 'updated',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Title'
+		}
 	];
 
 	headersToShow: SortableTableHeader[] = [];
@@ -57,20 +82,25 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 		private euaService: EuaService,
 		private route: ActivatedRoute,
 		private alertService: SystemAlertService
-	) { super(); }
+	) {
+		super();
+	}
 
 	ngOnInit() {
 		this.alertService.clearAllAlerts();
-		this.route.params
-			.pipe(
-				takeUntil(this.destroy$)
-			).subscribe( (params: Params) => {
-				if (toString(params[`clearCachedFilter`]) === 'true' || null == this.euaService.cache.listEuas) {
-					this.euaService.cache.listEuas = {};
-				}
-			});
+		this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params: Params) => {
+			if (
+				toString(params[`clearCachedFilter`]) === 'true' ||
+				null == this.euaService.cache.listEuas
+			) {
+				this.euaService.cache.listEuas = {};
+			}
+		});
 
-		this.headersToShow = this.headers.filter((header: SortableTableHeader) => this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show);
+		this.headersToShow = this.headers.filter(
+			(header: SortableTableHeader) =>
+				this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show
+		);
 
 		this.initializeFromCache();
 
@@ -84,7 +114,10 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 
 	columnsUpdated(updatedColumns: any) {
 		this.columns = cloneDeep(updatedColumns);
-		this.headersToShow = this.headers.filter((header: SortableTableHeader) => this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show);
+		this.headersToShow = this.headers.filter(
+			(header: SortableTableHeader) =>
+				this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show
+		);
 	}
 
 	confirmDeleteEua(eua: EndUserAgreement) {
@@ -92,22 +125,29 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 		const title = eua.euaModel.title;
 
 		this.modalService
-			.confirm('Delete End User Agreement?', `Are you sure you want to delete eua: "${eua.euaModel.title}" ?`, 'Delete')
+			.confirm(
+				'Delete End User Agreement?',
+				`Are you sure you want to delete eua: "${eua.euaModel.title}" ?`,
+				'Delete'
+			)
 			.pipe(
 				first(),
 				filter((action: ModalAction) => action === ModalAction.OK),
 				switchMap(() => {
 					return this.euaService.remove(id);
 				})
-			).subscribe(() => {
-				this.alertService.addAlert(`Deleted EUA entitled: ${title}`, 'success');
-				this.load$.next(true);
-			},
-			(response: HttpErrorResponse) => {
-				if (response.status >= 400 && response.status < 500) {
-					this.alertService.addAlert(response.error.message);
+			)
+			.subscribe(
+				() => {
+					this.alertService.addAlert(`Deleted EUA entitled: ${title}`, 'success');
+					this.load$.next(true);
+				},
+				(response: HttpErrorResponse) => {
+					if (response.status >= 400 && response.status < 500) {
+						this.alertService.addAlert(response.error.message);
+					}
 				}
-			});
+			);
 	}
 
 	publishEua(eua: EndUserAgreement) {
@@ -120,7 +160,8 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 				if (response.status >= 400 && response.status < 500) {
 					this.alertService.addAlert(response.error.message);
 				}
-			});
+			}
+		);
 		this.load$.next(true);
 	}
 
@@ -138,8 +179,12 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 		}
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<EndUserAgreement>> {
-		this.euaService.cache.listEuas = {search, paging: pagingOptions};
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<EndUserAgreement>> {
+		this.euaService.cache.listEuas = { search, paging: pagingOptions };
 
 		return this.euaService.search(query, search, pagingOptions, {});
 	}

--- a/src/app/core/admin/end-user-agreement/eua.model.ts
+++ b/src/app/core/admin/end-user-agreement/eua.model.ts
@@ -1,14 +1,12 @@
 export class EndUserAgreement {
-
 	constructor(
 		public euaModel: any = {
 			title: '',
-			text: '',
+			text: ''
 		}
 	) {}
 
 	public setFromEuaModel(euaModel: any): EndUserAgreement {
-
 		if (null == euaModel || null == euaModel.title) {
 			euaModel = null;
 		}

--- a/src/app/core/admin/end-user-agreement/eua.service.ts
+++ b/src/app/core/admin/end-user-agreement/eua.service.ts
@@ -14,13 +14,9 @@ import { User } from '../../auth/user.model';
  * Admin management of users
  */
 export class EuaService {
-
 	public cache: any = {};
 
-	constructor(
-		private http: HttpClient,
-		private alertService: SystemAlertService
-	) {}
+	constructor(private http: HttpClient, private alertService: SystemAlertService) {}
 
 	/**
 	 * Public methods to be exposed through the service
@@ -37,23 +33,28 @@ export class EuaService {
 	}
 
 	// Search Euas
-	search(query: any, search: string, paging: PagingOptions, options: any): Observable<PagingResults<EndUserAgreement>> {
-		return this.http.post(
-			'api/euas',
-			{q: query, s: search, options},
-			{ params: paging.toObj() }
-		).pipe(
-			map((results: PagingResults) => {
-				if (null != results && Array.isArray(results.elements)) {
-					results.elements = results.elements.map((element: any) => new EndUserAgreement().setFromEuaModel(element));
-				}
-				return results;
-			}),
-			catchError((error) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(NULL_PAGING_RESULTS);
-			})
-		);
+	search(
+		query: any,
+		search: string,
+		paging: PagingOptions,
+		options: any
+	): Observable<PagingResults<EndUserAgreement>> {
+		return this.http
+			.post('api/euas', { q: query, s: search, options }, { params: paging.toObj() })
+			.pipe(
+				map((results: PagingResults) => {
+					if (null != results && Array.isArray(results.elements)) {
+						results.elements = results.elements.map((element: any) =>
+							new EndUserAgreement().setFromEuaModel(element)
+						);
+					}
+					return results;
+				}),
+				catchError(error => {
+					this.alertService.addClientErrorAlert(error);
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 
 	// Update
@@ -69,5 +70,4 @@ export class EuaService {
 	publish(id: string): Observable<any> {
 		return this.http.post(`api/eua/${id}/publish`, {});
 	}
-
 }

--- a/src/app/core/admin/end-user-agreement/manage-eua.component.ts
+++ b/src/app/core/admin/end-user-agreement/manage-eua.component.ts
@@ -14,10 +14,7 @@ export abstract class ManageEuaComponent {
 	subtitle: string;
 	submitText: string;
 
-	protected constructor(
-		public router: Router,
-		public modalService: ModalService
-	) {
+	protected constructor(public router: Router, public modalService: ModalService) {
 		this.eua = new EndUserAgreement();
 	}
 

--- a/src/app/core/admin/user-management/admin-create-user.component.ts
+++ b/src/app/core/admin/user-management/admin-create-user.component.ts
@@ -14,7 +14,6 @@ import { User } from '../../auth/user.model';
 	templateUrl: 'manage-user.component.html'
 })
 export class AdminCreateUserComponent extends ManageUserComponent {
-
 	mode = 'admin-create';
 
 	constructor(
@@ -42,5 +41,4 @@ export class AdminCreateUserComponent extends ManageUserComponent {
 	submitUser(user: User): Observable<any> {
 		return this.adminUsersService.create(user);
 	}
-
 }

--- a/src/app/core/admin/user-management/admin-edit-user.component.ts
+++ b/src/app/core/admin/user-management/admin-edit-user.component.ts
@@ -14,7 +14,6 @@ import { SystemAlertService } from '../../../common/system-alert.module';
 	templateUrl: './manage-user.component.html'
 })
 export class AdminUpdateUserComponent extends ManageUserComponent implements OnDestroy {
-
 	private mode = 'admin-edit';
 
 	private id: string;
@@ -32,11 +31,11 @@ export class AdminUpdateUserComponent extends ManageUserComponent implements OnD
 	}
 
 	initialize() {
-		this.sub = this.route.params.subscribe( (params: any) => {
+		this.sub = this.route.params.subscribe((params: any) => {
 			this.id = params.id;
 
 			this.title = 'Edit User';
-			this.subtitle = 'Make changes to the user\'s information';
+			this.subtitle = "Make changes to the user's information";
 			this.okButtonText = 'Save';
 			this.navigateOnSuccess = '/admin/users';
 			this.okDisabled = false;
@@ -45,13 +44,21 @@ export class AdminUpdateUserComponent extends ManageUserComponent implements OnD
 				if (null == this.user.userModel.roles) {
 					this.user.userModel.roles = {};
 				}
-				this.user.userModel.externalRolesDisplay = this.user.userModel.externalRoles.join('\n');
-				this.user.userModel.externalGroupsDisplay = this.user.userModel.externalGroups.join('\n');
-				this.user.userModel.providerData = { dn: (null != this.user.userModel.providerData) ? this.user.userModel.providerData.dn : undefined };
+				this.user.userModel.externalRolesDisplay = this.user.userModel.externalRoles.join(
+					'\n'
+				);
+				this.user.userModel.externalGroupsDisplay = this.user.userModel.externalGroups.join(
+					'\n'
+				);
+				this.user.userModel.providerData = {
+					dn:
+						null != this.user.userModel.providerData
+							? this.user.userModel.providerData.dn
+							: undefined
+				};
 				this.metadataLocked = this.proxyPki && !this.user.userModel.bypassAccessCheck;
 			});
 		});
-
 	}
 
 	ngOnDestroy() {
@@ -65,5 +72,4 @@ export class AdminUpdateUserComponent extends ManageUserComponent implements OnD
 	submitUser(user: User): Observable<any> {
 		return this.adminUsersService.update(user);
 	}
-
 }

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -12,7 +12,8 @@ import {
 	PagingResults,
 	SortDirection,
 	SortableTableHeader,
-	AbstractPageableDataComponent, SortChange
+	AbstractPageableDataComponent,
+	SortChange
 } from '../../../common/paging.module';
 import { SystemAlertService } from '../../../common/system-alert.module';
 
@@ -25,8 +26,8 @@ import { AdminTopics } from '../admin-topic.model';
 @Component({
 	templateUrl: './admin-list-users.component.html'
 })
-export class AdminListUsersComponent extends AbstractPageableDataComponent<User> implements OnDestroy, OnInit {
-
+export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
+	implements OnDestroy, OnInit {
 	// Columns to show/hide in user table
 	columns: any = {
 		name: { show: true, display: 'Name' },
@@ -49,16 +50,41 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 	defaultColumns: any = JSON.parse(JSON.stringify(this.columns));
 
 	headers: SortableTableHeader[] = [
-		{ name: 'Name', sortable: true, sortField: 'name', sortDir: SortDirection.asc, tooltip: 'Sort by Name' },
-		{ name: 'Username', sortable: true, sortField: 'username', sortDir: SortDirection.asc, tooltip: 'Sort by Username' },
-		{ name: 'ID', sortable: false, sortField: '_id'},
+		{
+			name: 'Name',
+			sortable: true,
+			sortField: 'name',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Name'
+		},
+		{
+			name: 'Username',
+			sortable: true,
+			sortField: 'username',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Username'
+		},
+		{ name: 'ID', sortable: false, sortField: '_id' },
 		// { name: 'Teams', sortable: false },
 		{ name: 'Organization', sortable: false, sortField: 'organization' },
 		{ name: 'Email', sortable: false, sortField: 'email' },
 		{ name: 'Phone', sortable: false, sortField: 'phone' },
 		{ name: 'EUA', sortable: false, sortField: 'acceptedEua' },
-		{ name: 'Last Login', sortable: true, sortField: 'lastLogin', sortDir: SortDirection.desc, tooltip: 'Sort by Last Login', default: true },
-		{ name: 'Created', sortable: true, sortField: 'created', sortDir: SortDirection.desc, tooltip: 'Sort by Create Date' },
+		{
+			name: 'Last Login',
+			sortable: true,
+			sortField: 'lastLogin',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Last Login',
+			default: true
+		},
+		{
+			name: 'Created',
+			sortable: true,
+			sortField: 'created',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Create Date'
+		},
 		{ name: 'Updated', sortable: false, sortField: 'updated' },
 		// { name: 'Bypass AC', sortable: false, sortField: 'bypassAccessCheck' },
 		{ name: 'External Roles', sortable: false, sortField: 'externalRoles' },
@@ -81,38 +107,49 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 		private configService: ConfigService,
 		private adminUsersService: AdminUsersService,
 		private alertService: SystemAlertService
-	) { super(); }
+	) {
+		super();
+	}
 
 	ngOnInit() {
-		this.route.params
-			.pipe(
-				takeUntil(this.destroy$)
-			).subscribe((params: Params) => {
-				// Clear any alerts
-				this.alertService.clearAllAlerts();
+		this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params: Params) => {
+			// Clear any alerts
+			this.alertService.clearAllAlerts();
 
-				// Clear cache if requested
-				const clearCachedFilter = params[`clearCachedFilter`];
-				if (toString(clearCachedFilter) === 'true' || null == this.adminUsersService.cache.listUsers) {
-					this.adminUsersService.cache.listUsers = {};
-				}
-			});
+			// Clear cache if requested
+			const clearCachedFilter = params[`clearCachedFilter`];
+			if (
+				toString(clearCachedFilter) === 'true' ||
+				null == this.adminUsersService.cache.listUsers
+			) {
+				this.adminUsersService.cache.listUsers = {};
+			}
+		});
 
-		this.configService.getConfig()
-			.pipe(
-				first(),
-				takeUntil(this.destroy$)
-			).subscribe((config: any) => {
+		this.configService
+			.getConfig()
+			.pipe(first(), takeUntil(this.destroy$))
+			.subscribe((config: any) => {
 				this.enableUserBypassAC = config.enableUserBypassAC;
 				if (this.enableUserBypassAC) {
 					this.columns.bypassAccessCheck = { show: false, display: 'Bypass AC' };
 					this.defaultColumns = JSON.parse(JSON.stringify(this.columns));
-					this.headers.push({ name: 'Bypass AC', sortable: false, sortField: 'bypassAccessCheck' });
+					this.headers.push({
+						name: 'Bypass AC',
+						sortable: false,
+						sortField: 'bypassAccessCheck'
+					});
 				}
 
-				this.requiredExternalRoles = isArray(config.requiredRoles) ? config.requiredRoles : [];
+				this.requiredExternalRoles = isArray(config.requiredRoles)
+					? config.requiredRoles
+					: [];
 
-				this.headersToShow = this.headers.filter((header: SortableTableHeader) => this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show);
+				this.headersToShow = this.headers.filter(
+					(header: SortableTableHeader) =>
+						this.columns.hasOwnProperty(header.sortField) &&
+						this.columns[header.sortField].show
+				);
 
 				this.initializeFromCache();
 			});
@@ -144,7 +181,10 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 
 	columnsUpdated(updatedColumns: any) {
 		this.columns = cloneDeep(updatedColumns);
-		this.headersToShow = this.headers.filter((header: SortableTableHeader) => this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show);
+		this.headersToShow = this.headers.filter(
+			(header: SortableTableHeader) =>
+				this.columns.hasOwnProperty(header.sortField) && this.columns[header.sortField].show
+		);
 	}
 
 	/**
@@ -169,7 +209,7 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 			roles.bypassAC = { show: false, display: 'Bypass AC' };
 		}
 
-		Role.ROLES.forEach((role) => {
+		Role.ROLES.forEach(role => {
 			if (role.role !== 'user') {
 				roles[`${role.role}Role`] = { show: false, display: role.label };
 			}
@@ -180,7 +220,11 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 		return roles;
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<User>> {
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<User>> {
 		this.adminUsersService.cache.listUsers = {
 			filters: this.filters,
 			search,
@@ -198,7 +242,7 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 			elements.push({ bypassAccessCheck: true });
 		}
 
-		Role.ROLES.forEach((role) => {
+		Role.ROLES.forEach(role => {
 			const filter = this.filters[`${role.role}Role`];
 			if (filter != null && filter.show) {
 				const element = {};
@@ -209,13 +253,14 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 
 		if (this.filters.pending.show) {
 			const filter: any = {
-				$or: [ { 'roles.user': {$ne: true} } ]
+				$or: [{ 'roles.user': { $ne: true } }]
 			};
 			if (this.requiredExternalRoles.length > 0) {
-				filter.$or.push({ $and: [
-					{bypassAccessCheck: {$ne: true}},
-					{externalRoles: {$not: {$all: this.requiredExternalRoles}}}
-				]
+				filter.$or.push({
+					$and: [
+						{ bypassAccessCheck: { $ne: true } },
+						{ externalRoles: { $not: { $all: this.requiredExternalRoles } } }
+					]
 				});
 			}
 			elements.push(filter);
@@ -226,7 +271,6 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 		}
 		return query;
 	}
-
 }
 
 AdminTopics.registerTopic({

--- a/src/app/core/admin/user-management/admin-user.module.ts
+++ b/src/app/core/admin/user-management/admin-user.module.ts
@@ -34,17 +34,9 @@ import { SearchInputModule } from '../../../common/search-input.module';
 		SystemAlertModule,
 		SearchInputModule
 	],
-	exports: [
-	],
-	entryComponents: [
-	],
-	declarations:   [
-		AdminCreateUserComponent,
-		AdminListUsersComponent,
-		AdminUpdateUserComponent
-	],
-	providers:  [
-		AdminUsersService
-	],
+	exports: [],
+	entryComponents: [],
+	declarations: [AdminCreateUserComponent, AdminListUsersComponent, AdminUpdateUserComponent],
+	providers: [AdminUsersService]
 })
-export class AdminUserModule { }
+export class AdminUserModule {}

--- a/src/app/core/admin/user-management/admin-users.service.ts
+++ b/src/app/core/admin/user-management/admin-users.service.ts
@@ -13,31 +13,36 @@ import { SystemAlertService } from '../../../common/system-alert/system-alert.se
  * Admin management of users
  */
 export class AdminUsersService {
-
 	cache: any = {};
 
-	constructor(
-		private http: HttpClient,
-		private alertService: SystemAlertService
-	) {}
+	constructor(private http: HttpClient, private alertService: SystemAlertService) {}
 
-	search(query: any, search: string, paging: PagingOptions, options: any): Observable<PagingResults<User>> {
-		return this.http.post<PagingResults>(
-			'api/admin/users',
-			{ q: query, s: search, options },
-			{ params: paging.toObj() }
-		).pipe(
-			map((results: PagingResults) => {
-				if (null != results && Array.isArray(results.elements)) {
-					results.elements = results.elements.map((element: any) => new User().setFromUserModel(element));
-				}
-				return results;
-			}),
-			catchError((error) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(NULL_PAGING_RESULTS);
-			})
-		);
+	search(
+		query: any,
+		search: string,
+		paging: PagingOptions,
+		options: any
+	): Observable<PagingResults<User>> {
+		return this.http
+			.post<PagingResults>(
+				'api/admin/users',
+				{ q: query, s: search, options },
+				{ params: paging.toObj() }
+			)
+			.pipe(
+				map((results: PagingResults) => {
+					if (null != results && Array.isArray(results.elements)) {
+						results.elements = results.elements.map((element: any) =>
+							new User().setFromUserModel(element)
+						);
+					}
+					return results;
+				}),
+				catchError(error => {
+					this.alertService.addClientErrorAlert(error);
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 
 	removeUser(id: string) {
@@ -59,5 +64,4 @@ export class AdminUsersService {
 	update(user: User): Observable<any> {
 		return this.http.post(`api/admin/user/${user.userModel._id}`, user.userModel);
 	}
-
 }

--- a/src/app/core/admin/user-management/manage-user.component.ts
+++ b/src/app/core/admin/user-management/manage-user.component.ts
@@ -12,7 +12,6 @@ import { ConfigService } from '../../config.service';
 import { Role } from '../../auth/role.model';
 
 export abstract class ManageUserComponent implements OnDestroy, OnInit {
-
 	config: any;
 	error: string = null;
 	proxyPki: boolean;
@@ -34,14 +33,12 @@ export abstract class ManageUserComponent implements OnDestroy, OnInit {
 		protected router: Router,
 		protected configService: ConfigService,
 		protected alertService: SystemAlertService
-	) {
-	}
+	) {}
 
 	ngOnInit() {
-		this.configService.getConfig()
-			.pipe(
-				takeUntil(this.destroy$)
-			)
+		this.configService
+			.getConfig()
+			.pipe(takeUntil(this.destroy$))
 			.subscribe((config: any) => {
 				this.config = config;
 				this.proxyPki = config.auth === 'proxy-pki';
@@ -65,17 +62,17 @@ export abstract class ManageUserComponent implements OnDestroy, OnInit {
 
 	submit() {
 		if (this.validatePassword()) {
-			this.submitUser(this.user)
-				.subscribe(
-					() => this.router.navigate([this.navigateOnSuccess]),
-					(response: HttpErrorResponse) => {
-						this.alertService.addClientErrorAlert(response);
-					});
+			this.submitUser(this.user).subscribe(
+				() => this.router.navigate([this.navigateOnSuccess]),
+				(response: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(response);
+				}
+			);
 		}
 	}
 
 	bypassAccessCheck() {
-		this.metadataLocked = null != (this.user) && !this.user.userModel.bypassAccessCheck;
+		this.metadataLocked = null != this.user && !this.user.userModel.bypassAccessCheck;
 		this.handleBypassAccessCheck();
 	}
 
@@ -86,5 +83,4 @@ export abstract class ManageUserComponent implements OnDestroy, OnInit {
 		this.error = 'Passwords must match';
 		return false;
 	}
-
 }

--- a/src/app/core/audit/audit-object.component.ts
+++ b/src/app/core/audit/audit-object.component.ts
@@ -1,6 +1,12 @@
 import {
-	Component, Input, ViewChild, ViewContainerRef, ComponentRef, ComponentFactoryResolver,
-	ComponentFactory, OnInit
+	Component,
+	Input,
+	ViewChild,
+	ViewContainerRef,
+	ComponentRef,
+	ComponentFactoryResolver,
+	ComponentFactory,
+	OnInit
 } from '@angular/core';
 import { AuditObjectTypes } from './audit.classes';
 
@@ -37,10 +43,8 @@ AuditObjectTypes.registerType('user-authentication', UserAuthenticationObjectCom
 @Component({
 	selector: 'export-audit',
 	template: `
-			<span *ngIf='auditObject'>
-				<span class='fa fa-download'></span> Export config
-			</span>
-			`
+		<span *ngIf="auditObject"> <span class="fa fa-download"></span> Export config </span>
+	`
 })
 export class ExportAuditObjectComponent extends DefaultAuditObjectComponent {}
 AuditObjectTypes.registerType('export', ExportAuditObjectComponent);
@@ -57,17 +61,16 @@ export class AuditObjectComponent implements OnInit {
 
 	private componentRef: ComponentRef<any>;
 
-	constructor(
-		private componentFactoryResolver: ComponentFactoryResolver
-	) {}
+	constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
 
 	ngOnInit() {
 		if (!AuditObjectTypes.objects.hasOwnProperty(this.auditType)) {
 			this.auditType = 'default';
 		}
 
-		const factory: ComponentFactory<Component> =
-			this.componentFactoryResolver.resolveComponentFactory(AuditObjectTypes.objects[this.auditType]);
+		const factory: ComponentFactory<Component> = this.componentFactoryResolver.resolveComponentFactory(
+			AuditObjectTypes.objects[this.auditType]
+		);
 
 		this.componentRef = this.content.createComponent(factory);
 		this.componentRef.instance.auditObject = this.auditObject;

--- a/src/app/core/audit/audit-routing.module.ts
+++ b/src/app/core/audit/audit-routing.module.ts
@@ -11,11 +11,10 @@ import { AuthGuard } from '../auth/auth.guard';
 				path: 'audit',
 				component: ListAuditEntriesComponent,
 				canActivate: [AuthGuard],
-				data: { roles: [ 'auditor' ] }
-			}])
+				data: { roles: ['auditor'] }
+			}
+		])
 	],
-	exports: [
-		RouterModule
-	]
+	exports: [RouterModule]
 })
-export class AuditRoutingModule { }
+export class AuditRoutingModule {}

--- a/src/app/core/audit/audit-view-change-modal/audit-view-change-modal.component.ts
+++ b/src/app/core/audit/audit-view-change-modal/audit-view-change-modal.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { AuditViewDetailsModalComponent } from '../audit-view-details-modal/audit-view-details-modal.component';
 
 @Component({
-  templateUrl: './audit-view-change-modal.component.html'
+	templateUrl: './audit-view-change-modal.component.html'
 })
-export class AuditViewChangeModalComponent extends AuditViewDetailsModalComponent {
-}
+export class AuditViewChangeModalComponent extends AuditViewDetailsModalComponent {}

--- a/src/app/core/audit/audit-view-details-modal/audit-view-details-modal.component.ts
+++ b/src/app/core/audit/audit-view-details-modal/audit-view-details-modal.component.ts
@@ -2,14 +2,10 @@ import { Component } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 @Component({
-  templateUrl: './audit-view-details-modal.component.html'
+	templateUrl: './audit-view-details-modal.component.html'
 })
 export class AuditViewDetailsModalComponent {
-
 	auditEntry: any;
 
-	constructor(
-		public modalRef: BsModalRef
-	) {}
-
+	constructor(public modalRef: BsModalRef) {}
 }

--- a/src/app/core/audit/audit.classes.ts
+++ b/src/app/core/audit/audit.classes.ts
@@ -1,8 +1,5 @@
 export class AuditOption {
-	constructor(
-		public display?: string,
-		public selected: boolean = false
-	) {}
+	constructor(public display?: string, public selected: boolean = false) {}
 }
 
 export class AuditObjectTypes {

--- a/src/app/core/audit/audit.module.ts
+++ b/src/app/core/audit/audit.module.ts
@@ -17,8 +17,11 @@ import { AuditRoutingModule } from './audit-routing.module';
 import { AuditService } from './audit.service';
 import { ListAuditEntriesComponent } from './list-audit-entries/list-audit-entries.component';
 import {
-	AuditObjectComponent, UrlAuditObjectComponent,
-	DefaultAuditObjectComponent, ExportAuditObjectComponent, UserAuditObjectComponent,
+	AuditObjectComponent,
+	UrlAuditObjectComponent,
+	DefaultAuditObjectComponent,
+	ExportAuditObjectComponent,
+	UserAuditObjectComponent,
 	UserAuthenticationObjectComponent
 } from './audit-object.component';
 import { AuditViewChangeModalComponent } from './audit-view-change-modal/audit-view-change-modal.component';
@@ -63,11 +66,9 @@ import { AuditViewDetailsModalComponent } from './audit-view-details-modal/audit
 		UserAuditObjectComponent,
 		UserAuthenticationObjectComponent
 	],
-	providers: [
-		AuditService
-	]
+	providers: [AuditService]
 })
-export class AuditModule { }
+export class AuditModule {}
 
 export { AuditObjectTypes } from './audit.classes';
 export { ListAuditEntriesComponent } from './list-audit-entries/list-audit-entries.component';

--- a/src/app/core/audit/audit.service.spec.ts
+++ b/src/app/core/audit/audit.service.spec.ts
@@ -9,13 +9,11 @@ import { User } from '../auth/user.model';
 import { SystemAlertService } from '../../common/system-alert.module';
 
 describe('Audit Service', () => {
-
 	let injector: TestBed;
 	let service: AuditService;
 	let httpMock: HttpTestingController;
 
 	beforeEach(async () => {
-
 		TestBed.configureTestingModule({
 			imports: [HttpClientTestingModule],
 			providers: [AuditService, SystemAlertService]
@@ -24,7 +22,6 @@ describe('Audit Service', () => {
 		injector = getTestBed();
 		service = injector.get(AuditService);
 		httpMock = injector.get(HttpTestingController);
-
 	});
 
 	afterEach(() => {
@@ -33,13 +30,9 @@ describe('Audit Service', () => {
 	});
 
 	describe('#getDistinctValues', () => {
-
 		it('should call once and return an Observable<string[]>', () => {
-			const values = [
-				'value01',
-				'value 02'
-			];
-			service.getDistinctAuditValues('test-field').subscribe((actual) => {
+			const values = ['value01', 'value 02'];
+			service.getDistinctAuditValues('test-field').subscribe(actual => {
 				expect(actual).toBe(values);
 			});
 
@@ -47,11 +40,9 @@ describe('Audit Service', () => {
 			expect(req.request.method).toBe('GET');
 			req.flush(values);
 		});
-
 	});
 
 	describe('#isViewDetailsAction', () => {
-
 		it('should include defaults', () => {
 			expect(service.isViewDetailsAction('create')).toBeTruthy();
 			expect(service.isViewDetailsAction('delete')).toBeTruthy();
@@ -62,11 +53,9 @@ describe('Audit Service', () => {
 			service.addViewDetailsAction('new action');
 			expect(service.isViewDetailsAction('new action')).toBeTruthy();
 		});
-
 	});
 
 	describe('#isViewChangesAction', () => {
-
 		it('should include defaults', () => {
 			expect(service.isViewChangesAction('update')).toBeTruthy();
 			expect(service.isViewChangesAction('admin update')).toBeTruthy();
@@ -77,11 +66,9 @@ describe('Audit Service', () => {
 			service.addViewChangesAction('new action');
 			expect(service.isViewChangesAction('new action')).toBeTruthy();
 		});
-
 	});
 
 	describe('#search', () => {
-
 		it('should call once and return an Observable<PagingResults>', () => {
 			const results = {
 				elements: [
@@ -91,7 +78,7 @@ describe('Audit Service', () => {
 			} as PagingResults;
 			const paging = new PagingOptions();
 			paging.setPageNumber(2);
-			service.search({ actor: 'test' }, 'some-search', paging).subscribe((actual) => {
+			service.search({ actor: 'test' }, 'some-search', paging).subscribe(actual => {
 				console.log(actual);
 				expect(actual).toBe(results);
 			});
@@ -104,11 +91,9 @@ describe('Audit Service', () => {
 			});
 			req.flush(results);
 		});
-
 	});
 
 	describe('#matchUser', () => {
-
 		it('should call once and return an Observable<PagingResults>', () => {
 			const results = {
 				elements: [
@@ -117,7 +102,7 @@ describe('Audit Service', () => {
 				]
 			} as PagingResults;
 			const expectedResults = _cloneDeep(results);
-			expectedResults.elements = expectedResults.elements.map((element) => {
+			expectedResults.elements = expectedResults.elements.map(element => {
 				return new User().setFromUserModel(element);
 			});
 			const paging = new PagingOptions();
@@ -125,7 +110,7 @@ describe('Audit Service', () => {
 			const query = { actor: 'test' };
 			const search = 'some-search';
 			const options = { test: false };
-			service.matchUser(query, search, paging, options).subscribe((actual) => {
+			service.matchUser(query, search, paging, options).subscribe(actual => {
 				expect(actual).toEqual(expectedResults);
 			});
 
@@ -138,7 +123,5 @@ describe('Audit Service', () => {
 			});
 			req.flush(results);
 		});
-
 	});
-
 });

--- a/src/app/core/audit/audit.service.ts
+++ b/src/app/core/audit/audit.service.ts
@@ -11,20 +11,11 @@ import { SystemAlertService } from '../../common/system-alert/system-alert.servi
 
 @Injectable()
 export class AuditService {
+	private viewDetailsActions: string[] = ['create', 'delete'];
 
-	private viewDetailsActions: string[] = [
-		'create',
-		'delete'
-	];
+	private viewChangesActions: string[] = ['update', 'admin update'];
 
-	private viewChangesActions: string[] = [
-		'update',
-		'admin update'
-	];
-
-	constructor(
-		private http: HttpClient,
-		private alertService: SystemAlertService) {}
+	constructor(private http: HttpClient, private alertService: SystemAlertService) {}
 
 	public isViewDetailsAction(action: string) {
 		return this.viewDetailsActions.includes(action);
@@ -47,39 +38,46 @@ export class AuditService {
 	}
 
 	public search(query: any, search: string, paging: PagingOptions): Observable<PagingResults> {
-		return this.http.post<PagingResults>(
-			'api/audit',
-			{q: query, s: search},
-			{params: paging.toObj()}
-		).pipe(
-			map((results: PagingResults) => {
-				if (null != results && Array.isArray(results.elements)) {
-					results.elements.forEach((entry) => {
-						entry.isViewDetailsAction = this.isViewDetailsAction(entry.audit.action);
-						entry.isViewChangesAction = this.isViewChangesAction(entry.audit.action);
-					});
-				}
-				return results;
-			}),
-			catchError((error) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(NULL_PAGING_RESULTS);
-			})
-		);
+		return this.http
+			.post<PagingResults>('api/audit', { q: query, s: search }, { params: paging.toObj() })
+			.pipe(
+				map((results: PagingResults) => {
+					if (null != results && Array.isArray(results.elements)) {
+						results.elements.forEach(entry => {
+							entry.isViewDetailsAction = this.isViewDetailsAction(
+								entry.audit.action
+							);
+							entry.isViewChangesAction = this.isViewChangesAction(
+								entry.audit.action
+							);
+						});
+					}
+					return results;
+				}),
+				catchError(error => {
+					this.alertService.addClientErrorAlert(error);
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 
-	public matchUser(query: any, search: string, paging: PagingOptions, options: any): Observable<PagingResults> {
-		return this.http.post(
-			'api/users/match',
-			{ q: query, s: search, options },
-			{ params: paging.toObj() }
-		).pipe(
-			map((results: PagingResults) => {
-				if (null != results && _isArray(results.elements)) {
-					results.elements = results.elements.map((element: any) => new User().setFromUserModel(element));
-				}
-				return results;
-			})
-		);
+	public matchUser(
+		query: any,
+		search: string,
+		paging: PagingOptions,
+		options: any
+	): Observable<PagingResults> {
+		return this.http
+			.post('api/users/match', { q: query, s: search, options }, { params: paging.toObj() })
+			.pipe(
+				map((results: PagingResults) => {
+					if (null != results && _isArray(results.elements)) {
+						results.elements = results.elements.map((element: any) =>
+							new User().setFromUserModel(element)
+						);
+					}
+					return results;
+				})
+			);
 	}
 }

--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.scss
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.scss
@@ -1,7 +1,6 @@
 @import '../../../common/paging/quick-filters/quick-filters.component';
 
 .audit-filter {
-
 	label {
 		float: left;
 		line-height: 2;
@@ -13,7 +12,6 @@
 			width: auto;
 		}
 	}
-
 }
 
 //.quick-select-header

--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.spec.ts
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.spec.ts
@@ -18,14 +18,16 @@ import { SystemAlertModule, SystemAlertService } from '../../../common/system-al
 
 import { ListAuditEntriesComponent } from './list-audit-entries.component';
 import {
-	AuditObjectComponent, UrlAuditObjectComponent,
-	DefaultAuditObjectComponent, ExportAuditObjectComponent, UserAuditObjectComponent,
+	AuditObjectComponent,
+	UrlAuditObjectComponent,
+	DefaultAuditObjectComponent,
+	ExportAuditObjectComponent,
+	UserAuditObjectComponent,
 	UserAuthenticationObjectComponent
 } from '../audit-object.component';
 import { AuditService } from '../audit.service';
 
 describe('Audit Component Spec', () => {
-
 	let auditServiceSpy;
 
 	let fixture: ComponentFixture<ListAuditEntriesComponent>;
@@ -33,58 +35,55 @@ describe('Audit Component Spec', () => {
 	let rootHTMLElement: HTMLElement;
 
 	const matchedUsers = {
-		elements: [{
-			userModel: {
-				name: 'Test User 01',
-				username: 'test01'
+		elements: [
+			{
+				userModel: {
+					name: 'Test User 01',
+					username: 'test01'
+				}
+			},
+			{
+				userModel: {
+					name: 'Test User 02',
+					username: 'test02'
+				}
 			}
-		}, {
-			userModel: {
-				name: 'Test User 02',
-				username: 'test02'
-			}
-		}],
+		],
 		totalPages: 1,
 		totalSize: 2
 	} as PagingResults;
 
-	const distinctResultsActions = [
-		'admin update',
-		'create',
-		'authentication succeeded'
-	];
-	const distinctResultsTypes = [
-		'user',
-		'user-authentication'
-	];
+	const distinctResultsActions = ['admin update', 'create', 'authentication succeeded'];
+	const distinctResultsTypes = ['user', 'user-authentication'];
 	const searchResults = {
-		elements: [{
-			created: 1567973747442,
-			id: '5d75617309e3e93d36b1c948',
-			message: 'admin user updated',
-			audit: {
-				action: 'admin update',
-				actor: {
-					username: 'testuser01',
-					name: 'Test User 01'
-				},
-				auditType: 'user',
-				object: {
-					before: {
-						username: 'testuser01',
-						name: 'Test User 1'
-					},
-					after: {
+		elements: [
+			{
+				created: 1567973747442,
+				id: '5d75617309e3e93d36b1c948',
+				message: 'admin user updated',
+				audit: {
+					action: 'admin update',
+					actor: {
 						username: 'testuser01',
 						name: 'Test User 01'
+					},
+					auditType: 'user',
+					object: {
+						before: {
+							username: 'testuser01',
+							name: 'Test User 1'
+						},
+						after: {
+							username: 'testuser01',
+							name: 'Test User 01'
+						}
 					}
 				}
 			}
-		}]
+		]
 	};
 
 	beforeEach(async () => {
-
 		auditServiceSpy = jasmine.createSpyObj('AuditService', [
 			'getDistinctAuditValues',
 			'isViewDetailsAction',
@@ -92,7 +91,7 @@ describe('Audit Component Spec', () => {
 			'search',
 			'matchUser'
 		]);
-		auditServiceSpy.getDistinctAuditValues.and.callFake((field) => {
+		auditServiceSpy.getDistinctAuditValues.and.callFake(field => {
 			if (field === 'audit.action') {
 				return of(distinctResultsActions);
 			} else if (field === 'audit.auditType') {
@@ -103,14 +102,17 @@ describe('Audit Component Spec', () => {
 		});
 		auditServiceSpy.isViewDetailsAction.and.callThrough();
 		auditServiceSpy.isViewChangesAction.and.callThrough();
-		auditServiceSpy.search.and.returnValue( of(searchResults) );
-		auditServiceSpy.matchUser.and.returnValue( of(matchedUsers) );
+		auditServiceSpy.search.and.returnValue(of(searchResults));
+		auditServiceSpy.matchUser.and.returnValue(of(matchedUsers));
 
 		TestBed.configureTestingModule({
 			declarations: [
 				ListAuditEntriesComponent,
-				AuditObjectComponent, UrlAuditObjectComponent,
-				DefaultAuditObjectComponent, ExportAuditObjectComponent, UserAuditObjectComponent,
+				AuditObjectComponent,
+				UrlAuditObjectComponent,
+				DefaultAuditObjectComponent,
+				ExportAuditObjectComponent,
+				UserAuditObjectComponent,
 				UserAuthenticationObjectComponent
 			],
 			imports: [
@@ -130,12 +132,14 @@ describe('Audit Component Spec', () => {
 				BsModalService,
 				SystemAlertService
 			]
-		})
-		.overrideModule(BrowserDynamicTestingModule, {
+		}).overrideModule(BrowserDynamicTestingModule, {
 			set: {
 				entryComponents: [
-					AuditObjectComponent, UrlAuditObjectComponent,
-					DefaultAuditObjectComponent, ExportAuditObjectComponent, UserAuditObjectComponent,
+					AuditObjectComponent,
+					UrlAuditObjectComponent,
+					DefaultAuditObjectComponent,
+					ExportAuditObjectComponent,
+					UserAuditObjectComponent,
 					UserAuthenticationObjectComponent
 				]
 			}
@@ -148,18 +152,22 @@ describe('Audit Component Spec', () => {
 	});
 
 	describe('audit list display', () => {
-
 		it('should display the audit entry on load', () => {
-
 			fixture.detectChanges();
 
 			console.log(component.loading);
 
 			fixture.whenStable().then(() => {
 				// Verify that the Address String is display in the proper HTML field
-				expect(rootHTMLElement.querySelector('.table-row').textContent).toContain('testuser01');
-				expect(rootHTMLElement.querySelector('.table-row').textContent).toContain('admin update');
-				expect(rootHTMLElement.querySelector('.table-row').textContent).toContain('2019-09-08 20:15:47Z');
+				expect(rootHTMLElement.querySelector('.table-row').textContent).toContain(
+					'testuser01'
+				);
+				expect(rootHTMLElement.querySelector('.table-row').textContent).toContain(
+					'admin update'
+				);
+				expect(rootHTMLElement.querySelector('.table-row').textContent).toContain(
+					'2019-09-08 20:15:47Z'
+				);
 
 				// Verify that the values are formatted properly
 
@@ -168,7 +176,5 @@ describe('Audit Component Spec', () => {
 				expect(auditServiceSpy.search).toHaveBeenCalledTimes(1);
 			});
 		});
-
 	});
-
 });

--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.ts
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.ts
@@ -11,7 +11,9 @@ import {
 	PagingOptions,
 	SortDirection,
 	PagingResults,
-	AbstractPageableDataComponent, SortableTableHeader, SortChange
+	AbstractPageableDataComponent,
+	SortableTableHeader,
+	SortChange
 } from '../../../common/paging.module';
 
 import { AuditOption } from '../audit.classes';
@@ -23,8 +25,8 @@ import { AuditViewDetailsModalComponent } from '../audit-view-details-modal/audi
 	styleUrls: ['./list-audit-entries.component.scss'],
 	templateUrl: './list-audit-entries.component.html'
 })
-export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any> implements OnInit {
-
+export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any>
+	implements OnInit {
 	actionOptions: AuditOption[] = [];
 	actionsFormShown = true;
 	actorFormShown = true;
@@ -36,10 +38,37 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 	queryUserSearchTerm = '';
 
 	headers: SortableTableHeader[] = [
-		{ name: 'Actor', sortable: true, sortField: 'audit.actor.name', sortDir: SortDirection.asc, tooltip: 'Sort by Key', iconClass: 'fa-user' },
-		{ name: 'Timestamp', sortable: true, sortField: 'created', sortDir: SortDirection.desc, tooltip: 'Sort by Timestamp', iconClass: 'fa-clock-o', default: true },
-		{ name: 'Action', sortable: true, sortField: 'audit.action', sortDir: SortDirection.asc, tooltip: 'Sort by Action' },
-		{ name: 'Type', sortable: true, sortField: 'audit.auditType', sortDir: SortDirection.asc, tooltip: 'Sort by Type' },
+		{
+			name: 'Actor',
+			sortable: true,
+			sortField: 'audit.actor.name',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Key',
+			iconClass: 'fa-user'
+		},
+		{
+			name: 'Timestamp',
+			sortable: true,
+			sortField: 'created',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Timestamp',
+			iconClass: 'fa-clock-o',
+			default: true
+		},
+		{
+			name: 'Action',
+			sortable: true,
+			sortField: 'audit.action',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Action'
+		},
+		{
+			name: 'Type',
+			sortable: true,
+			sortField: 'audit.auditType',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Type'
+		},
 		{ name: 'Object', sortable: false },
 		{ name: 'Before', sortable: false, iconClass: 'fa-history' },
 		{ name: 'Message', sortable: false, iconClass: 'fa-file-text-o' }
@@ -49,7 +78,9 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 
 	dateRangeFilter: any;
 
-	queryStartDate: Date = utc().subtract(1, 'days').toDate();
+	queryStartDate: Date = utc()
+		.subtract(1, 'days')
+		.toDate();
 
 	queryEndDate: Date = utc().toDate();
 
@@ -61,10 +92,7 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 
 	private auditModalRef: BsModalRef;
 
-	constructor(
-		private auditService: AuditService,
-		private modalService: BsModalService
-	) {
+	constructor(private auditService: AuditService, private modalService: BsModalService) {
 		super();
 	}
 
@@ -90,7 +118,9 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 		this.searchUsersRef = new Observable((observer: any) => {
 			observer.next(this.queryUserSearchTerm);
 		}).pipe(
-			mergeMap((token: string) => this.auditService.matchUser({}, token, this.userPagingOpts, {})),
+			mergeMap((token: string) =>
+				this.auditService.matchUser({}, token, this.userPagingOpts, {})
+			),
 			map((result: PagingResults) => {
 				return result.elements.map((r: any) => {
 					r.displayName = `${r.userModel.name}  [${r.userModel.username}]`;
@@ -104,8 +134,14 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 			this.auditService.getDistinctAuditValues('audit.action'),
 			this.auditService.getDistinctAuditValues('audit.auditType')
 		]).subscribe((results: any[]) => {
-			this.actionOptions = results[0].filter((r: any) => _isString(r)).sort().map((r: any) => new AuditOption(r));
-			this.auditTypeOptions = results[1].filter((r: any) => _isString(r)).sort().map((r: any) => new AuditOption(r));
+			this.actionOptions = results[0]
+				.filter((r: any) => _isString(r))
+				.sort()
+				.map((r: any) => new AuditOption(r));
+			this.auditTypeOptions = results[1]
+				.filter((r: any) => _isString(r))
+				.sort()
+				.map((r: any) => new AuditOption(r));
 		});
 
 		this.sortEvent$.next(this.headers.find((header: any) => header.default) as SortChange);
@@ -113,7 +149,11 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 		super.ngOnInit();
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<any>> {
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<any>> {
 		return this.auditService.search(query, search, pagingOptions);
 	}
 
@@ -125,11 +165,17 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 	viewMore(auditEntry: any, type: string) {
 		switch (type) {
 			case 'viewDetails':
-				this.auditModalRef = this.modalService.show(AuditViewDetailsModalComponent, { ignoreBackdropClick: true, class: 'modal-lg' });
+				this.auditModalRef = this.modalService.show(AuditViewDetailsModalComponent, {
+					ignoreBackdropClick: true,
+					class: 'modal-lg'
+				});
 				this.auditModalRef.content.auditEntry = auditEntry;
 				break;
 			case 'viewChanges':
-				this.auditModalRef = this.modalService.show(AuditViewChangeModalComponent, { ignoreBackdropClick: true, class: 'modal-lg' });
+				this.auditModalRef = this.modalService.show(AuditViewChangeModalComponent, {
+					ignoreBackdropClick: true,
+					class: 'modal-lg'
+				});
 				this.auditModalRef.content.auditEntry = auditEntry;
 				break;
 			default:
@@ -152,17 +198,17 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 			};
 		}
 
-		const selectedActions = this.actionOptions.filter((opt) => opt.selected);
+		const selectedActions = this.actionOptions.filter(opt => opt.selected);
 		if (selectedActions.length > 0) {
 			query['audit.action'] = {
-				$in: selectedActions.map((opt) => opt.display)
+				$in: selectedActions.map(opt => opt.display)
 			};
 		}
 
-		const selectedAuditTypes = this.auditTypeOptions.filter((opt) => opt.selected);
+		const selectedAuditTypes = this.auditTypeOptions.filter(opt => opt.selected);
 		if (selectedAuditTypes.length > 0) {
 			query['audit.auditType'] = {
-				$in: selectedAuditTypes.map((opt) => opt.display)
+				$in: selectedAuditTypes.map(opt => opt.display)
 			};
 		}
 
@@ -179,11 +225,11 @@ export class ListAuditEntriesComponent extends AbstractPageableDataComponent<any
 
 		if (this.dateRangeFilter.selected === 'choose') {
 			if (null != this.queryStartDate) {
-				timeQuery = (null == timeQuery) ? {} : timeQuery;
+				timeQuery = null == timeQuery ? {} : timeQuery;
 				timeQuery.$gte = utc(this.queryStartDate).startOf('day');
 			}
 			if (null != this.queryEndDate) {
-				timeQuery = (null == timeQuery) ? {} : timeQuery;
+				timeQuery = null == timeQuery ? {} : timeQuery;
 				timeQuery.$lt = utc(this.queryEndDate).endOf('day');
 			}
 		} else if (this.dateRangeFilter.selected !== 'everything') {

--- a/src/app/core/auth/auth.guard.ts
+++ b/src/app/core/auth/auth.guard.ts
@@ -12,17 +12,14 @@ import { AuthorizationService } from './authorization.service';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-
 	constructor(
 		private router: Router,
 		private configService: ConfigService,
 		private sessionService: SessionService,
 		private authorizationService: AuthorizationService
-	) { }
-
+	) {}
 
 	canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-
 		// Default to requiring authentication if guard is present
 		let requiresAuthentication = true;
 		if (get(route, 'data.requiresAuthentication', true) === false) {
@@ -38,7 +35,6 @@ export class AuthGuard implements CanActivate {
 			return of(true);
 		}
 
-
 		// -----------------------------------------------------------
 		// Yes, the user needs to be authenticated
 		// -----------------------------------------------------------
@@ -47,7 +43,7 @@ export class AuthGuard implements CanActivate {
 
 		const session$ = this.sessionService.getSession().pipe(
 			first(),
-			catchError((error) => {
+			catchError(error => {
 				// Handle the error
 				console.log(error);
 				return of(null);
@@ -63,7 +59,9 @@ export class AuthGuard implements CanActivate {
 				return of(session);
 			}),
 			switchMap(() => {
-				return this.authorizationService.isAuthenticated() ? this.sessionService.getCurrentEua() : of(null);
+				return this.authorizationService.isAuthenticated()
+					? this.sessionService.getCurrentEua()
+					: of(null);
 			}),
 			map(() => {
 				return this.checkAccess(route, state);
@@ -106,7 +104,7 @@ export class AuthGuard implements CanActivate {
 			// compile a list of roles that are missing
 			const requiredRoles = get(route, 'data.roles', ['user']);
 			const missingRoles: any[] = [];
-			requiredRoles.forEach( (role: any) => {
+			requiredRoles.forEach((role: any) => {
 				if (!this.authorizationService.hasRole(role)) {
 					missingRoles.push(role);
 				}
@@ -119,10 +117,8 @@ export class AuthGuard implements CanActivate {
 				this.router.navigate(['/unauthorized']);
 				return false;
 			}
-
 		}
 
 		return true;
 	}
-
 }

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -8,22 +8,18 @@ import { catchError } from 'rxjs/operators';
 
 import { SessionService } from './session.service';
 
-
 /**
  * HTTP Interceptor that will interpret authentication-related HTTP calls
  */
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-
 	constructor(private router: Router, private sessionService: SessionService) {
 		// Nothing here
 	}
 
 	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-
 		return next.handle(req).pipe(
-			catchError((err) => {
-
+			catchError(err => {
 				// Grab all the useful stuff out of the error response
 				const status = get(err, 'status', 200);
 				const type = get(err, 'error.type', '');
@@ -35,20 +31,16 @@ export class AuthInterceptor implements HttpInterceptor {
 				// Go to signin if the user isn't logged in and wasn't already on the signin page
 				if (401 === status && !url.endsWith('auth/signin')) {
 					this.router.navigate(['/signin']);
-
 				} else if (403 === status) {
 					if ('eua' === type) {
 						this.router.navigate(['/eua']);
 					} else {
-						this.router.navigate(['/access'], {state: stateObject});
+						this.router.navigate(['/access'], { state: stateObject });
 					}
 				}
 
 				return throwError(err);
-
 			})
 		);
-
 	}
-
 }

--- a/src/app/core/auth/authentication.service.ts
+++ b/src/app/core/auth/authentication.service.ts
@@ -5,13 +5,9 @@ import { Observable } from 'rxjs';
 
 import { User } from './user.model';
 
-
 @Injectable()
 export class AuthenticationService {
-
-	constructor(
-		private http: HttpClient
-	) {}
+	constructor(private http: HttpClient) {}
 
 	signin(username: string, password: string): Observable<any> {
 		return this.http.post('api/auth/signin', { username, password });
@@ -25,8 +21,7 @@ export class AuthenticationService {
 		return this.http.get('api/user/me');
 	}
 
-	logout() {
-	}
+	logout() {}
 
 	getCurrentEua(): Observable<any> {
 		return this.http.get('api/eua');

--- a/src/app/core/auth/authorization.directive.ts
+++ b/src/app/core/auth/authorization.directive.ts
@@ -4,7 +4,9 @@ import {
 	TemplateRef,
 	ViewContainerRef,
 	OnInit,
-	SimpleChanges, OnChanges, EmbeddedViewRef,
+	SimpleChanges,
+	OnChanges,
+	EmbeddedViewRef,
 	ɵstringify as stringify
 } from '@angular/core';
 
@@ -19,10 +21,10 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 	@Input() hasEveryRole: string[];
 	@Input() hasSomeRoles: string[];
 
-	private _thenTemplateRef: TemplateRef<any>|null = null;
-	private _elseTemplateRef: TemplateRef<any>|null = null;
-	private _thenViewRef: EmbeddedViewRef<any>|null = null;
-	private _elseViewRef: EmbeddedViewRef<any>|null = null;
+	private _thenTemplateRef: TemplateRef<any> | null = null;
+	private _elseTemplateRef: TemplateRef<any> | null = null;
+	private _thenViewRef: EmbeddedViewRef<any> | null = null;
+	private _elseViewRef: EmbeddedViewRef<any> | null = null;
 
 	constructor(
 		private templateRef: TemplateRef<any>,
@@ -34,36 +36,36 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 	}
 
 	@Input()
-	set isAuthenticatedThen(templateRef: TemplateRef<any>|null) {
+	set isAuthenticatedThen(templateRef: TemplateRef<any> | null) {
 		this.setThenTemplate('isAuthenticatedThen', templateRef);
 	}
 	@Input()
-	set hasRoleThen(templateRef: TemplateRef<any>|null) {
+	set hasRoleThen(templateRef: TemplateRef<any> | null) {
 		this.setThenTemplate('hasRoleThen', templateRef);
 	}
 	@Input()
-	set hasEveryRoleThen(templateRef: TemplateRef<any>|null) {
+	set hasEveryRoleThen(templateRef: TemplateRef<any> | null) {
 		this.setThenTemplate('hasEveryRoleThen', templateRef);
 	}
 	@Input()
-	set hasSomeRolesThen(templateRef: TemplateRef<any>|null) {
+	set hasSomeRolesThen(templateRef: TemplateRef<any> | null) {
 		this.setThenTemplate('hasSomeRolesThen', templateRef);
 	}
 
 	@Input()
-	set isAuthenticatedElse(templateRef: TemplateRef<any>|null) {
+	set isAuthenticatedElse(templateRef: TemplateRef<any> | null) {
 		this.setElseTemplate('isAuthenticatedElse', templateRef);
 	}
 	@Input()
-	set hasRoleElse(templateRef: TemplateRef<any>|null) {
+	set hasRoleElse(templateRef: TemplateRef<any> | null) {
 		this.setElseTemplate('hasRoleElse', templateRef);
 	}
 	@Input()
-	set hasEveryRoleElse(templateRef: TemplateRef<any>|null) {
+	set hasEveryRoleElse(templateRef: TemplateRef<any> | null) {
 		this.setElseTemplate('hasEveryRoleElse', templateRef);
 	}
 	@Input()
-	set hasSomeRolesElse(templateRef: TemplateRef<any>|null) {
+	set hasSomeRolesElse(templateRef: TemplateRef<any> | null) {
 		this.setElseTemplate('hasSomeRolesElse', templateRef);
 	}
 
@@ -80,9 +82,11 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 
 		if (hasRoleChanges || hasEveryRoleChanges || hasSomeRolesChanges) {
 			// Due to bug when you pass empty array
-			if ((hasRoleChanges && hasRoleChanges.firstChange)
-				|| (hasEveryRoleChanges && hasEveryRoleChanges.firstChange)
-				|| (hasSomeRolesChanges && hasSomeRolesChanges.firstChange)) {
+			if (
+				(hasRoleChanges && hasRoleChanges.firstChange) ||
+				(hasEveryRoleChanges && hasEveryRoleChanges.firstChange) ||
+				(hasSomeRolesChanges && hasSomeRolesChanges.firstChange)
+			) {
 				return;
 			}
 
@@ -90,14 +94,14 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 		}
 	}
 
-	private setThenTemplate(property: string, templateRef: TemplateRef<any>|null) {
+	private setThenTemplate(property: string, templateRef: TemplateRef<any> | null) {
 		assertTemplate(property, templateRef);
 		this._thenTemplateRef = templateRef;
 		this._thenViewRef = null; // clear previous view if any
 		this._updateView();
 	}
 
-	private setElseTemplate(property: string, templateRef: TemplateRef<any>|null) {
+	private setElseTemplate(property: string, templateRef: TemplateRef<any> | null) {
 		assertTemplate(property, templateRef);
 		this._elseTemplateRef = templateRef;
 		this._elseViewRef = null; // clear previous view if any
@@ -110,7 +114,9 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 				this._viewContainer.clear();
 				this._elseViewRef = null;
 				if (this._thenTemplateRef) {
-					this._thenViewRef = this._viewContainer.createEmbeddedView(this._thenTemplateRef);
+					this._thenViewRef = this._viewContainer.createEmbeddedView(
+						this._thenTemplateRef
+					);
 				}
 			}
 		} else {
@@ -118,7 +124,9 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 				this._viewContainer.clear();
 				this._thenViewRef = null;
 				if (this._elseTemplateRef) {
-					this._elseViewRef = this._viewContainer.createEmbeddedView(this._elseTemplateRef);
+					this._elseViewRef = this._viewContainer.createEmbeddedView(
+						this._elseTemplateRef
+					);
 				}
 			}
 		}
@@ -141,9 +149,11 @@ export class AuthorizationDirective implements OnChanges, OnInit {
 	}
 }
 
-function assertTemplate(property: string, templateRef: TemplateRef<any>| null): void {
+function assertTemplate(property: string, templateRef: TemplateRef<any> | null): void {
 	const isTemplateRefOrNull = !!(!templateRef || templateRef.createEmbeddedView);
 	if (!isTemplateRefOrNull) {
-		throw new Error(`${property} must be a TemplateRef, but received '${stringify(templateRef)}'.`);
+		throw new Error(
+			`${property} must be a TemplateRef, but received '${stringify(templateRef)}'.`
+		);
 	}
 }

--- a/src/app/core/auth/authorization.service.spec.ts
+++ b/src/app/core/auth/authorization.service.spec.ts
@@ -11,11 +11,9 @@ class MockSessionService {
 	getSession(): Observable<Session> {
 		return this.sessionSubject;
 	}
-
 }
 
 describe('AuthorizationService', () => {
-
 	let localService: AuthorizationService;
 	let sessionService: SessionService;
 
@@ -61,27 +59,24 @@ describe('AuthorizationService', () => {
 		TestBed.configureTestingModule({
 			providers: [
 				AuthorizationService,
-				{ provide: SessionService, useClass: MockSessionService}
+				{ provide: SessionService, useClass: MockSessionService }
 			]
 		});
 	});
 
-	beforeEach(
-		inject(
-			[AuthorizationService, SessionService],
-			(service: AuthorizationService, 	session: SessionService) => {
-				localService = service;
-				sessionService = session;
-			}
-		)
-	);
+	beforeEach(inject(
+		[AuthorizationService, SessionService],
+		(service: AuthorizationService, session: SessionService) => {
+			localService = service;
+			sessionService = session;
+		}
+	));
 
 	it('should create an instance', () => {
 		expect(localService).toBeTruthy();
 	});
 
 	describe('isAuthenticated', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.isAuthenticated()).toBeFalsy();
@@ -91,11 +86,9 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(USER_SESSION);
 			expect(localService.isAuthenticated()).toBeTruthy();
 		});
-
 	});
 
 	describe('hasExternalRole', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.hasExternalRole('ROLE1')).toBeFalsy();
@@ -110,11 +103,9 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(USER_SESSION);
 			expect(localService.hasExternalRole('ROLE1')).toBeTruthy();
 		});
-
 	});
 
 	describe('hasRole', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.hasRole('user')).toBeFalsy();
@@ -129,11 +120,9 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(USER_SESSION);
 			expect(localService.hasRole('user')).toBeTruthy();
 		});
-
 	});
 
 	describe('hasEveryRole', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.hasEveryRole([Role.USER])).toBeFalsy();
@@ -148,11 +137,9 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(ADMIN_SESSION);
 			expect(localService.hasEveryRole([Role.USER, Role.ADMIN])).toBeTruthy();
 		});
-
 	});
 
 	describe('hasSomeRoles', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.hasSomeRoles([Role.USER])).toBeFalsy();
@@ -169,11 +156,9 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(ADMIN_SESSION);
 			expect(localService.hasSomeRoles([Role.USER, Role.ADMIN])).toBeTruthy();
 		});
-
 	});
 
 	describe('isAdmin', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.isAdmin()).toBeFalsy();
@@ -188,11 +173,9 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(ADMIN_SESSION);
 			expect(localService.isAdmin()).toBeTruthy();
 		});
-
 	});
 
 	describe('isUser', () => {
-
 		it('should return false when session is null', () => {
 			sessionService.sessionSubject.next(EMPTY_SESSION);
 			expect(localService.isUser()).toBeFalsy();
@@ -209,8 +192,5 @@ describe('AuthorizationService', () => {
 			sessionService.sessionSubject.next(ADMIN_SESSION);
 			expect(localService.isUser()).toBeTruthy();
 		});
-
 	});
-
-
 });

--- a/src/app/core/auth/authorization.service.ts
+++ b/src/app/core/auth/authorization.service.ts
@@ -9,17 +9,12 @@ import { SessionService } from './session.service';
 
 @Injectable()
 export class AuthorizationService {
-
 	private session: Session;
 
-	constructor(
-		private sessionService: SessionService
-	) {
-		this.sessionService.getSession().subscribe(
-			(session: Session) => {
-				this.session = session;
-			}
-		);
+	constructor(private sessionService: SessionService) {
+		this.sessionService.getSession().subscribe((session: Session) => {
+			this.session = session;
+		});
 	}
 
 	public isEuaCurrent() {
@@ -30,7 +25,7 @@ export class AuthorizationService {
 	}
 
 	public isAuthenticated(): boolean {
-		return (null != this.session && null != this.session.name);
+		return null != this.session && null != this.session.name;
 	}
 
 	public hasExternalRole(role: string): boolean {
@@ -43,7 +38,7 @@ export class AuthorizationService {
 		role = this.roleToString(role);
 
 		const roles = get(this.session, 'user.userModel.roles', {});
-		return (null != roles[role]) && roles[role];
+		return null != roles[role] && roles[role];
 	}
 
 	public hasAnyRole(): boolean {

--- a/src/app/core/auth/credentials.model.ts
+++ b/src/app/core/auth/credentials.model.ts
@@ -1,5 +1,3 @@
 export class Credentials {
-	constructor(
-		public username?: string,
-		public password?: string) {}
+	constructor(public username?: string, public password?: string) {}
 }

--- a/src/app/core/auth/role.model.ts
+++ b/src/app/core/auth/role.model.ts
@@ -1,18 +1,28 @@
 export class Role {
+	public static USER: Role = new Role(
+		'User',
+		'Account is enabled, has access to the system',
+		'user'
+	);
+	public static EDITOR: Role = new Role(
+		'Editor',
+		'Can create and manage resources in the system',
+		'editor'
+	);
+	public static AUDITOR: Role = new Role(
+		'Auditor',
+		'Has the ability to view auditing, logging, and metrics information',
+		'auditor'
+	);
+	public static ADMIN: Role = new Role(
+		'Admin',
+		'Has full, unrestricted access to the system',
+		'admin'
+	);
 
-	public static USER: Role = new Role('User', 'Account is enabled, has access to the system', 'user');
-	public static EDITOR: Role = new Role('Editor', 'Can create and manage resources in the system', 'editor');
-	public static AUDITOR: Role = new Role('Auditor', 'Has the ability to view auditing, logging, and metrics information', 'auditor');
-	public static ADMIN: Role = new Role('Admin', 'Has full, unrestricted access to the system', 'admin');
-
-	constructor(
-		public label: string,
-		public description: string,
-		public role: string
-	) {}
+	constructor(public label: string, public description: string, public role: string) {}
 
 	public static get ROLES(): Role[] {
 		return [this.USER, this.EDITOR, this.AUDITOR, this.ADMIN];
 	}
-
 }

--- a/src/app/core/auth/session.service.ts
+++ b/src/app/core/auth/session.service.ts
@@ -15,7 +15,6 @@ import { ConfigService } from '../config.service';
 
 @Injectable()
 export class SessionService {
-
 	// The current session information
 	sessionSubject = new BehaviorSubject<Session>(null);
 
@@ -40,7 +39,7 @@ export class SessionService {
 		private authService: AuthenticationService,
 		private configService: ConfigService,
 		private http: HttpClient,
-		private router: Router,
+		private router: Router
 	) {}
 
 	reloadSession(): Observable<any> {
@@ -49,7 +48,7 @@ export class SessionService {
 				return of(null);
 			}),
 			this.mapUserModelToSession,
-			tap((session) => {
+			tap(session => {
 				this.sessionSubject.next(session);
 			})
 		);
@@ -58,7 +57,7 @@ export class SessionService {
 	signin(username: string, password: string): Observable<any> {
 		return this.authService.signin(username, password).pipe(
 			this.mapUserModelToSession,
-			tap((session) => {
+			tap(session => {
 				this.sessionSubject.next(session);
 			})
 		);
@@ -85,7 +84,7 @@ export class SessionService {
 				return of(null);
 			}),
 			this.mapUserModelToSession,
-			tap((session) => {
+			tap(session => {
 				this.sessionSubject.next(session);
 			})
 		);
@@ -108,7 +107,6 @@ export class SessionService {
 	}
 
 	private goToRoute(url: string, extras?: NavigationExtras) {
-
 		// Redirect the user to a URL
 		if (null == url) {
 			url = '/';
@@ -124,7 +122,7 @@ export class SessionService {
 		}
 
 		// Redirect the user
-		this.router.navigate([ url ], extras).catch(() => {
+		this.router.navigate([url], extras).catch(() => {
 			this.router.navigate(['']);
 		});
 	}
@@ -134,7 +132,7 @@ export class SessionService {
 
 		if (url && -1 !== url.indexOf('?')) {
 			const queryParamString = url.split('?')[1];
-			const paramSegments = (!isEmpty(queryParamString)) ? queryParamString.split('&') : [];
+			const paramSegments = !isEmpty(queryParamString) ? queryParamString.split('&') : [];
 			paramSegments.forEach((segment: string) => {
 				const keyValuePair = segment.split('=');
 				if (keyValuePair.length === 2) {
@@ -145,6 +143,4 @@ export class SessionService {
 
 		return queryParams;
 	}
-
-
 }

--- a/src/app/core/auth/user.model.ts
+++ b/src/app/core/auth/user.model.ts
@@ -4,8 +4,8 @@ export class User {
 	constructor(
 		public userModel: any = {}, // raw User model object,
 		public credentials: Credentials = new Credentials(),
-		public eua?: any) {
-	}
+		public eua?: any
+	) {}
 
 	public setEua(eua: any) {
 		this.eua = eua;

--- a/src/app/core/config.service.ts
+++ b/src/app/core/config.service.ts
@@ -7,7 +7,6 @@ import { Config } from './config.model';
 
 @Injectable()
 export class ConfigService {
-
 	configSubject = new AsyncSubject<Config>();
 
 	constructor(private http: HttpBackend) {
@@ -33,10 +32,9 @@ export class ConfigService {
 
 		this.http.handle(request).subscribe(
 			(httpEvent: HttpEvent<Config>) => {
-
 				if (httpEvent instanceof HttpResponse) {
 					let newConfig = null;
-					const response = (httpEvent as HttpResponse<Config>);
+					const response = httpEvent as HttpResponse<Config>;
 
 					if (response.status >= 200 && response.status < 300) {
 						newConfig = response.body;
@@ -49,6 +47,7 @@ export class ConfigService {
 			() => {
 				this.configSubject.next(null);
 				this.configSubject.complete();
-			});
+			}
+		);
 	}
 }

--- a/src/app/core/core-routing.module.ts
+++ b/src/app/core/core-routing.module.ts
@@ -52,10 +52,7 @@ import { AuthGuard } from './auth/auth.guard';
 			}
 		])
 	],
-	exports: [
-		RouterModule
-	],
-	providers: [ ]
+	exports: [RouterModule],
+	providers: []
 })
-
 export class CoreRoutingModule {}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -19,7 +19,7 @@ import { AuthenticationService } from './auth/authentication.service';
 import { AuthGuard } from './auth/auth.guard';
 import { AuthorizationService } from './auth/authorization.service';
 import { AuthInterceptor } from './auth/auth.interceptor';
-import { ConfigService} from './config.service';
+import { ConfigService } from './config.service';
 import { CoreRoutingModule } from './core-routing.module';
 import { ExportConfigService } from './export-config.service';
 import { LoadingSpinnerModule } from '../common/loading-spinner.module';
@@ -38,15 +38,16 @@ import { UserEuaComponent } from './eua/user-eua.component';
 import { TeamsModule } from './teams/teams.module';
 import { MessagesModule } from './messages/messages.module';
 
-
 export function getConfiguration(configService: ConfigService) {
 	return () => {
-		return configService.getConfig().toPromise().catch((error) => {
-			return { error };
-		});
+		return configService
+			.getConfig()
+			.toPromise()
+			.catch(error => {
+				return { error };
+			});
 	};
 }
-
 
 @NgModule({
 	imports: [
@@ -69,11 +70,7 @@ export function getConfiguration(configService: ConfigService) {
 		SystemAlertModule,
 		MessagesModule
 	],
-	exports: [
-		SiteContainerComponent,
-		UserEuaComponent,
-		AuthorizationDirective
-	],
+	exports: [SiteContainerComponent, UserEuaComponent, AuthorizationDirective],
 	declarations: [
 		AboutComponent,
 		AccessComponent,
@@ -94,7 +91,12 @@ export function getConfiguration(configService: ConfigService) {
 		ExportConfigService,
 		PageTitleService,
 		SessionService,
-		{ provide: APP_INITIALIZER, useFactory: getConfiguration, deps: [ ConfigService ], multi: true },
+		{
+			provide: APP_INITIALIZER,
+			useFactory: getConfiguration,
+			deps: [ConfigService],
+			multi: true
+		},
 		{ provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
 	]
 })

--- a/src/app/core/eua/user-eua.component.ts
+++ b/src/app/core/eua/user-eua.component.ts
@@ -8,30 +8,29 @@ import { SystemAlertService } from '../../common/system-alert.module';
 	templateUrl: 'user-eua.component.html'
 })
 export class UserEuaComponent implements OnInit {
-
 	agree = false;
 
 	eua: any;
 
 	showAlerts = false;
 
-	constructor(
-		private sessionService: SessionService,
-		private alertService: SystemAlertService
-	) {}
+	constructor(private sessionService: SessionService, private alertService: SystemAlertService) {}
 
 	ngOnInit() {
 		this.alertService.clearAllAlerts();
-		this.sessionService.getCurrentEua().subscribe( (eua: any) => this.eua = eua);
+		this.sessionService.getCurrentEua().subscribe((eua: any) => (this.eua = eua));
 	}
 
 	accept() {
 		this.alertService.clearAllAlerts();
 		this.showAlerts = true;
-		this.sessionService.acceptEua().subscribe(() => {
-			this.sessionService.goToPreviousRoute();
-		}, (error: HttpErrorResponse) => {
-			this.alertService.addAlert(error.error.message);
-		});
+		this.sessionService.acceptEua().subscribe(
+			() => {
+				this.sessionService.goToPreviousRoute();
+			},
+			(error: HttpErrorResponse) => {
+				this.alertService.addAlert(error.error.message);
+			}
+		);
 	}
 }

--- a/src/app/core/export-config.service.ts
+++ b/src/app/core/export-config.service.ts
@@ -8,14 +8,11 @@ import { Observable } from 'rxjs';
  * Admin management of users
  */
 export class ExportConfigService {
-
 	constructor(private http: HttpClient) {}
 
 	postExportConfig(type: string, config: any): Observable<any> {
-		return this.http.post(
-			'/api/requestExport',
-			JSON.stringify({ type, config }),
-			{ headers: { 'Content-Type': 'application/json'	} }
-		);
+		return this.http.post('/api/requestExport', JSON.stringify({ type, config }), {
+			headers: { 'Content-Type': 'application/json' }
+		});
 	}
 }

--- a/src/app/core/feedback/admin/admin-list-feedback.component.ts
+++ b/src/app/core/feedback/admin/admin-list-feedback.component.ts
@@ -7,7 +7,8 @@ import {
 	PagingOptions,
 	SortDirection,
 	SortableTableHeader,
-	AbstractPageableDataComponent, SortChange
+	AbstractPageableDataComponent,
+	SortChange
 } from '../../../common/paging.module';
 import { SystemAlertService } from '../../../common/system-alert.module';
 import { ExportConfigService } from '../../export-config.service';
@@ -18,17 +19,28 @@ import { FeedbackService } from '../feedback.service';
 @Component({
 	templateUrl: 'admin-list-feedback.component.html'
 })
-export class AdminListFeedbackComponent extends AbstractPageableDataComponent<any> implements OnInit {
-
+export class AdminListFeedbackComponent extends AbstractPageableDataComponent<any>
+	implements OnInit {
 	headers: SortableTableHeader[] = [
-		{ name: 'Submitted By', sortable: true, sortField: 'audit.actor', sortDir: SortDirection.asc },
+		{
+			name: 'Submitted By',
+			sortable: true,
+			sortField: 'audit.actor',
+			sortDir: SortDirection.asc
+		},
 		{ name: 'Email', sortable: false },
 		{ name: 'Type', sortable: true, sortField: 'type', sortDir: SortDirection.asc },
 		{ name: 'Feedback', sortable: false },
 		{ name: 'Submitted From', sortable: true, sortField: 'url', sortDir: SortDirection.asc },
 		{ name: 'Browser', sortable: true, sortField: 'browser', sortDir: SortDirection.asc },
 		{ name: 'OS', sortable: true, sortField: 'os', sortDir: SortDirection.asc },
-		{ name: 'Submission Time', sortable: true, sortField: 'created', sortDir: SortDirection.desc, default: true }
+		{
+			name: 'Submission Time',
+			sortable: true,
+			sortField: 'created',
+			sortDir: SortDirection.desc,
+			default: true
+		}
 	];
 
 	constructor(
@@ -49,13 +61,20 @@ export class AdminListFeedbackComponent extends AbstractPageableDataComponent<an
 
 	export() {
 		this.exportConfigService
-			.postExportConfig('feedback', { sort: this.pagingOptions.sortField, dir: this.pagingOptions.sortDir })
+			.postExportConfig('feedback', {
+				sort: this.pagingOptions.sortField,
+				dir: this.pagingOptions.sortDir
+			})
 			.subscribe((response: any) => {
 				window.open(`/api/admin/feedback/csv/${response._id}`);
 			});
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<any>> {
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<any>> {
 		return this.feedbackService.getFeedback(pagingOptions, query, search, {});
 	}
 }

--- a/src/app/core/feedback/feedback-flyout/feedback-flyout.component.ts
+++ b/src/app/core/feedback/feedback-flyout/feedback-flyout.component.ts
@@ -16,7 +16,6 @@ import { FeedbackService } from '../feedback.service';
 	styleUrls: ['./feedback-flyout.component.scss']
 })
 export class FeedbackFlyoutComponent implements OnInit {
-
 	@ViewChild(FlyoutComponent, { static: false }) flyout: FlyoutComponent;
 
 	baseUrl = '';
@@ -34,13 +33,19 @@ export class FeedbackFlyoutComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
-		this.configService.getConfig().pipe(first()).subscribe((config: any) => {
-			this.baseUrl = config.app.clientUrl || '';
+		this.configService
+			.getConfig()
+			.pipe(first())
+			.subscribe((config: any) => {
+				this.baseUrl = config.app.clientUrl || '';
 
-			if (Array.isArray(config.feedback.classificationOpts) && !isEmpty(config.feedback.classificationOpts)) {
-				this.classificationOptions = config.feedback.classificationOpts;
-			}
-		});
+				if (
+					Array.isArray(config.feedback.classificationOpts) &&
+					!isEmpty(config.feedback.classificationOpts)
+				) {
+					this.classificationOptions = config.feedback.classificationOpts;
+				}
+			});
 	}
 
 	closeForm() {
@@ -56,15 +61,17 @@ export class FeedbackFlyoutComponent implements OnInit {
 
 		// Get the current URL from the router at the time of submission.
 		this.feedback.currentRoute = `${this.baseUrl}${this.router.url}`;
-		this.feedbackService.submit(this.feedback).subscribe(() => {
-			this.status = 'success';
-			setTimeout(() => {
+		this.feedbackService.submit(this.feedback).subscribe(
+			() => {
+				this.status = 'success';
+				setTimeout(() => {
 					this.closeForm();
-				}, 2000
-			);
-		}, (error: HttpErrorResponse) => {
-			this.status = 'failure';
-			this.errorMsg = error.error.message;
-		});
+				}, 2000);
+			},
+			(error: HttpErrorResponse) => {
+				this.status = 'failure';
+				this.errorMsg = error.error.message;
+			}
+		);
 	}
 }

--- a/src/app/core/feedback/feedback-modal.component.ts
+++ b/src/app/core/feedback/feedback-modal.component.ts
@@ -14,7 +14,6 @@ import { Feedback } from './feedback.model';
 	templateUrl: 'feedback-modal.component.html'
 })
 export class FeedbackModalComponent implements OnInit {
-
 	error: string;
 
 	success: string;
@@ -35,13 +34,19 @@ export class FeedbackModalComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
-		this.configService.getConfig().pipe(first()).subscribe((config: any) => {
-			this.baseUrl = config.app.clientUrl || '';
+		this.configService
+			.getConfig()
+			.pipe(first())
+			.subscribe((config: any) => {
+				this.baseUrl = config.app.clientUrl || '';
 
-			if (Array.isArray(config.feedback.classificationOpts) && !isEmpty(config.feedback.classificationOpts)) {
-				this.classificationOptions = config.feedback.classificationOpts;
-			}
-		});
+				if (
+					Array.isArray(config.feedback.classificationOpts) &&
+					!isEmpty(config.feedback.classificationOpts)
+				) {
+					this.classificationOptions = config.feedback.classificationOpts;
+				}
+			});
 	}
 
 	submit() {
@@ -51,12 +56,15 @@ export class FeedbackModalComponent implements OnInit {
 		// Get the current URL from the router at the time of submission.
 		this.feedback.currentRoute = `${this.baseUrl}${this.router.url}`;
 
-		this.feedbackService.submit(this.feedback).subscribe(() => {
-			this.success = 'Feedback successfully submitted!';
-			setTimeout(() => this.modalRef.hide(), 1500);
-		}, (error: HttpErrorResponse) => {
-			this.submitting = false;
-			this.error = error.error.message;
-		});
+		this.feedbackService.submit(this.feedback).subscribe(
+			() => {
+				this.success = 'Feedback successfully submitted!';
+				setTimeout(() => this.modalRef.hide(), 1500);
+			},
+			(error: HttpErrorResponse) => {
+				this.submitting = false;
+				this.error = error.error.message;
+			}
+		);
 	}
 }

--- a/src/app/core/feedback/feedback-routing.module.ts
+++ b/src/app/core/feedback/feedback-routing.module.ts
@@ -13,7 +13,7 @@ import { AdminComponent } from '../admin/admin.module';
 				path: 'admin',
 				component: AdminComponent,
 				canActivate: [AuthGuard],
-				data: {roles: ['admin']},
+				data: { roles: ['admin'] },
 				children: [
 					{
 						path: 'feedback',
@@ -23,8 +23,6 @@ import { AdminComponent } from '../admin/admin.module';
 			}
 		])
 	],
-	exports: [
-		RouterModule
-	]
+	exports: [RouterModule]
 })
-export class FeedbackRoutingModule { }
+export class FeedbackRoutingModule {}

--- a/src/app/core/feedback/feedback.model.ts
+++ b/src/app/core/feedback/feedback.model.ts
@@ -16,6 +16,5 @@ export class Feedback {
 
 	currentRoute: string;
 
-	constructor() {
-	}
+	constructor() {}
 }

--- a/src/app/core/feedback/feedback.module.ts
+++ b/src/app/core/feedback/feedback.module.ts
@@ -36,25 +36,12 @@ import { SearchInputModule } from '../../common/search-input.module';
 
 		FeedbackRoutingModule
 	],
-	exports: [
-		AdminListFeedbackComponent,
-		FeedbackModalComponent,
-		FeedbackFlyoutComponent
-	],
-	entryComponents: [
-		AdminListFeedbackComponent,
-		FeedbackModalComponent
-	],
-	declarations:   [
-		AdminListFeedbackComponent,
-		FeedbackModalComponent,
-		FeedbackFlyoutComponent
-	],
-	providers:  [
-		FeedbackService
-	],
+	exports: [AdminListFeedbackComponent, FeedbackModalComponent, FeedbackFlyoutComponent],
+	entryComponents: [AdminListFeedbackComponent, FeedbackModalComponent],
+	declarations: [AdminListFeedbackComponent, FeedbackModalComponent, FeedbackFlyoutComponent],
+	providers: [FeedbackService]
 })
-export class FeedbackModule { }
+export class FeedbackModule {}
 export { AdminListFeedbackComponent } from './admin/admin-list-feedback.component';
 export { FeedbackModalComponent } from './feedback-modal.component';
 export { FeedbackService } from './feedback.service';

--- a/src/app/core/feedback/feedback.service.spec.ts
+++ b/src/app/core/feedback/feedback.service.spec.ts
@@ -2,7 +2,6 @@ import { FeedbackService } from './feedback.service';
 import { Feedback } from './feedback.model';
 
 describe('FeedbackService', () => {
-
 	it('should exist', () => {
 		expect(new FeedbackService({} as any, {} as any)).toBeDefined();
 	});
@@ -39,12 +38,8 @@ describe('FeedbackService', () => {
 			feedback.text = 'hello there';
 			feedback.subType = 'Other';
 			feedback.otherText = 'yes';
-			feedback.classification = {prefix: 'K', level: 'OK'};
-			expect(service.getFormattedText(feedback)).toEqual(
-				'K Other - yes\n' +
-				'K hello there'
-			);
+			feedback.classification = { prefix: 'K', level: 'OK' };
+			expect(service.getFormattedText(feedback)).toEqual('K Other - yes\n' + 'K hello there');
 		});
 	});
-
 });

--- a/src/app/core/feedback/feedback.service.ts
+++ b/src/app/core/feedback/feedback.service.ts
@@ -10,24 +10,22 @@ import { Feedback } from './feedback.model';
 
 @Injectable()
 export class FeedbackService {
-
 	static feedbackTypes: any[] = [
 		{ name: 'General Feedback', prompt: 'Ask a question or make a comment' },
 		{ name: 'Feature Request', prompt: 'Suggest a new feature' },
-		{ name: 'Bug Report', prompt: 'Report a bug/error',
+		{
+			name: 'Bug Report',
+			prompt: 'Report a bug/error',
 			subType: {
-				label: 'What\'s the bug/error type?',
+				label: "What's the bug/error type?",
 				types: ['Content or data', 'Styling', 'Technical', 'Other', 'Unsure']
 			}
 		}
 	];
 
-	headers: any = { 'Content-Type': 'application/json'	};
+	headers: any = { 'Content-Type': 'application/json' };
 
-	constructor(
-		private http: HttpClient,
-		private alertService: SystemAlertService
-	) {}
+	constructor(private http: HttpClient, private alertService: SystemAlertService) {}
 
 	getFormattedText(feedback: Feedback): string {
 		let text = '';
@@ -56,16 +54,23 @@ export class FeedbackService {
 		);
 	}
 
-	getFeedback(paging: PagingOptions, query: any, search: string, options: any): Observable<PagingResults> {
-		return this.http.post<PagingResults>(
-			'api/admin/feedback',
-			JSON.stringify({ s: search, q: query, options }),
-			{ params: paging.toObj(), headers: this.headers }
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addAlert(error.error.message);
-				return of(NULL_PAGING_RESULTS);
-			})
-		);
+	getFeedback(
+		paging: PagingOptions,
+		query: any,
+		search: string,
+		options: any
+	): Observable<PagingResults> {
+		return this.http
+			.post<PagingResults>(
+				'api/admin/feedback',
+				JSON.stringify({ s: search, q: query, options }),
+				{ params: paging.toObj(), headers: this.headers }
+			)
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addAlert(error.error.message);
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 }

--- a/src/app/core/help/getting-started/external-links.component.ts
+++ b/src/app/core/help/getting-started/external-links.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { first } from 'rxjs/operators';
 
@@ -9,7 +9,6 @@ import { ConfigService } from '../../config.service';
 	templateUrl: 'external-links.component.html'
 })
 export class ExternalLinksComponent implements OnInit {
-
 	links: any;
 
 	private config: any;
@@ -19,16 +18,18 @@ export class ExternalLinksComponent implements OnInit {
 	constructor(private configService: ConfigService) {}
 
 	ngOnInit() {
-		this.configService.getConfig().pipe(first()).subscribe((config: any) => {
-			this.config = config;
+		this.configService
+			.getConfig()
+			.pipe(first())
+			.subscribe((config: any) => {
+				this.config = config;
 
-			this.externalLinksEnabled = config.welcomeLinks && config.welcomeLinks.enabled;
-			this.links = config.welcomeLinks.links;
-		});
+				this.externalLinksEnabled = config.welcomeLinks && config.welcomeLinks.enabled;
+				this.links = config.welcomeLinks.links;
+			});
 	}
 
 	handleLinkClick(evt: any) {
 		evt.stopPropagation();
 	}
-
 }

--- a/src/app/core/help/getting-started/getting-started-help.component.ts
+++ b/src/app/core/help/getting-started/getting-started-help.component.ts
@@ -1,4 +1,4 @@
-import {Component, Output, EventEmitter, OnInit} from '@angular/core';
+import { Component, Output, EventEmitter, OnInit } from '@angular/core';
 
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
@@ -22,14 +22,18 @@ export class GettingStartedHelpComponent implements OnInit {
 	constructor(private configService: ConfigService) {}
 
 	ngOnInit() {
-		this.configService.getConfig().pipe(first()).subscribe((config: any) => {
-			this.config = config;
-			this.externalLinksEnabled = config.welcomeLinks
-				&& config.welcomeLinks.enabled
-				&& isArray(config.welcomeLinks.links)
-				&& !isEmpty(config.welcomeLinks.links);
-			this.appName = config.app.title;
-		});
+		this.configService
+			.getConfig()
+			.pipe(first())
+			.subscribe((config: any) => {
+				this.config = config;
+				this.externalLinksEnabled =
+					config.welcomeLinks &&
+					config.welcomeLinks.enabled &&
+					isArray(config.welcomeLinks.links) &&
+					!isEmpty(config.welcomeLinks.links);
+				this.appName = config.app.title;
+			});
 	}
 
 	back() {

--- a/src/app/core/help/help-routing.module.ts
+++ b/src/app/core/help/help-routing.module.ts
@@ -20,7 +20,7 @@ export class HelpBreadcrumbResolver implements Resolve<string> {
 				path: 'help',
 				component: HelpComponent,
 				canActivate: [AuthGuard],
-				data: { roles: [ 'user' ] },
+				data: { roles: ['user'] },
 				children: [
 					/**
 					 * Default Route
@@ -38,12 +38,10 @@ export class HelpBreadcrumbResolver implements Resolve<string> {
 						}
 					}
 				]
-			}])
+			}
+		])
 	],
-	exports: [
-	],
-	providers: [
-		HelpBreadcrumbResolver
-	]
+	exports: [],
+	providers: [HelpBreadcrumbResolver]
 })
-export class HelpRoutingModule { }
+export class HelpRoutingModule {}

--- a/src/app/core/help/help-topic-wrapper.component.ts
+++ b/src/app/core/help/help-topic-wrapper.component.ts
@@ -7,12 +7,9 @@ const defaultKey = 'getting-started';
 	template: '<help-topic [key]="key"></help-topic>'
 })
 export class HelpTopicWrapperComponent {
-
 	key: string = defaultKey;
 
-	constructor(
-		private route: ActivatedRoute,
-	) {
+	constructor(private route: ActivatedRoute) {
 		route.params.subscribe((params: Params) => {
 			this.key = params.topic;
 		});

--- a/src/app/core/help/help-topic.component.ts
+++ b/src/app/core/help/help-topic.component.ts
@@ -1,5 +1,10 @@
 import {
-	Component, ComponentFactory, ComponentFactoryResolver, ComponentRef, Input, ViewChild,
+	Component,
+	ComponentFactory,
+	ComponentFactoryResolver,
+	ComponentRef,
+	Input,
+	ViewChild,
 	ViewContainerRef
 } from '@angular/core';
 import values from 'lodash/values';
@@ -15,7 +20,9 @@ export class HelpTopics {
 	}
 
 	static getTopicList(): string[] {
-		return values(this.topicOrder).sort((a, b) => a.ordinal - b.ordinal).map((v) => v.key);
+		return values(this.topicOrder)
+			.sort((a, b) => a.ordinal - b.ordinal)
+			.map(v => v.key);
 	}
 
 	static getTopicTitle(title: string, short: boolean = false): string {
@@ -38,7 +45,9 @@ export class HelpTopicComponent {
 
 		if (null != key && null != HelpTopics.topics[key]) {
 			// Dynamically create the component
-			const factory: ComponentFactory<HelpTopicComponent> = this.resolver.resolveComponentFactory(HelpTopics.topics[key]);
+			const factory: ComponentFactory<HelpTopicComponent> = this.resolver.resolveComponentFactory(
+				HelpTopics.topics[key]
+			);
 			this.componentRef = this.content.createComponent(factory);
 		} else {
 			console.log(`WARNING: No handler for help topic: ${key}.`);
@@ -47,5 +56,5 @@ export class HelpTopicComponent {
 
 	componentRef: ComponentRef<any>;
 
-	constructor(private resolver: ComponentFactoryResolver) { }
+	constructor(private resolver: ComponentFactoryResolver) {}
 }

--- a/src/app/core/help/help.component.ts
+++ b/src/app/core/help/help.component.ts
@@ -16,22 +16,20 @@ export class HelpTopic {
 	styleUrls: ['help.component.scss']
 })
 export class HelpComponent {
-
 	helpTopics: HelpTopic[] = [];
 
 	homeBreadcrumb: Breadcrumb = { label: 'Help', url: '/help' };
 
 	title: string;
 
-	constructor(
-		private route: ActivatedRoute,
-		private router: Router
-	) {
-		this.helpTopics = HelpTopics.getTopicList().map((topic: string) => ({ id: topic, title: HelpTopics.getTopicTitle(topic, true) }));
+	constructor(private route: ActivatedRoute, private router: Router) {
+		this.helpTopics = HelpTopics.getTopicList().map((topic: string) => ({
+			id: topic,
+			title: HelpTopics.getTopicTitle(topic, true)
+		}));
 
 		router.events
-			.pipe(
-				filter((event: Event) => event instanceof NavigationEnd)
-			).subscribe(() => this.title = BreadcrumbService.getBreadcrumbLabel(route.snapshot));
+			.pipe(filter((event: Event) => event instanceof NavigationEnd))
+			.subscribe(() => (this.title = BreadcrumbService.getBreadcrumbLabel(route.snapshot)));
 	}
 }

--- a/src/app/core/help/help.module.ts
+++ b/src/app/core/help/help.module.ts
@@ -23,18 +23,14 @@ import { GettingStartedHelpComponent } from './getting-started/getting-started-h
 		RouterModule
 	],
 	exports: [],
-	entryComponents: [
-		GettingStartedHelpComponent
-	],
-	declarations:   [
+	entryComponents: [GettingStartedHelpComponent],
+	declarations: [
 		ExternalLinksComponent,
 		GettingStartedHelpComponent,
 		HelpComponent,
 		HelpTopicComponent,
 		HelpTopicWrapperComponent
 	],
-	providers:  [
-		HelpTopics
-	]
+	providers: [HelpTopics]
 })
-export class HelpModule { }
+export class HelpModule {}

--- a/src/app/core/messages/admin/admin-messages-routing.module.ts
+++ b/src/app/core/messages/admin/admin-messages-routing.module.ts
@@ -14,7 +14,7 @@ import { AuthGuard } from '../../auth/auth.guard';
 				path: 'admin',
 				component: AdminComponent,
 				canActivate: [AuthGuard],
-				data: { roles: [ 'admin' ] },
+				data: { roles: ['admin'] },
 				children: [
 					{
 						path: 'messages',
@@ -22,14 +22,15 @@ import { AuthGuard } from '../../auth/auth.guard';
 					},
 					{
 						path: 'message',
-						component: CreateMessageComponent,
+						component: CreateMessageComponent
 					},
 					{
 						path: 'message/:id',
 						component: UpdateMessageComponent
 					}
 				]
-			}])
+			}
+		])
 	],
 	exports: []
 })

--- a/src/app/core/messages/admin/admin-messages.module.ts
+++ b/src/app/core/messages/admin/admin-messages.module.ts
@@ -31,13 +31,7 @@ import { SearchInputModule } from 'src/app/common/search-input.module';
 		NgSelectModule
 	],
 	exports: [],
-	declarations: [
-		UpdateMessageComponent,
-		CreateMessageComponent,
-		ListMessagesComponent
-	],
-	providers: [
-	]
+	declarations: [UpdateMessageComponent, CreateMessageComponent, ListMessagesComponent],
+	providers: []
 })
-export class AdminMessagesModule {
-}
+export class AdminMessagesModule {}

--- a/src/app/core/messages/admin/create-message.component.ts
+++ b/src/app/core/messages/admin/create-message.component.ts
@@ -7,17 +7,17 @@ import { ConfigService } from '../../config.service';
 import { SystemAlertService } from 'src/app/common/system-alert.module';
 
 @Component({
-	templateUrl: './manage-message.component.html',
+	templateUrl: './manage-message.component.html'
 })
 export class CreateMessageComponent extends ManageMessageComponent {
-
 	mode = 'admin-create';
 
 	constructor(
 		router: Router,
 		configService: ConfigService,
 		alertService: SystemAlertService,
-		private messageService: MessageService) {
+		private messageService: MessageService
+	) {
 		super(router, configService, alertService);
 	}
 
@@ -33,5 +33,4 @@ export class CreateMessageComponent extends ManageMessageComponent {
 	submitMessage(message: Message) {
 		return this.messageService.create(message);
 	}
-
 }

--- a/src/app/core/messages/admin/edit-message.component.ts
+++ b/src/app/core/messages/admin/edit-message.component.ts
@@ -7,12 +7,10 @@ import { Message } from '../message.class';
 import { ConfigService } from '../../config.service';
 import { SystemAlertService } from 'src/app/common/system-alert.module';
 
-
 @Component({
 	templateUrl: './manage-message.component.html'
 })
 export class UpdateMessageComponent extends ManageMessageComponent {
-
 	mode = 'admin-edit';
 
 	private id: string;
@@ -32,7 +30,7 @@ export class UpdateMessageComponent extends ManageMessageComponent {
 			this.id = params[`id`];
 
 			this.title = 'Edit Message';
-			this.subtitle = 'Make changes to the message\'s information';
+			this.subtitle = "Make changes to the message's information";
 			this.okButtonText = 'Save';
 			this.navigateOnSuccess = '/admin/messages';
 			this.okDisabled = false;
@@ -45,5 +43,4 @@ export class UpdateMessageComponent extends ManageMessageComponent {
 	submitMessage(message: Message) {
 		return this.messageService.update(message);
 	}
-
 }

--- a/src/app/core/messages/admin/list-messages.component.ts
+++ b/src/app/core/messages/admin/list-messages.component.ts
@@ -10,7 +10,9 @@ import {
 	PagingOptions,
 	SortDirection,
 	SortableTableHeader,
-	PagingResults, AbstractPageableDataComponent, SortChange
+	PagingResults,
+	AbstractPageableDataComponent,
+	SortChange
 } from 'src/app/common/paging.module';
 import { SystemAlertService } from 'src/app/common/system-alert.module';
 import { ModalService, ModalAction } from 'src/app/common/modal.module';
@@ -22,8 +24,8 @@ import { MessageService } from '../message.service';
 @Component({
 	templateUrl: './list-messages.component.html'
 })
-export class ListMessagesComponent extends AbstractPageableDataComponent<Message> implements OnInit {
-
+export class ListMessagesComponent extends AbstractPageableDataComponent<Message>
+	implements OnInit {
 	filters: any = {};
 	sort: any;
 
@@ -31,21 +33,31 @@ export class ListMessagesComponent extends AbstractPageableDataComponent<Message
 		{ name: 'Title', sortField: 'title', sortDir: SortDirection.asc, sortable: true },
 		{ name: 'Type', sortField: 'type', sortDir: SortDirection.asc, sortable: true },
 		{ name: 'Created', sortField: 'created', sortDir: SortDirection.desc, sortable: true },
-		{ name: 'Updated', sortField: 'updated', sortDir: SortDirection.desc, sortable: true, default: true }
+		{
+			name: 'Updated',
+			sortField: 'updated',
+			sortDir: SortDirection.desc,
+			sortable: true,
+			default: true
+		}
 	];
 
 	constructor(
 		private messageService: MessageService,
 		public alertService: SystemAlertService,
 		private modalService: ModalService,
-		private route: ActivatedRoute) {
+		private route: ActivatedRoute
+	) {
 		super();
 	}
 
 	ngOnInit() {
 		this.alertService.clearAllAlerts();
 		this.route.params.subscribe((params: Params) => {
-			if (toString(params[`clearCachedFilter`]) === 'true' || null == this.messageService.cache.listMessages) {
+			if (
+				toString(params[`clearCachedFilter`]) === 'true' ||
+				null == this.messageService.cache.listMessages
+			) {
 				this.messageService.cache.listMessages = {};
 			}
 
@@ -71,8 +83,12 @@ export class ListMessagesComponent extends AbstractPageableDataComponent<Message
 		}
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<Message>> {
-		this.messageService.cache.messages = {search, paging: pagingOptions};
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<Message>> {
+		this.messageService.cache.messages = { search, paging: pagingOptions };
 
 		return this.messageService.search(query, search, pagingOptions);
 	}
@@ -81,7 +97,11 @@ export class ListMessagesComponent extends AbstractPageableDataComponent<Message
 		const id = message._id;
 
 		this.modalService
-			.confirm('Delete message?', `Are you sure you want to delete message: "${message.title}" ?`, 'Delete')
+			.confirm(
+				'Delete message?',
+				`Are you sure you want to delete message: "${message.title}" ?`,
+				'Delete'
+			)
 			.pipe(
 				first(),
 				filter((action: ModalAction) => action === ModalAction.OK),
@@ -89,14 +109,16 @@ export class ListMessagesComponent extends AbstractPageableDataComponent<Message
 					return this.messageService.remove(id);
 				})
 			)
-			.subscribe(() => {
-				this.alertService.addAlert(`Deleted message.`, 'success');
-				this.load$.next(true);
-			}, (error: HttpErrorResponse) => {
-				this.alertService.addAlert(error.message);
-			});
+			.subscribe(
+				() => {
+					this.alertService.addAlert(`Deleted message.`, 'success');
+					this.load$.next(true);
+				},
+				(error: HttpErrorResponse) => {
+					this.alertService.addAlert(error.message);
+				}
+			);
 	}
-
 }
 
 AdminTopics.registerTopic({

--- a/src/app/core/messages/admin/manage-message.component.ts
+++ b/src/app/core/messages/admin/manage-message.component.ts
@@ -8,7 +8,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { OnInit } from '@angular/core';
 
 export abstract class ManageMessageComponent implements OnInit {
-
 	message: Message;
 	error: string = null;
 	okDisabled: boolean;
@@ -35,12 +34,11 @@ export abstract class ManageMessageComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
-		this.configService.getConfig()
-			.subscribe((config: any) => {
-				this.config = config;
+		this.configService.getConfig().subscribe((config: any) => {
+			this.config = config;
 
-				this.initialize();
-			});
+			this.initialize();
+		});
 	}
 
 	abstract initialize(): void;
@@ -48,15 +46,14 @@ export abstract class ManageMessageComponent implements OnInit {
 	abstract submitMessage(message: Message): Observable<any>;
 
 	submit() {
-		this.submitMessage(this.message)
-			.subscribe(
-				() => this.router.navigate([this.navigateOnSuccess]),
-				(response: HttpErrorResponse) => {
-					if (response.status >= 400 && response.status < 500) {
-						const errors = response.message.split('\n');
-						this.error = errors.join(', ');
-					}
-				});
+		this.submitMessage(this.message).subscribe(
+			() => this.router.navigate([this.navigateOnSuccess]),
+			(response: HttpErrorResponse) => {
+				if (response.status >= 400 && response.status < 500) {
+					const errors = response.message.split('\n');
+					this.error = errors.join(', ');
+				}
+			}
+		);
 	}
-
 }

--- a/src/app/core/messages/message.service.ts
+++ b/src/app/core/messages/message.service.ts
@@ -8,7 +8,6 @@ import { Observable, BehaviorSubject, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { SystemAlertService } from '../../common/system-alert.module';
 
-
 @Injectable()
 export class MessageService {
 	headers: any = { 'Content-Type': 'application/json' };
@@ -21,29 +20,24 @@ export class MessageService {
 	constructor(
 		private alertService: SystemAlertService,
 		private http: HttpClient,
-		private socketService: SocketService,
+		private socketService: SocketService
 	) {
 		this.initialize();
 	}
 
 	create(message: Message) {
-		return this.http.post(
-			'api/admin/message',
-			JSON.stringify(message),
-			{ headers: this.headers }
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(null);
-			})
-		);
+		return this.http
+			.post('api/admin/message', JSON.stringify(message), { headers: this.headers })
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(null);
+				})
+			);
 	}
 
 	get(id: string) {
-		return this.http.get(
-			`api/admin/message/${id}`,
-			{ headers: this.headers }
-		).pipe(
+		return this.http.get(`api/admin/message/${id}`, { headers: this.headers }).pipe(
 			catchError((error: HttpErrorResponse) => {
 				this.alertService.addClientErrorAlert(error);
 				return of(null);
@@ -55,36 +49,31 @@ export class MessageService {
 	 * Retrieves an array of a field's value for all messages in the system
 	 */
 	getAll(query: any, field: any) {
-		return this.http.post(
-			`api/admin/message/getAll`,
-			{ query, field },
-			{ headers: this.headers }
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(null);
-			})
-		);
+		return this.http
+			.post(`api/admin/message/getAll`, { query, field }, { headers: this.headers })
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(null);
+				})
+			);
 	}
 
 	update(message: Message) {
-		return this.http.post(
-			`api/admin/message/${message._id}`,
-			JSON.stringify(message),
-			{ headers: this.headers }
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(null);
+		return this.http
+			.post(`api/admin/message/${message._id}`, JSON.stringify(message), {
+				headers: this.headers
 			})
-		);
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(null);
+				})
+			);
 	}
 
 	remove(id: string) {
-		return this.http.delete(
-			`api/admin/message/${id}`,
-			{ headers: this.headers }
-		).pipe(
+		return this.http.delete(`api/admin/message/${id}`, { headers: this.headers }).pipe(
 			catchError((error: HttpErrorResponse) => {
 				this.alertService.addClientErrorAlert(error);
 				return of(null);
@@ -92,25 +81,27 @@ export class MessageService {
 		);
 	}
 
-	search(query: any, search: any, paging: PagingOptions = new PagingOptions()): Observable<PagingResults<Message>> {
-		return this.http.post<PagingResults<Message>>(
-			'api/messages',
-			{ q: query, s: search },
-			{ headers: this.headers, params: paging.toObj() },
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(NULL_PAGING_RESULTS);
-			})
-		);
+	search(
+		query: any,
+		search: any,
+		paging: PagingOptions = new PagingOptions()
+	): Observable<PagingResults<Message>> {
+		return this.http
+			.post<PagingResults<Message>>(
+				'api/messages',
+				{ q: query, s: search },
+				{ headers: this.headers, params: paging.toObj() }
+			)
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 
 	recent(): Observable<any[]> {
-		return this.http.post<any>(
-			'api/messages/recent',
-			{},
-			{ headers: this.headers }
-		).pipe(
+		return this.http.post<any>('api/messages/recent', {}, { headers: this.headers }).pipe(
 			catchError((error: HttpErrorResponse) => {
 				this.alertService.addClientErrorAlert(error);
 				return of(null);
@@ -119,16 +110,14 @@ export class MessageService {
 	}
 
 	dismiss(ids: string[]) {
-		return this.http.post(
-			'api/messages/dismiss',
-			{ messageIds: ids },
-			{ headers: this.headers }
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(null);
-			})
-		);
+		return this.http
+			.post('api/messages/dismiss', { messageIds: ids }, { headers: this.headers })
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(null);
+				})
+			);
 	}
 
 	/**
@@ -168,14 +157,13 @@ export class MessageService {
 			this.subscribe();
 		}
 
-		this.messageReceived
-			.subscribe(() => {
-				this.updateNewMessageIndicator();
-			});
+		this.messageReceived.subscribe(() => {
+			this.updateNewMessageIndicator();
+		});
 	}
 
 	updateNewMessageIndicator() {
-		this.recent().subscribe((results) => {
+		this.recent().subscribe(results => {
 			if (results !== null) {
 				this.numMessagesIndicator.next(results.length);
 			}
@@ -188,6 +176,5 @@ export class MessageService {
 			message.setFromModel(payload.message);
 			this.messageReceived.emit(message);
 		}
-	}
-
+	};
 }

--- a/src/app/core/messages/messages-routing.module.ts
+++ b/src/app/core/messages/messages-routing.module.ts
@@ -8,16 +8,14 @@ import { ViewAllMessagesComponent } from './view-all-messages/view-all-messages.
 	declarations: [],
 	imports: [
 		CommonModule,
-		RouterModule.forChild(
-			[
-				{
-					path: 'messages',
-					component: ViewAllMessagesComponent,
-					canActivate: [AuthGuard],
-					data: { roles: [ 'user' ] }
-				}
-			]
-		)
+		RouterModule.forChild([
+			{
+				path: 'messages',
+				component: ViewAllMessagesComponent,
+				canActivate: [AuthGuard],
+				data: { roles: ['user'] }
+			}
+		])
 	]
 })
-export class MessagesRoutingModule { }
+export class MessagesRoutingModule {}

--- a/src/app/core/messages/messages.module.ts
+++ b/src/app/core/messages/messages.module.ts
@@ -21,17 +21,8 @@ import { SearchInputModule } from 'src/app/common/search-input.module';
 		SystemAlertModule,
 		SearchInputModule
 	],
-	exports: [
-		RecentMessagesComponent
-	],
-	declarations: [
-		ViewAllMessagesComponent,
-		RecentMessagesComponent
-	],
-	providers: [
-		MessageService,
-		SocketService
-	]
+	exports: [RecentMessagesComponent],
+	declarations: [ViewAllMessagesComponent, RecentMessagesComponent],
+	providers: [MessageService, SocketService]
 })
-export class MessagesModule {
-}
+export class MessagesModule {}

--- a/src/app/core/messages/recent-messages/recent-messages.component.scss
+++ b/src/app/core/messages/recent-messages/recent-messages.component.scss
@@ -12,7 +12,7 @@ $card-icon-width: 31px;
 	width: $card-width;
 
 	.card-body {
-		padding: .75rem;
+		padding: 0.75rem;
 	}
 
 	.col-alert-icon {

--- a/src/app/core/messages/recent-messages/recent-messages.component.ts
+++ b/src/app/core/messages/recent-messages/recent-messages.component.ts
@@ -12,46 +12,40 @@ import { MessageService } from '../message.service';
 	styleUrls: ['./recent-messages.component.scss']
 })
 export class RecentMessagesComponent implements OnInit {
-
 	@Input() container: any;
 	messages: Message[];
 	loading = false;
 
-	constructor(
-		private messageService: MessageService,
-		private router: Router
-	) { }
+	constructor(private messageService: MessageService, private router: Router) {}
 
 	ngOnInit() {
 		this.messages = [];
 
-		this.messageService.messageReceived
-			.subscribe(() => {
-				// Redo search on a new message
-				this.load();
-			});
+		this.messageService.messageReceived.subscribe(() => {
+			// Redo search on a new message
+			this.load();
+		});
 		this.load();
 	}
 
 	load() {
 		this.loading = true;
-		this.messageService.recent()
-			.subscribe((result) => {
-				const messages = orderBy(result, ['created'], ['desc']);
-				this.messages = messages as Message[];
-				this.messageService.numMessagesIndicator.next(this.messages.length);
-				this.loading = false;
-			});
+		this.messageService.recent().subscribe(result => {
+			const messages = orderBy(result, ['created'], ['desc']);
+			this.messages = messages as Message[];
+			this.messageService.numMessagesIndicator.next(this.messages.length);
+			this.loading = false;
+		});
 	}
 
 	dismissMessage(message: Message) {
-		this.messageService.dismiss([message._id]).subscribe((result) => {
+		this.messageService.dismiss([message._id]).subscribe(result => {
 			this.load();
 		});
 	}
 
 	dismissAll() {
-		this.messageService.dismiss(this.messages.map((m) => m._id)).subscribe(() => {
+		this.messageService.dismiss(this.messages.map(m => m._id)).subscribe(() => {
 			this.load();
 		});
 	}

--- a/src/app/core/messages/view-all-messages/view-all-messages.component.ts
+++ b/src/app/core/messages/view-all-messages/view-all-messages.component.ts
@@ -12,7 +12,6 @@ import { Message } from '../message.class';
 	styleUrls: ['./view-all-messages.component.scss']
 })
 export class ViewAllMessagesComponent implements OnInit {
-
 	pageNumber = 0;
 	messages: Message[] = [];
 	loadMore = true;
@@ -21,13 +20,11 @@ export class ViewAllMessagesComponent implements OnInit {
 
 	@ViewChild(SearchInputComponent, { static: true }) searchInput: SearchInputComponent;
 
-	constructor(
-		private messagesService: MessageService
-	) { }
+	constructor(private messagesService: MessageService) {}
 
 	ngOnInit() {
 		this.loadMessages(this.pageNumber);
-		this.messagesService.messageReceived.subscribe((message) => {
+		this.messagesService.messageReceived.subscribe(message => {
 			this.newMessages = true;
 		});
 	}
@@ -35,7 +32,7 @@ export class ViewAllMessagesComponent implements OnInit {
 	@HostListener('window:scroll')
 	onScroll() {
 		// If at the bottom of the page, load more messages
-		if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight && this.loadMore) {
+		if (window.innerHeight + window.scrollY >= document.body.offsetHeight && this.loadMore) {
 			this.loadMore = false; // Set to false temporarily to avoid multiple loads
 			this.pageNumber++;
 			this.loadMessages(this.pageNumber);
@@ -43,16 +40,22 @@ export class ViewAllMessagesComponent implements OnInit {
 	}
 
 	loadMessages(page: number) {
-		this.messagesService.search({}, this.search, new PagingOptions(page, 20, 0, 0, 'created', SortDirection.desc)).subscribe((messages: PagingResults) => {
-			if (page === 0) {
-				this.messages = messages.elements;
-			} else {
-				this.messages = this.messages.concat(messages.elements);
-			}
-			if (this.messages.length < messages.totalSize) {
-				this.loadMore = true;
-			}
-		});
+		this.messagesService
+			.search(
+				{},
+				this.search,
+				new PagingOptions(page, 20, 0, 0, 'created', SortDirection.desc)
+			)
+			.subscribe((messages: PagingResults) => {
+				if (page === 0) {
+					this.messages = messages.elements;
+				} else {
+					this.messages = this.messages.concat(messages.elements);
+				}
+				if (this.messages.length < messages.totalSize) {
+					this.loadMore = true;
+				}
+			});
 	}
 
 	loadNewMessages() {
@@ -68,5 +71,4 @@ export class ViewAllMessagesComponent implements OnInit {
 		this.pageNumber = 0;
 		this.loadMessages(this.pageNumber);
 	}
-
 }

--- a/src/app/core/page-title.service.ts
+++ b/src/app/core/page-title.service.ts
@@ -10,7 +10,6 @@ import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 
 import { ConfigService } from './config.service';
 
-
 @Injectable()
 export class PageTitleService {
 	constructor(
@@ -21,50 +20,48 @@ export class PageTitleService {
 	) {}
 
 	init() {
-
-		this.configService.getConfig().subscribe((config) => {
+		this.configService.getConfig().subscribe(config => {
 			const appTitle = get(config, 'app.title', null);
 
-			this.router.events.pipe(
-				filter((event) => event instanceof NavigationEnd),
-				map(() => this.activatedRoute),
-				map((route) => {
-					// Get to the leaf route
-					while (null != route.firstChild) {
-						route = route.firstChild;
-					}
-					return route;
-				}),
-				switchMap((route) => route.data),
-				map((data) => {
-
-					try {
-						let pathTitle = data.title;
-
-						// If there wasn't a path title, try to generate one
-						if (null == pathTitle) {
-							pathTitle = this.router.url.split(';')[0]
-								.split('/')
-								.slice(1)
-								.map((frag) => capitalize(frag))
-								.join(' > ');
+			this.router.events
+				.pipe(
+					filter(event => event instanceof NavigationEnd),
+					map(() => this.activatedRoute),
+					map(route => {
+						// Get to the leaf route
+						while (null != route.firstChild) {
+							route = route.firstChild;
 						}
+						return route;
+					}),
+					switchMap(route => route.data),
+					map(data => {
+						try {
+							let pathTitle = data.title;
 
-						if (isEmpty(appTitle) || isEmpty(pathTitle)) {
-							return `${appTitle}${pathTitle}`;
-						} else {
-							return `${appTitle} - ${pathTitle}`;
+							// If there wasn't a path title, try to generate one
+							if (null == pathTitle) {
+								pathTitle = this.router.url
+									.split(';')[0]
+									.split('/')
+									.slice(1)
+									.map(frag => capitalize(frag))
+									.join(' > ');
+							}
+
+							if (isEmpty(appTitle) || isEmpty(pathTitle)) {
+								return `${appTitle}${pathTitle}`;
+							} else {
+								return `${appTitle} - ${pathTitle}`;
+							}
+						} catch {
+							return appTitle;
 						}
-					} catch {
-						return appTitle;
-					}
-
-				})
-			).subscribe((title: string) => {
-				this.titleService.setTitle(title);
-			});
-
+					})
+				)
+				.subscribe((title: string) => {
+					this.titleService.setTitle(title);
+				});
 		});
 	}
-
 }

--- a/src/app/core/signin/signin.component.ts
+++ b/src/app/core/signin/signin.component.ts
@@ -8,10 +8,9 @@ import { SessionService } from '../auth/session.service';
 
 @Component({
 	templateUrl: 'signin.component.html',
-	styleUrls: [ 'signin.component.scss' ]
+	styleUrls: ['signin.component.scss']
 })
 export class SigninComponent implements OnDestroy, OnInit {
-
 	loaded = false;
 	pkiMode = false;
 
@@ -19,11 +18,7 @@ export class SigninComponent implements OnDestroy, OnInit {
 	password: string;
 	error: string;
 
-	constructor(
-		private configService: ConfigService,
-		private sessionService: SessionService
-	) {}
-
+	constructor(private configService: ConfigService, private sessionService: SessionService) {}
 
 	ngOnInit() {
 		this.configService.getConfig().subscribe((config: Config) => {
@@ -39,16 +34,14 @@ export class SigninComponent implements OnDestroy, OnInit {
 
 	signin() {
 		this.sessionService.signin(this.username, this.password).subscribe(
-			(result) => {
+			result => {
 				this.sessionService.goToPreviousRoute();
 			},
-			(error) => {
+			error => {
 				this.error = get(error, 'error.message', 'Unexpected error signing in.');
 			}
 		);
 	}
 
-	ngOnDestroy() {
-
-	}
+	ngOnDestroy() {}
 }

--- a/src/app/core/signup/signup.component.ts
+++ b/src/app/core/signup/signup.component.ts
@@ -15,7 +15,6 @@ import { SystemAlertService } from '../../common/system-alert.module';
 	templateUrl: '../admin/user-management/manage-user.component.html'
 })
 export class SignupComponent extends ManageUserComponent implements OnDestroy, OnInit {
-
 	mode = 'signup';
 
 	inviteId: string;
@@ -61,5 +60,4 @@ export class SignupComponent extends ManageUserComponent implements OnDestroy, O
 	ngOnDestroy() {
 		this.routeParamSubscription.unsubscribe();
 	}
-
 }

--- a/src/app/core/site-container/site-container.component.scss
+++ b/src/app/core/site-container/site-container.component.scss
@@ -69,7 +69,7 @@ footer.site-footer {
 		margin-bottom: $copyright-banner-height;
 	}
 
-	.copyright-active.footer-active &{
+	.copyright-active.footer-active & {
 		margin-bottom: $footer-banner-height + $copyright-banner-height;
 	}
 }

--- a/src/app/core/site-container/site-container.component.ts
+++ b/src/app/core/site-container/site-container.component.ts
@@ -8,10 +8,9 @@ import { ConfigService } from '../config.service';
 @Component({
 	selector: 'site-container',
 	templateUrl: 'site-container.component.html',
-	styleUrls: [ 'site-container.component.scss' ]
+	styleUrls: ['site-container.component.scss']
 })
 export class SiteContainerComponent {
-
 	bannerHtml = undefined;
 	copyrightHtml = undefined;
 	showFeedbackFlyout = false;
@@ -23,7 +22,6 @@ export class SiteContainerComponent {
 			this.showFeedbackFlyout = get(config, 'feedback.showFlyout', false);
 		});
 	}
-
 
 	skipToMainContent(e: any) {
 		e.preventDefault();

--- a/src/app/core/site-navbar/navbar-topic.model.ts
+++ b/src/app/core/site-navbar/navbar-topic.model.ts
@@ -29,5 +29,4 @@ export class NavbarTopics {
 		const topics = values(this.topics);
 		return sortBy(topics, ['ordinal', 'title', 'path']);
 	}
-
 }

--- a/src/app/core/site-navbar/site-navbar.component.scss
+++ b/src/app/core/site-navbar/site-navbar.component.scss
@@ -4,7 +4,6 @@
 @import '../site-container/shared';
 @import './shared';
 
-
 // -------------------------------------------------
 // Navbar offsets given the header/footer setup
 // -------------------------------------------------
@@ -24,7 +23,6 @@
 	bottom: $footer-banner-height + $copyright-banner-height;
 }
 
-
 // -------------------------------------------------
 // Navbar Left
 // A left-docked vertical navigation bar
@@ -42,7 +40,7 @@
 	width: $nav-closed-width;
 	z-index: 10000;
 
-	transition: width .15s ease-in-out;
+	transition: width 0.15s ease-in-out;
 
 	// A normal element
 	.element {
@@ -59,7 +57,8 @@
 			&:hover {
 				color: $nav-element-hover-color;
 			}
-			&:hover, &.highlight-link {
+			&:hover,
+			&.highlight-link {
 				background-color: $nav-element-hover-background-color;
 				cursor: pointer;
 				text-decoration: none;
@@ -90,7 +89,6 @@
 		}
 	}
 
-
 	// A divider element
 	.element-divider {
 		border-bottom: $nav-element-font-color solid 1px;
@@ -106,12 +104,12 @@
 		margin-top: $nav-element-padding;
 	}
 
-
 	// The element that contains the logo
 	.element-logo {
 		padding: 0;
 
-		> a, > a:hover {
+		> a,
+		> a:hover {
 			background-color: $nav-element-logo-color-bg;
 			padding: 0;
 
@@ -152,7 +150,8 @@
 			width: $nav-open-width - 2 * $nav-element-logo-img-margin;
 		}
 
-		.nav-inner-scroll, .nav-collapse {
+		.nav-inner-scroll,
+		.nav-collapse {
 			width: $nav-open-width;
 		}
 	}
@@ -168,11 +167,10 @@
 	}
 }
 
-
 // Offset the content by the width of the navbar
 .navbar-content {
 	margin-left: $nav-closed-width;
-	transition: margin-left .15s ease-in-out;
+	transition: margin-left 0.15s ease-in-out;
 
 	&.navbar-open {
 		margin-left: $nav-open-width;
@@ -215,7 +213,7 @@
 	line-height: 16px;
 	font-size: 12px;
 	font-weight: 500;
-	background: #00ABF4;
+	background: #00abf4;
 	font-family: Roboto, sans-serif;
 
 	.navbar-open & {

--- a/src/app/core/site-navbar/site-navbar.component.ts
+++ b/src/app/core/site-navbar/site-navbar.component.ts
@@ -16,10 +16,9 @@ import { MessageService } from '../messages/message.service';
 @Component({
 	selector: 'site-navbar',
 	templateUrl: 'site-navbar.component.html',
-	styleUrls: [ 'site-navbar.component.scss' ]
+	styleUrls: ['site-navbar.component.scss']
 })
 export class SiteNavbarComponent implements OnInit {
-
 	navbarOpenValue = false;
 
 	adminNavOpen = false;
@@ -64,11 +63,10 @@ export class SiteNavbarComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
-		this.sessionService.getSession()
-			.subscribe((session) => {
-				this.session = session;
-				this.messageService.updateNewMessageIndicator();
-			});
+		this.sessionService.getSession().subscribe(session => {
+			this.session = session;
+			this.messageService.updateNewMessageIndicator();
+		});
 
 		this.configService.getConfig().subscribe((config: Config) => {
 			this.showFeedbackOption = get(config, 'feedback.showInSidebar', true);
@@ -77,7 +75,7 @@ export class SiteNavbarComponent implements OnInit {
 		this.adminMenuItems = AdminTopics.getTopics();
 
 		this.navbarItems = NavbarTopics.getTopics();
-		this.messageService.numMessagesIndicator.subscribe((count) => {
+		this.messageService.numMessagesIndicator.subscribe(count => {
 			this.numNewMessages = count;
 		});
 	}
@@ -87,6 +85,9 @@ export class SiteNavbarComponent implements OnInit {
 	}
 
 	showFeedbackModal() {
-		this.modalService.show(FeedbackModalComponent, { ignoreBackdropClick: true, class: 'modal-lg' });
+		this.modalService.show(FeedbackModalComponent, {
+			ignoreBackdropClick: true,
+			class: 'modal-lg'
+		});
 	}
 }

--- a/src/app/core/socket.service.ts
+++ b/src/app/core/socket.service.ts
@@ -9,23 +9,21 @@ import { SessionService } from './auth/session.service';
 
 @Injectable()
 export class SocketService {
-
 	protected socket: SocketIOClient.Socket;
 
 	constructor(
 		private authorizationService: AuthorizationService,
-		private sessionService: SessionService) {
+		private sessionService: SessionService
+	) {
 		this.initialize();
 	}
 
 	public initialize(): void {
 		// Do not autoconnect when the socket is created.  We will wait to do that ourselves once the
 		// user has logged in.
-		this.socket = io.connect(
-			{
-				autoConnect: false
-			}
-		);
+		this.socket = io.connect({
+			autoConnect: false
+		});
 
 		// If the user is already active, connect to the socket right away.
 		if (this.authorizationService.isAuthenticated()) {

--- a/src/app/core/teams/add-members-modal/add-members-modal.component.ts
+++ b/src/app/core/teams/add-members-modal/add-members-modal.component.ts
@@ -19,7 +19,6 @@ import { AddedMember, TeamsService } from '../teams.service';
 	styleUrls: ['./add-members-modal.component.scss']
 })
 export class AddMembersModalComponent implements OnInit {
-
 	@Input() teamId: string;
 
 	@Output() readonly usersAdded: EventEmitter<number> = new EventEmitter();
@@ -38,16 +37,15 @@ export class AddMembersModalComponent implements OnInit {
 
 	private pagingOptions: PagingOptions = new PagingOptions();
 
-	constructor(
-		private teamsService: TeamsService,
-		public modalRef: BsModalRef
-	) {}
+	constructor(private teamsService: TeamsService, public modalRef: BsModalRef) {}
 
 	ngOnInit() {
 		this.dataSource = new Observable((observer: any) => {
 			observer.next(this.queryUserSearchTerm);
 		}).pipe(
-			mergeMap((token: string) => this.teamsService.searchUsers({}, token, this.pagingOptions, {})),
+			mergeMap((token: string) =>
+				this.teamsService.searchUsers({}, token, this.pagingOptions, {})
+			),
 			map((result: PagingResults) => {
 				return result.elements.map((r: any) => {
 					r.displayName = `${r.userModel.name}  [${r.userModel.username}]`;
@@ -61,12 +59,11 @@ export class AddMembersModalComponent implements OnInit {
 		this.submitting = true;
 
 		// Add users who are already in the system
-		this.teamsService.addMembers(this.addedMembers, this.teamId)
-			.subscribe(() => {
-				this.submitting = false;
-				this.modalRef.hide();
-				this.usersAdded.emit(this.addedMembers.length);
-			});
+		this.teamsService.addMembers(this.addedMembers, this.teamId).subscribe(() => {
+			this.submitting = false;
+			this.modalRef.hide();
+			this.usersAdded.emit(this.addedMembers.length);
+		});
 	}
 
 	remove(ndx: number) {
@@ -85,10 +82,17 @@ export class AddMembersModalComponent implements OnInit {
 	typeaheadOnSelect(e: TypeaheadMatch) {
 		const selectedUsername = get(e, 'item.userModel.username');
 		const selectedUserId = get(e, 'item.userModel._id');
-		if (null != selectedUsername && this.addedMembers.findIndex((u: AddedMember) => u.username === selectedUsername) === -1) {
-			this.addedMembers.push({ username: selectedUsername, _id: selectedUserId, role: this.defaultRole, roleDisplay: TeamRole.getDisplay(this.defaultRole)} as AddedMember);
+		if (
+			null != selectedUsername &&
+			this.addedMembers.findIndex((u: AddedMember) => u.username === selectedUsername) === -1
+		) {
+			this.addedMembers.push({
+				username: selectedUsername,
+				_id: selectedUserId,
+				role: this.defaultRole,
+				roleDisplay: TeamRole.getDisplay(this.defaultRole)
+			} as AddedMember);
 		}
 		this.queryUserSearchTerm = '';
 	}
-
 }

--- a/src/app/core/teams/create-team/create-team.component.ts
+++ b/src/app/core/teams/create-team/create-team.component.ts
@@ -26,7 +26,6 @@ import { TeamsService } from '../teams.service';
 	styleUrls: ['./create-team.component.scss']
 })
 export class CreateTeamComponent implements OnInit {
-
 	team: Team = new Team();
 
 	showExternalTeams = false;
@@ -57,14 +56,14 @@ export class CreateTeamComponent implements OnInit {
 		private sessionService: SessionService,
 		private authenticationService: AuthenticationService,
 		private authorizationService: AuthorizationService,
-		private alertService: SystemAlertService,
-	) {
-	}
+		private alertService: SystemAlertService
+	) {}
 
 	ngOnInit() {
 		this.alertService.clearAllAlerts();
 
-		this.configService.getConfig()
+		this.configService
+			.getConfig()
 			.pipe(first())
 			.subscribe((config: any) => {
 				// Need to show external groups when in proxy-pki mode
@@ -73,19 +72,20 @@ export class CreateTeamComponent implements OnInit {
 				}
 			});
 
-		this.sessionService.getSession()
-			.subscribe((session) => {
-				this.user = session.user;
-				this.isAdmin = this.authorizationService.isAdmin();
-				this.defaultTeamAdmin = this.user.userModel;
-			});
+		this.sessionService.getSession().subscribe(session => {
+			this.user = session.user;
+			this.isAdmin = this.authorizationService.isAdmin();
+			this.defaultTeamAdmin = this.user.userModel;
+		});
 
 		// Bind the search users typeahead to a function
 		if (this.isAdmin) {
 			this.searchUsersRef = new Observable((observer: any) => {
 				observer.next(this.queryUserSearchTerm);
 			}).pipe(
-				mergeMap((token: string) => this.userService.search({}, token, this.pagingOptions, {})),
+				mergeMap((token: string) =>
+					this.userService.search({}, token, this.pagingOptions, {})
+				),
 				map((result: PagingResults) => {
 					return result.elements
 						.filter((user: any) => user._id !== this.defaultTeamAdmin._id)
@@ -108,16 +108,21 @@ export class CreateTeamComponent implements OnInit {
 	save() {
 		this.submitting = true;
 		this.teamsService
-			.create(this.team, (this.defaultTeamAdmin._id !== this.user.userModel._id) ? this.defaultTeamAdmin._id : null)
-			.pipe(
-				tap(() => this.authenticationService.reloadCurrentUser())
+			.create(
+				this.team,
+				this.defaultTeamAdmin._id !== this.user.userModel._id
+					? this.defaultTeamAdmin._id
+					: null
 			)
-			.subscribe(() => {
-				return this.router.navigate(['/teams', {clearCachedFilter: true}]);
-			}, (error: HttpErrorResponse) => {
-				this.submitting = false;
-				this.alertService.addClientErrorAlert(error);
-			});
+			.pipe(tap(() => this.authenticationService.reloadCurrentUser()))
+			.subscribe(
+				() => {
+					return this.router.navigate(['/teams', { clearCachedFilter: true }]);
+				},
+				(error: HttpErrorResponse) => {
+					this.submitting = false;
+					this.alertService.addClientErrorAlert(error);
+				}
+			);
 	}
-
 }

--- a/src/app/core/teams/help/teams-help.component.ts
+++ b/src/app/core/teams/help/teams-help.component.ts
@@ -4,7 +4,6 @@ import { HelpTopics } from '../../help/help-topic.component';
 @Component({
 	templateUrl: './teams-help.component.html'
 })
-export class TeamsHelpComponent {
-}
+export class TeamsHelpComponent {}
 
 HelpTopics.registerTopic('teams', TeamsHelpComponent, 9);

--- a/src/app/core/teams/list-teams/list-teams.component.ts
+++ b/src/app/core/teams/list-teams/list-teams.component.ts
@@ -10,7 +10,8 @@ import {
 	PagingResults,
 	SortDirection,
 	SortableTableHeader,
-	SortChange, AbstractPageableDataComponent
+	SortChange,
+	AbstractPageableDataComponent
 } from '../../../common/paging.module';
 
 @Component({
@@ -18,17 +19,32 @@ import {
 	styleUrls: ['./list-teams.component.scss']
 })
 export class ListTeamsComponent extends AbstractPageableDataComponent<Team> implements OnInit {
-
 	headers: SortableTableHeader[] = [
-		{ name: 'Name', sortable: true, sortField: 'name', sortDir: SortDirection.asc, tooltip: 'Sort by Team Name', default: true },
-		{ name: 'Created', sortable: true, sortField: 'created', sortDir: SortDirection.desc, tooltip: 'Sort by Created' },
-		{ name: 'Description', sortable: true, sortField: 'description', sortDir: SortDirection.desc, tooltip: 'Sort by Description' }
+		{
+			name: 'Name',
+			sortable: true,
+			sortField: 'name',
+			sortDir: SortDirection.asc,
+			tooltip: 'Sort by Team Name',
+			default: true
+		},
+		{
+			name: 'Created',
+			sortable: true,
+			sortField: 'created',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Created'
+		},
+		{
+			name: 'Description',
+			sortable: true,
+			sortField: 'description',
+			sortDir: SortDirection.desc,
+			tooltip: 'Sort by Description'
+		}
 	];
 
-	constructor(
-		private teamsService: TeamsService,
-		private alertService: SystemAlertService
-	) {
+	constructor(private teamsService: TeamsService, private alertService: SystemAlertService) {
 		super();
 	}
 
@@ -40,7 +56,11 @@ export class ListTeamsComponent extends AbstractPageableDataComponent<Team> impl
 		super.ngOnInit();
 	}
 
-	loadData(pagingOptions: PagingOptions, search: string, query: any): Observable<PagingResults<Team>> {
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<Team>> {
 		return this.teamsService.search(pagingOptions, query, search, {});
 	}
 }

--- a/src/app/core/teams/team-authorization.service.ts
+++ b/src/app/core/teams/team-authorization.service.ts
@@ -13,19 +13,20 @@ type TeamIdObj = Team | { _id: string };
 
 @Injectable()
 export class TeamAuthorizationService {
-
 	private member: TeamMember;
 
-	constructor(
-		private sessionService: SessionService
-	) {
-		this.sessionService.getSession()
+	constructor(private sessionService: SessionService) {
+		this.sessionService
+			.getSession()
 			.pipe(
 				first(),
-				map((session: Session) => new TeamMember().setFromTeamMemberModel(null, session.user.userModel))
-			).subscribe((member: TeamMember) => {
-			this.member = member;
-		});
+				map((session: Session) =>
+					new TeamMember().setFromTeamMemberModel(null, session.user.userModel)
+				)
+			)
+			.subscribe((member: TeamMember) => {
+				this.member = member;
+			});
 	}
 
 	hasTeams(): boolean {

--- a/src/app/core/teams/team-member.model.ts
+++ b/src/app/core/teams/team-member.model.ts
@@ -7,7 +7,6 @@ import { Team } from './team.model';
 import { TeamRole } from './team-role.model';
 
 export class TeamMember extends User {
-
 	public explicit = false;
 
 	public active = false;
@@ -24,7 +23,7 @@ export class TeamMember extends User {
 		return this.userModel.teams.length > 0;
 	}
 
-	public getRoleInTeam(team: Team| { _id: string }): string {
+	public getRoleInTeam(team: Team | { _id: string }): string {
 		if (null != this.userModel) {
 			const teams = get(this, 'userModel.teams', []);
 			// Find the role of this user in the team
@@ -52,12 +51,13 @@ export class TeamMember extends User {
 			}
 
 			// Determine if user is implicit/explicit and active/inactive
-			this.explicit = (null != userModel.teams && userModel.teams.length > 0);
+			this.explicit = null != userModel.teams && userModel.teams.length > 0;
 
 			if (userModel.bypassAccessCheck) {
 				this.active = true;
 			} else if (null != team) {
-				this.active = (0 === difference(team.requiresExternalTeams, userModel.externalGroups).length);
+				this.active =
+					0 === difference(team.requiresExternalTeams, userModel.externalGroups).length;
 			}
 		}
 

--- a/src/app/core/teams/team-role.model.ts
+++ b/src/app/core/teams/team-role.model.ts
@@ -1,14 +1,21 @@
 export class TeamRole {
+	public static VIEW_ONLY: TeamRole = new TeamRole(
+		'View Only',
+		'This user can view resources within this team.',
+		'member'
+	);
+	public static EDITOR: TeamRole = new TeamRole(
+		'Editor',
+		'This user has member privileges and can also create and manage resources within this team',
+		'editor'
+	);
+	public static ADMIN: TeamRole = new TeamRole(
+		'Admin',
+		'This user has editor privileges and can also manage team membership',
+		'admin'
+	);
 
-	public static VIEW_ONLY: TeamRole = new TeamRole('View Only', 'This user can view resources within this team.', 'member');
-	public static EDITOR: TeamRole = new TeamRole('Editor', 'This user has member privileges and can also create and manage resources within this team', 'editor');
-	public static ADMIN: TeamRole = new TeamRole('Admin', 'This user has editor privileges and can also manage team membership', 'admin');
-
-	constructor(
-		public label: string,
-		public description: string,
-		public role: string
-	) {}
+	constructor(public label: string, public description: string, public role: string) {}
 
 	public static get ROLES(): TeamRole[] {
 		return [this.VIEW_ONLY, this.EDITOR, this.ADMIN];
@@ -16,7 +23,6 @@ export class TeamRole {
 
 	static getDisplay(role: string): string {
 		const teamRole: TeamRole = TeamRole.ROLES.find((tr: TeamRole) => tr.role === role);
-		return (null != teamRole) ? teamRole.label : 'Unknown';
+		return null != teamRole ? teamRole.label : 'Unknown';
 	}
-
 }

--- a/src/app/core/teams/team.model.ts
+++ b/src/app/core/teams/team.model.ts
@@ -10,7 +10,7 @@ export class Team {
 		public created?: number,
 		public requiresExternalTeams?: string[]
 	) {
-		this.requiresExternalTeams = (null == requiresExternalTeams) ? [] : requiresExternalTeams;
+		this.requiresExternalTeams = null == requiresExternalTeams ? [] : requiresExternalTeams;
 	}
 
 	setFromModel(model: any): Team {
@@ -34,4 +34,3 @@ export class Team {
 		return false;
 	}
 }
-

--- a/src/app/core/teams/teams-routing.module.ts
+++ b/src/app/core/teams/teams-routing.module.ts
@@ -14,29 +14,27 @@ import { TeamsResolve } from './teams.resolver';
 				path: 'teams',
 				component: ListTeamsComponent,
 				canActivate: [AuthGuard],
-				data: { roles: [ 'user' ] }
+				data: { roles: ['user'] }
 			},
 			{
 				path: 'team/create',
 				component: CreateTeamComponent,
 				canActivate: [AuthGuard],
 				data: {
-					roles: [ 'editor' ]
+					roles: ['editor']
 				}
 			},
 			{
 				path: 'team/:id',
 				component: ViewTeamComponent,
 				canActivate: [AuthGuard],
-				data: { roles: [ 'user' ] },
+				data: { roles: ['user'] },
 				resolve: {
 					team: TeamsResolve
 				}
 			}
 		])
 	],
-	exports: [
-		RouterModule
-	]
+	exports: [RouterModule]
 })
-export class TeamsRoutingModule { }
+export class TeamsRoutingModule {}

--- a/src/app/core/teams/teams.module.ts
+++ b/src/app/core/teams/teams.module.ts
@@ -44,10 +44,7 @@ import { TeamsRoutingModule } from './teams-routing.module';
 
 		TeamsRoutingModule
 	],
-	entryComponents: [
-		AddMembersModalComponent,
-		TeamsHelpComponent
-	],
+	entryComponents: [AddMembersModalComponent, TeamsHelpComponent],
 	declarations: [
 		AddMembersModalComponent,
 		CreateTeamComponent,
@@ -56,11 +53,6 @@ import { TeamsRoutingModule } from './teams-routing.module';
 		ViewTeamComponent,
 		TeamsHelpComponent
 	],
-	providers: [
-		TeamAuthorizationService,
-		TeamsService,
-		TeamsResolve
-	]
+	providers: [TeamAuthorizationService, TeamsService, TeamsResolve]
 })
-export class TeamsModule {
-}
+export class TeamsModule {}

--- a/src/app/core/teams/teams.resolver.ts
+++ b/src/app/core/teams/teams.resolver.ts
@@ -6,10 +6,7 @@ import { TeamsService } from './teams.service';
 
 @Injectable()
 export class TeamsResolve implements Resolve<Team> {
-
-	constructor(
-		private teamsService: TeamsService
-	) {}
+	constructor(private teamsService: TeamsService) {}
 
 	resolve(route: ActivatedRouteSnapshot) {
 		return this.teamsService.get(route.paramMap.get('id'));

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -24,7 +24,6 @@ export interface AddedMember {
 
 @Injectable()
 export class TeamsService {
-
 	headers: any = { 'Content-Type': 'application/json' };
 
 	constructor(
@@ -32,32 +31,44 @@ export class TeamsService {
 		private sessionService: SessionService,
 		private alertService: SystemAlertService,
 		private authorizationService: AuthorizationService,
-		private teamAuthorizationService: TeamAuthorizationService) {
-	}
+		private teamAuthorizationService: TeamAuthorizationService
+	) {}
 
 	// create(team: Team, firstAdmin?: any): Observable<any> {
 	// 	return this.asyHttp.put(new HttpOptions('team', () => { }, { team, firstAdmin }));
 	// }
 
 	create(team: Team, firstAdmin?: string): Observable<any> {
-		return this.http.put(
-			`api/team`,
-			JSON.stringify({
-				team,
-				firstAdmin: firstAdmin ? firstAdmin : null
-			}),
-			{ headers: this.headers }
-		).pipe(
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(null);
-			})
-		);
+		return this.http
+			.put(
+				`api/team`,
+				JSON.stringify({
+					team,
+					firstAdmin: firstAdmin ? firstAdmin : null
+				}),
+				{ headers: this.headers }
+			)
+			.pipe(
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(null);
+				})
+			);
 	}
 
 	get(teamId: string): Observable<Team> {
 		return this.http.get(`api/team/${teamId}`).pipe(
-			map((result: any) => (null != result) ? new Team(result._id, result.name, result.description, result.created, result.requiresExternalTeams) : null),
+			map((result: any) =>
+				null != result
+					? new Team(
+							result._id,
+							result.name,
+							result.description,
+							result.created,
+							result.requiresExternalTeams
+					  )
+					: null
+			),
 			catchError((error: HttpErrorResponse) => {
 				this.alertService.addClientErrorAlert(error);
 				return of(null);
@@ -66,35 +77,56 @@ export class TeamsService {
 	}
 
 	update(id: string, updateData: any): Observable<Team> {
-		return this.http.post(
-			`api/team/${id}`,
-			JSON.stringify(updateData),
-			{ headers: this.headers }
-		).pipe(
-			map((result: any) => (null != result) ? new Team(result._id, result.name, result.description, result.created, result.requiresExternalTeams) : null),
-			catchError((error: HttpErrorResponse) => {
-				this.alertService.addClientErrorAlert(error);
-				return of(null);
-			})
-		);
+		return this.http
+			.post(`api/team/${id}`, JSON.stringify(updateData), { headers: this.headers })
+			.pipe(
+				map((result: any) =>
+					null != result
+						? new Team(
+								result._id,
+								result.name,
+								result.description,
+								result.created,
+								result.requiresExternalTeams
+						  )
+						: null
+				),
+				catchError((error: HttpErrorResponse) => {
+					this.alertService.addClientErrorAlert(error);
+					return of(null);
+				})
+			);
 	}
 
-	search(paging: PagingOptions, query: any, search: string = null, options: any): Observable<PagingResults<Team>> {
-		return this.http.post(
-			'api/teams',
-			JSON.stringify({s: search, q: query, options}),
-			{ params: paging.toObj(), headers: this.headers }
-		).pipe(
-			map((result: PagingResults) => {
-				if (null != result && Array.isArray(result.elements)) {
-					result.elements = result.elements.map((element: any) => new Team(element._id, element.name, element.description, element.created).setFromModel(element));
-				}
-				return result;
-			}),
-			catchError(() => {
-				return of(NULL_PAGING_RESULTS);
+	search(
+		paging: PagingOptions,
+		query: any,
+		search: string = null,
+		options: any
+	): Observable<PagingResults<Team>> {
+		return this.http
+			.post('api/teams', JSON.stringify({ s: search, q: query, options }), {
+				params: paging.toObj(),
+				headers: this.headers
 			})
-		);
+			.pipe(
+				map((result: PagingResults) => {
+					if (null != result && Array.isArray(result.elements)) {
+						result.elements = result.elements.map((element: any) =>
+							new Team(
+								element._id,
+								element.name,
+								element.description,
+								element.created
+							).setFromModel(element)
+						);
+					}
+					return result;
+				}),
+				catchError(() => {
+					return of(NULL_PAGING_RESULTS);
+				})
+			);
 	}
 
 	delete(teamId: string): Observable<any> {
@@ -102,30 +134,34 @@ export class TeamsService {
 	}
 
 	addMember(teamId: string, memberId: string, role?: string): Observable<any> {
-		return this.http.post(
-			`api/team/${teamId}/member/${memberId}`,
-			JSON.stringify({ role }),
-			{ headers: this.headers }
-		);
+		return this.http.post(`api/team/${teamId}/member/${memberId}`, JSON.stringify({ role }), {
+			headers: this.headers
+		});
 	}
 
 	addMembers(newMembers: AddedMember[], teamId: string): Observable<any> {
-		return this.http.put(
-			`api/team/${teamId}/members`,
-			JSON.stringify({ newMembers }),
-			{ headers: this.headers }
-		);
+		return this.http.put(`api/team/${teamId}/members`, JSON.stringify({ newMembers }), {
+			headers: this.headers
+		});
 	}
 
-	searchMembers(team: Team, query: any, search: any, paging: PagingOptions, options: any): Observable<PagingResults> {
-		return this.http.post(
-			`api/team/${team._id}/members?`,
-			JSON.stringify({s: search, q: query, options}),
-			{ params: paging.toObj(), headers: this.headers }
-		).pipe(
-			map((result: PagingResults) => this.handleTeamMembers(result, team)),
-			catchError(() => of(NULL_PAGING_RESULTS))
-		);
+	searchMembers(
+		team: Team,
+		query: any,
+		search: any,
+		paging: PagingOptions,
+		options: any
+	): Observable<PagingResults> {
+		return this.http
+			.post(
+				`api/team/${team._id}/members?`,
+				JSON.stringify({ s: search, q: query, options }),
+				{ params: paging.toObj(), headers: this.headers }
+			)
+			.pipe(
+				map((result: PagingResults) => this.handleTeamMembers(result, team)),
+				catchError(() => of(NULL_PAGING_RESULTS))
+			);
 	}
 
 	removeMember(teamId: string, memberId: string): Observable<any> {
@@ -135,7 +171,7 @@ export class TeamsService {
 	updateMemberRole(teamId: string, memberId: string, role: string): Observable<any> {
 		return this.http.post(
 			`api/team/${teamId}/member/${memberId}/role`,
-			JSON.stringify( { role }),
+			JSON.stringify({ role }),
 			{ headers: this.headers }
 		);
 	}
@@ -152,32 +188,41 @@ export class TeamsService {
 	getTeamsCanManageResources(): Observable<Team[]> {
 		return this.getTeams().pipe(
 			map((teams: Team[]) => {
-				return teams.filter((team) => {
-					return this.authorizationService.isAdmin()
-						|| this.teamAuthorizationService.canManageResources(team);
+				return teams.filter(team => {
+					return (
+						this.authorizationService.isAdmin() ||
+						this.teamAuthorizationService.canManageResources(team)
+					);
 				});
 			})
 		);
 	}
 
-	searchUsers(query: any, search: string, paging: PagingOptions, options: any): Observable<PagingResults> {
-		return this.http.post(
-			'api/users',
-			{ q: query, s: search, options },
-			{ params: paging.toObj() }
-		).pipe(
-			map((results: PagingResults) => {
-				if (null != results && isArray(results.elements)) {
-					results.elements = results.elements.map((element: any) => new User().setFromUserModel(element));
-				}
-				return results;
-			})
-		);
+	searchUsers(
+		query: any,
+		search: string,
+		paging: PagingOptions,
+		options: any
+	): Observable<PagingResults> {
+		return this.http
+			.post('api/users', { q: query, s: search, options }, { params: paging.toObj() })
+			.pipe(
+				map((results: PagingResults) => {
+					if (null != results && isArray(results.elements)) {
+						results.elements = results.elements.map((element: any) =>
+							new User().setFromUserModel(element)
+						);
+					}
+					return results;
+				})
+			);
 	}
 
 	private handleTeamMembers(result: any, team: Team) {
 		if (null != result && Array.isArray(result.elements)) {
-			result.elements = result.elements.map((element: any) => new TeamMember().setFromTeamMemberModel(team, element));
+			result.elements = result.elements.map((element: any) =>
+				new TeamMember().setFromTeamMemberModel(team, element)
+			);
 		}
 		return result;
 	}

--- a/src/app/core/teams/view-team/view-team.component.ts
+++ b/src/app/core/teams/view-team/view-team.component.ts
@@ -22,7 +22,6 @@ import { TeamAuthorizationService } from '../team-authorization.service';
 	styleUrls: ['./view-team.component.scss']
 })
 export class ViewTeamComponent implements OnInit {
-
 	team: Team;
 	_team: any;
 
@@ -39,13 +38,10 @@ export class ViewTeamComponent implements OnInit {
 		private authenticationService: AuthenticationService,
 		private authorizationService: AuthorizationService,
 		private teamAuthorizationService: TeamAuthorizationService
-	) {
-	}
+	) {}
 
 	ngOnInit() {
-		this.route.data.pipe(
-			map((data) => data.team)
-		).subscribe((team) => {
+		this.route.data.pipe(map(data => data.team)).subscribe(team => {
 			this.updateTeam(team);
 		});
 	}
@@ -60,10 +56,9 @@ export class ViewTeamComponent implements OnInit {
 	}
 
 	saveEdit() {
-		this.teamsService.update(this.team._id, this._team)
-			.pipe(
-				tap(() => this.authenticationService.reloadCurrentUser())
-			)
+		this.teamsService
+			.update(this.team._id, this._team)
+			.pipe(tap(() => this.authenticationService.reloadCurrentUser()))
 			.subscribe((team: Team) => {
 				this.isEditing = false;
 				this.team = team;
@@ -74,9 +69,10 @@ export class ViewTeamComponent implements OnInit {
 	updateTeam(team: any) {
 		if (null != team) {
 			this.team = team;
-			this.canManageTeam = this.authorizationService.isAdmin() || this.teamAuthorizationService.isAdmin(team);
+			this.canManageTeam =
+				this.authorizationService.isAdmin() || this.teamAuthorizationService.isAdmin(team);
 		} else {
-			this.router.navigate(['resource/invalid', {type: 'team'}]);
+			this.router.navigate(['resource/invalid', { type: 'team' }]);
 		}
 	}
 
@@ -86,7 +82,8 @@ export class ViewTeamComponent implements OnInit {
 				'Delete team?',
 				`Are you sure you want to delete the team: <strong>"${this.team.name}"</strong>?<br/>This action cannot be undone.`,
 				'Delete'
-			).pipe(
+			)
+			.pipe(
 				first(),
 				filter((action: ModalAction) => action === ModalAction.OK),
 				switchMap(() => this.teamsService.delete(this.team._id)),
@@ -95,7 +92,7 @@ export class ViewTeamComponent implements OnInit {
 					this.alertService.addClientErrorAlert(error);
 					return of(null);
 				})
-			).subscribe(() => this.router.navigate(['/teams', {clearCachedFilter: true}]));
+			)
+			.subscribe(() => this.router.navigate(['/teams', { clearCachedFilter: true }]));
 	}
-
 }

--- a/src/app/core/unauthorized.component.ts
+++ b/src/app/core/unauthorized.component.ts
@@ -6,14 +6,12 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 		<div class="container">
 			<div class="row">
 				<div class="col-md-8 offset-2 jumbotron" style="margin-top: 4rem;">
-
 					<h1 [innerHTML]="title"></h1>
 					<p [innerHTML]="message"></p>
-
 				</div>
 			</div>
 		</div>
-	`,
+	`
 })
 export class UnauthorizedComponent {
 	title = `&#x0CA0;_&#x0CA0;<br/><br/>Not Authorized`;

--- a/src/app/site/example/example-routing.module.ts
+++ b/src/app/site/example/example-routing.module.ts
@@ -8,7 +8,6 @@ import { SearchComponent } from './search.component';
 import { WelcomeComponent } from './welcome.component';
 import { GridComponent } from './grid/grid.component';
 
-
 @NgModule({
 	imports: [
 		RouterModule.forChild([
@@ -20,32 +19,30 @@ import { GridComponent } from './grid/grid.component';
 			{
 				path: 'welcome',
 				component: WelcomeComponent,
-				canActivate: [ AuthGuard ]
+				canActivate: [AuthGuard]
 			},
 			{
 				path: 'explore',
 				component: ExploreComponent,
-				canActivate: [ AuthGuard ]
+				canActivate: [AuthGuard]
 			},
 			{
 				path: 'search',
 				component: SearchComponent,
-				canActivate: [ AuthGuard ]
+				canActivate: [AuthGuard]
 			},
 			{
 				path: 'forms',
 				component: FormsComponent,
-				canActivate: [ AuthGuard ]
+				canActivate: [AuthGuard]
 			},
 			{
 				path: 'grid',
 				component: GridComponent,
-				canActivate: [ AuthGuard ]
+				canActivate: [AuthGuard]
 			}
 		])
 	],
-	exports: [
-		RouterModule
-	]
+	exports: [RouterModule]
 })
-export class ExampleRoutingModule { }
+export class ExampleRoutingModule {}

--- a/src/app/site/example/example.module.ts
+++ b/src/app/site/example/example.module.ts
@@ -12,17 +12,10 @@ import { ExampleHelpComponent } from './help/example-help.component';
 import { FormsComponent } from './forms/forms.component';
 import { GridComponent } from './grid/grid.component';
 
-
 @NgModule({
-	imports: [
-		ExampleRoutingModule,
-		NgSelectModule
-	],
-	entryComponents: [
-		ExampleHelpComponent
-	],
-	exports: [
-	],
+	imports: [ExampleRoutingModule, NgSelectModule],
+	entryComponents: [ExampleHelpComponent],
+	exports: [],
 	declarations: [
 		ExploreComponent,
 		SearchComponent,
@@ -31,8 +24,6 @@ import { GridComponent } from './grid/grid.component';
 		FormsComponent,
 		GridComponent
 	],
-	providers: [
-		AuthGuard
-	]
+	providers: [AuthGuard]
 })
-export class ExampleModule { }
+export class ExampleModule {}

--- a/src/app/site/example/explore.component.ts
+++ b/src/app/site/example/explore.component.ts
@@ -10,13 +10,11 @@ import { NavbarTopics } from '../../core/core.module';
 					<p>Simple demonstration of routing.</p>
 				</div>
 			</div>
-		</div>`,
-	styles: [ '' ]
+		</div>
+	`,
+	styles: ['']
 })
-export class ExploreComponent {
-
-
-}
+export class ExploreComponent {}
 
 NavbarTopics.registerTopic({
 	id: 'explore',

--- a/src/app/site/example/forms/forms.component.ts
+++ b/src/app/site/example/forms/forms.component.ts
@@ -11,7 +11,6 @@ export class FormsComponent {
 	}
 }
 
-
 NavbarTopics.registerTopic({
 	id: 'forms',
 	title: 'Forms',

--- a/src/app/site/example/grid/grid.component.scss
+++ b/src/app/site/example/grid/grid.component.scss
@@ -1,17 +1,18 @@
 .row {
 	> .col,
-	> [class^="col-"] {
-		padding-top: .75rem;
-		padding-bottom: .75rem;
-		background-color: rgba(86, 61, 124, .15);
-		border: 1px solid rgba(86, 61, 124, .2);
+	> [class^='col-'] {
+		padding-top: 0.75rem;
+		padding-bottom: 0.75rem;
+		background-color: rgba(86, 61, 124, 0.15);
+		border: 1px solid rgba(86, 61, 124, 0.2);
 	}
 }
 
-.row+.row {
+.row + .row {
 	margin-top: 1rem;
 }
 
-.container, .container-fluid {
+.container,
+.container-fluid {
 	margin: 1rem 0;
 }

--- a/src/app/site/example/grid/grid.component.ts
+++ b/src/app/site/example/grid/grid.component.ts
@@ -6,9 +6,7 @@ import { NavbarTopics } from '../../../core/core.module';
 	templateUrl: './grid.component.html',
 	styleUrls: ['./grid.component.scss']
 })
-export class GridComponent {
-}
-
+export class GridComponent {}
 
 NavbarTopics.registerTopic({
 	id: 'grid',

--- a/src/app/site/example/search.component.ts
+++ b/src/app/site/example/search.component.ts
@@ -10,13 +10,11 @@ import { NavbarTopics } from '../../core/core.module';
 					<p>Simple demonstration of routing.</p>
 				</div>
 			</div>
-		</div>`,
-	styles: [ '' ]
+		</div>
+	`,
+	styles: ['']
 })
-export class SearchComponent {
-
-
-}
+export class SearchComponent {}
 
 NavbarTopics.registerTopic({
 	id: 'search',

--- a/src/app/site/example/shared/example-mock.service.ts
+++ b/src/app/site/example/shared/example-mock.service.ts
@@ -8,7 +8,6 @@ import { ExampleService } from './example.service';
 
 @Injectable()
 export class ExampleMockService extends ExampleService {
-
 	constructor(private http: HttpClient) {
 		super();
 	}
@@ -31,5 +30,4 @@ export class ExampleMockService extends ExampleService {
 			}
 		]);
 	}
-
 }

--- a/src/app/site/example/shared/example-rest.service.ts
+++ b/src/app/site/example/shared/example-rest.service.ts
@@ -8,7 +8,6 @@ import { ExampleService } from './example.service';
 
 @Injectable()
 export class ExampleRestService extends ExampleService {
-
 	constructor(private http: HttpClient) {
 		super();
 	}
@@ -18,7 +17,6 @@ export class ExampleRestService extends ExampleService {
 	 */
 
 	public getExamples(): Observable<Example[]> {
-		return this.http.get<Example []>(`api/example`);
+		return this.http.get<Example[]>(`api/example`);
 	}
-
 }

--- a/src/app/site/example/shared/example.service.ts
+++ b/src/app/site/example/shared/example.service.ts
@@ -6,7 +6,5 @@ import { Example } from './example.model';
 
 @Injectable()
 export abstract class ExampleService {
-
 	abstract getExamples(): Observable<Example[]>;
-
 }

--- a/src/app/site/example/welcome.component.ts
+++ b/src/app/site/example/welcome.component.ts
@@ -9,9 +9,8 @@ import { Component } from '@angular/core';
 					<p>Simple demonstration of routing.</p>
 				</div>
 			</div>
-		</div>`,
-	styles: [ '' ]
+		</div>
+	`,
+	styles: ['']
 })
-export class WelcomeComponent {
-
-}
+export class WelcomeComponent {}

--- a/src/app/site/site.module.ts
+++ b/src/app/site/site.module.ts
@@ -5,17 +5,9 @@ import { AuthGuard, CoreModule } from '../core/core.module';
 import { ExampleModule } from './example/example.module';
 
 @NgModule({
-	imports: [
-		CoreModule,
-		ExampleModule
-	],
-	exports: [
-
-	],
-	declarations: [
-	],
-	providers: [
-		AuthGuard
-	]
+	imports: [CoreModule, ExampleModule],
+	exports: [],
+	declarations: [],
+	providers: [AuthGuard]
 })
-export class SiteModule { }
+export class SiteModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,6 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
-// REMOVEME: Testing precommit hooks.
-
 if (environment.production) {
 	enableProdMode();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,12 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+// REMOVEME: Testing precommit hooks.
+
 if (environment.production) {
 	enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-	.catch((err) => console.error(err));
+platformBrowserDynamic()
+	.bootstrapModule(AppModule)
+	.catch(err => console.error(err));

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -15,9 +15,8 @@
  */
 
 /***************************************************************************************************
-* BROWSER POLYFILLS
-*/
-
+ * BROWSER POLYFILLS
+ */
 
 /**
  * If the application will be indexed by Google Search, the following is required.
@@ -57,8 +56,7 @@ import 'core-js/es6/reflect';
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
-
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -43,7 +43,8 @@ html {
 	}
 }
 
-.back-link, .text-decoration-underline {
+.back-link,
+.text-decoration-underline {
 	text-decoration: underline;
 }
 
@@ -64,12 +65,19 @@ html {
 
 // when the .skip-to class is applied to non-interactive
 // elements it should not have a style when focused
-div, span, h1, h2, h3, h4, h5, h6 {
+div,
+span,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
 	&.skip-to:focus {
 		outline: 0;
 	}
 }
 
 .user-role-external::after {
-	content: '(external)'
+	content: '(external)';
 }

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -25,12 +25,12 @@ $ux-color-background: $color-white !default;
 $ux-color-white: $color-white !default;
 $ux-color-brand-background: map-get($color-accent, 'default') !default;
 $ux-color-primary-highlight: map-get($color-primary, 'lightest') !default;
-$ux-color-primary-medium:  map-get($color-primary, 'lighter') !default;
-$ux-color-primary:  map-get($color-primary, 'default') !default;
+$ux-color-primary-medium: map-get($color-primary, 'lighter') !default;
+$ux-color-primary: map-get($color-primary, 'default') !default;
 $ux-color-primary-dark: map-get($color-primary, 'darker') !default;
 
 $ux-color-alert-success: map-get($color-success, 'default') !default;
-$ux-color-alert-error:  map-get($color-error, 'default') !default;
+$ux-color-alert-error: map-get($color-error, 'default') !default;
 $ux-color-alert-warning: map-get($color-warning, 'default') !default;
 $ux-color-alert-notification: map-get($color-info, 'default') !default;
 

--- a/src/styles/_links.scss
+++ b/src/styles/_links.scss
@@ -4,7 +4,6 @@ $link-color-light: map-get($color-accent, 'lightest') !default;
 $link-color-dark: map-get($color-primary, 'default') !default;
 
 .link {
-
 	&.link-light {
 		color: $link-color-light;
 	}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -5,7 +5,7 @@
 	border-radius: $border-radius;
 }
 
-@mixin focus-style($color: $ux-color-primary, $alpha: .5, $spread: 3px, $inset: false) {
+@mixin focus-style($color: $ux-color-primary, $alpha: 0.5, $spread: 3px, $inset: false) {
 	$box-shadow-color: rgba($color, $alpha);
 	outline: none;
 

--- a/src/styles/_ng-select.scss
+++ b/src/styles/_ng-select.scss
@@ -27,7 +27,7 @@ $ng-select-value-padding-left: $input-padding-x;
 	}
 }
 
-.form-group .ng-select .ng-select-container .ng-value-container .ng-input>input {
+.form-group .ng-select .ng-select-container .ng-value-container .ng-input > input {
 	height: 27px;
 	margin-top: -2px;
 }

--- a/src/styles/_ngx-bootstrap.scss
+++ b/src/styles/_ngx-bootstrap.scss
@@ -23,5 +23,4 @@
 @import './ngx-bootstrap/datepicker';
 @import './ngx-bootstrap/tables';
 
-
-@include text-emphasis-variant(".text-highlight", $ux-color-highlight);
+@include text-emphasis-variant('.text-highlight', $ux-color-highlight);

--- a/src/styles/_palettes.scss
+++ b/src/styles/_palettes.scss
@@ -34,7 +34,7 @@ $palette-primary: (
 		A100: $color-black,
 		A200: $color-white,
 		A400: $color-white,
-		A700: $color-white,
+		A700: $color-white
 	)
 );
 
@@ -71,10 +71,9 @@ $palette-gray: (
 		A100: $color-black,
 		A200: $color-black,
 		A400: $color-black,
-		A700: $color-white,
+		A700: $color-white
 	)
 );
-
 
 $palette-red: (
 	50: #f7e3e9,
@@ -138,10 +137,9 @@ $palette-yellow: (
 		A100: $color-black,
 		A200: $color-black,
 		A400: $color-black,
-		A700: $color-black,
+		A700: $color-black
 	)
 );
-
 
 $palette-green: (
 	50: #f1f8e9,
@@ -172,7 +170,7 @@ $palette-green: (
 		A100: $color-black,
 		A200: $color-black,
 		A400: $color-black,
-		A700: $color-black,
+		A700: $color-black
 	)
 );
 
@@ -201,14 +199,13 @@ $palette-teal: (
 		600: $color-white,
 		700: $color-white,
 		800: $color-white,
-		90 : $color-white,
+		90: $color-white,
 		A100: $color-black,
 		A200: $color-black,
 		A400: $color-black,
 		A700: $color-black
 	)
 );
-
 
 $palette-blue: (
 	50: #e1f5fe,
@@ -239,7 +236,7 @@ $palette-blue: (
 		A100: $color-black,
 		A200: $color-black,
 		A400: $color-black,
-		A700: $color-white,
+		A700: $color-white
 	)
 );
 
@@ -258,20 +255,29 @@ $palette-blue: (
 // @param $color-map
 // @param $primary
 // @param $lighter
-@function mat-palette($base-palette, $default: 500, $lighter: 100, $lightest: 50, $darker: 700, $darkest: 900) {
-	$result: map_merge($base-palette, (
-		default: map-get($base-palette, $default),
-		lighter: map-get($base-palette, $lighter),
-		lightest: map-get($base-palette, $lightest),
-		darker: map-get($base-palette, $darker),
-		darkest: map-get($base-palette, $darkest),
-
-		default-contrast: mat-contrast($base-palette, $default),
-		lighter-contrast: mat-contrast($base-palette, $lighter),
-		lightest-contrast: mat-contrast($base-palette, $lightest),
-		darker-contrast: mat-contrast($base-palette, $darker),
-		darkest-contrast: mat-contrast($base-palette, $darkest)
-	));
+@function mat-palette(
+	$base-palette,
+	$default: 500,
+	$lighter: 100,
+	$lightest: 50,
+	$darker: 700,
+	$darkest: 900
+) {
+	$result: map_merge(
+		$base-palette,
+		(
+			default: map-get($base-palette, $default),
+			lighter: map-get($base-palette, $lighter),
+			lightest: map-get($base-palette, $lightest),
+			darker: map-get($base-palette, $darker),
+			darkest: map-get($base-palette, $darkest),
+			default-contrast: mat-contrast($base-palette, $default),
+			lighter-contrast: mat-contrast($base-palette, $lighter),
+			lightest-contrast: mat-contrast($base-palette, $lightest),
+			darker-contrast: mat-contrast($base-palette, $darker),
+			darkest-contrast: mat-contrast($base-palette, $darkest)
+		)
+	);
 
 	@return $result;
 }

--- a/src/styles/_selection.scss
+++ b/src/styles/_selection.scss
@@ -8,21 +8,21 @@ $radio-checkbox-hover-color: $ux-color-highlight !default;
 $radio-checkbox-size: 20px !default;
 $radio-checkbox-border-width: 2px !default;
 $radio-checkbox-label-padding: 10px !default;
-$radio-checkbox-margin-y: .25rem !default;
+$radio-checkbox-margin-y: 0.25rem !default;
 
 // Calculated
 $radio-inner-margin: ($radio-checkbox-border-width * 2) + 1;
-$radio-inner-size: $radio-checkbox-size  - ($radio-inner-margin * 2);
+$radio-inner-size: $radio-checkbox-size - ($radio-inner-margin * 2);
 
 $checkbox-inner-margin: ($radio-checkbox-border-width * 2);
-$checkbox-inner-size: $radio-checkbox-size  - ($checkbox-inner-margin * 2);
+$checkbox-inner-size: $radio-checkbox-size - ($checkbox-inner-margin * 2);
 
 input {
-	&[type="radio"],
-	&[type="checkbox"],
-	&[type="radio"].form-check-input,
-	&[type="checkbox"].form-check-input {
-		left: -9999px;     // hides default ui elements
+	&[type='radio'],
+	&[type='checkbox'],
+	&[type='radio'].form-check-input,
+	&[type='checkbox'].form-check-input {
+		left: -9999px; // hides default ui elements
 		position: absolute;
 
 		& + label {
@@ -88,7 +88,7 @@ input {
 		}
 	}
 
-	&[type="radio"] {
+	&[type='radio'] {
 		+ label {
 			&:before {
 				border-radius: 100%;
@@ -114,7 +114,7 @@ input {
 		}
 	}
 
-	&[type="checkbox"] {
+	&[type='checkbox'] {
 		& + label {
 			&:before {
 				border-radius: $border-radius;

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -22,8 +22,7 @@ $font-size: 14px !default;
 	@if $value == antialiased {
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
-	}
-	@else {
+	} @else {
 		-webkit-font-smoothing: subpixel-antialiased;
 		-moz-osx-font-smoothing: auto;
 	}

--- a/src/styles/ngx-bootstrap/_buttons.scss
+++ b/src/styles/ngx-bootstrap/_buttons.scss
@@ -13,12 +13,19 @@ $ux-button-border-disabled: $ux-color-light-gray !default;
 $ux-button-color-disabled: $ux-color-medium-gray !default;
 
 .btn {
-
 	@include font-normal($btn-font-size);
 
-	&.btn-primary, &.btn-secondary {
+	&.btn-primary,
+	&.btn-secondary {
 		@include font-color-light();
-		@include button-variant($ux-button-bg, $ux-button-border, $ux-button-bg-hover, $ux-button-border-hover, $ux-button-bg-mouse-down, $ux-button-border-mouse-down);
+		@include button-variant(
+			$ux-button-bg,
+			$ux-button-border,
+			$ux-button-bg-hover,
+			$ux-button-border-hover,
+			$ux-button-bg-mouse-down,
+			$ux-button-border-mouse-down
+		);
 	}
 
 	&.btn-large {
@@ -29,8 +36,14 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 		@include font-normal($font-size-sm);
 	}
 
-	&.btn-outline-primary, &.btn-outline-secondary {
-		@include button-outline-variant($ux-button-bg, #FFF, $ux-button-bg-mouse-down, $ux-button-bg-mouse-down);
+	&.btn-outline-primary,
+	&.btn-outline-secondary {
+		@include button-outline-variant(
+			$ux-button-bg,
+			#fff,
+			$ux-button-bg-mouse-down,
+			$ux-button-bg-mouse-down
+		);
 
 		&:hover {
 			border-color: $ux-button-bg-hover;
@@ -54,7 +67,14 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 	}
 
 	&.btn-card {
-		@include button-variant($ux-color-white, $card-border-color, $ux-color-white, $ux-color-highlight, $ux-color-white, $ux-color-primary-medium);
+		@include button-variant(
+			$ux-color-white,
+			$card-border-color,
+			$ux-color-white,
+			$ux-color-highlight,
+			$ux-color-white,
+			$ux-color-primary-medium
+		);
 
 		&:hover,
 		&.hover {
@@ -63,13 +83,11 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 	}
 }
 
-
 // File
 //
 // Custom file input.
 
 .custom-file-btn {
-
 	display: flex;
 	align-items: center;
 
@@ -77,7 +95,7 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 
 	&::after {
 		content: attr(data-after);
-		margin-left: .5rem;
+		margin-left: 0.5rem;
 	}
 
 	.custom-file-btn-input {
@@ -104,7 +122,6 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 
 		&:not(:disabled):not(.disabled):active,
 		&:not(:disabled):not(.disabled).active {
-
 			& ~ .custom-file-btn-label {
 				@include box-shadow($btn-active-box-shadow);
 			}
@@ -126,13 +143,18 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 		background-color: transparent;
 		border: $btn-border-width solid transparent;
 		margin-bottom: 0;
-		@include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
+		@include button-size(
+			$btn-padding-y,
+			$btn-padding-x,
+			$btn-font-size,
+			$btn-line-height,
+			$btn-border-radius
+		);
 		@include transition($btn-transition);
 	}
 
 	&.custom-file-btn-primary {
 		.custom-file-btn-input {
-
 			&:hover ~ .custom-file-btn-label {
 				color: color-yiq($ux-button-bg-hover);
 				@include gradient-bg($ux-button-bg-hover);
@@ -143,9 +165,18 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 			&.focus ~ .custom-file-btn-label {
 				// Avoid using mixin so we can pass custom focus shadow properly
 				@if $enable-shadows {
-					box-shadow: $btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), .5);
+					box-shadow: $btn-box-shadow,
+						0
+						0
+						0
+						$btn-focus-width
+						rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
 				} @else {
-					box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), .5);
+					box-shadow: 0
+						0
+						0
+						$btn-focus-width
+						rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
 				}
 			}
 
@@ -174,9 +205,18 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 				&:focus ~ .custom-file-btn-label {
 					// Avoid using mixin so we can pass custom focus shadow properly
 					@if $enable-shadows and $btn-active-box-shadow != none {
-						box-shadow: $btn-active-box-shadow, 0 0 0 $btn-focus-width rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), .5);
+						box-shadow: $btn-active-box-shadow,
+							0
+							0
+							0
+							$btn-focus-width
+							rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
 					} @else {
-						box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), .5);
+						box-shadow: 0
+							0
+							0
+							$btn-focus-width
+							rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
 					}
 				}
 			}
@@ -191,18 +231,16 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 	}
 
 	&.custom-file-btn-outline {
-
 		.custom-file-btn-input {
-
 			&:hover ~ .custom-file-btn-label {
-				color: #FFF;
+				color: #fff;
 				background-color: $ux-button-bg-hover;
 				border-color: $ux-button-bg-hover;
 			}
 
 			&:focus ~ .custom-file-btn-label,
 			&.focus ~ .custom-file-btn-label {
-				box-shadow: 0 0 0 $btn-focus-width rgba($ux-button-bg, .5);
+				box-shadow: 0 0 0 $btn-focus-width rgba($ux-button-bg, 0.5);
 			}
 
 			&.disabled ~ .custom-file-btn-label,
@@ -223,9 +261,10 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 				&:focus ~ .custom-file-btn-label {
 					// Avoid using mixin so we can pass custom focus shadow properly
 					@if $enable-shadows and $btn-active-box-shadow != none {
-						box-shadow: $btn-active-box-shadow, 0 0 0 $btn-focus-width rgba($ux-button-bg, .5);
+						box-shadow: $btn-active-box-shadow,
+							0 0 0 $btn-focus-width rgba($ux-button-bg, 0.5);
 					} @else {
-						box-shadow: 0 0 0 $btn-focus-width rgba($ux-button-bg, .5);
+						box-shadow: 0 0 0 $btn-focus-width rgba($ux-button-bg, 0.5);
 					}
 				}
 			}

--- a/src/styles/ngx-bootstrap/_buttons.scss
+++ b/src/styles/ngx-bootstrap/_buttons.scss
@@ -167,10 +167,10 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 				@if $enable-shadows {
 					box-shadow: $btn-box-shadow,
 						0
-						0
-						0
-						$btn-focus-width
-						rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
+							0
+							0
+							$btn-focus-width
+							rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
 				} @else {
 					box-shadow: 0
 						0
@@ -207,10 +207,10 @@ $ux-button-color-disabled: $ux-color-medium-gray !default;
 					@if $enable-shadows and $btn-active-box-shadow != none {
 						box-shadow: $btn-active-box-shadow,
 							0
-							0
-							0
-							$btn-focus-width
-							rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
+								0
+								0
+								$btn-focus-width
+								rgba(mix(color-yiq($ux-button-bg), $ux-button-border, 15%), 0.5);
 					} @else {
 						box-shadow: 0
 							0

--- a/src/styles/ngx-bootstrap/_cards.scss
+++ b/src/styles/ngx-bootstrap/_cards.scss
@@ -1,6 +1,6 @@
 @import 'shared';
 
-$card-box-shadow: 0 1px 1px rgba(0, 0, 0, .3) !default;
+$card-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3) !default;
 $card-selected-check-size: 2rem !default;
 
 .card {

--- a/src/styles/ngx-bootstrap/_grid.scss
+++ b/src/styles/ngx-bootstrap/_grid.scss
@@ -2,7 +2,11 @@
 
 // Modified copy of make-grid-columns from Bootstrap (node_modules/bootstrap/scss/mixins/_grid-framework.scss).
 // Creates 'col-na' classes vs 'col'.
-@mixin make-nav-aware-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
+@mixin make-nav-aware-grid-columns(
+	$columns: $grid-columns,
+	$gutter: $grid-gutter-width,
+	$breakpoints: $grid-breakpoints
+) {
 	// Common properties for all breakpoints
 	%na-grid-column {
 		position: relative;
@@ -45,17 +49,24 @@
 				}
 			}
 
-			.order#{$infix}-first { order: -1; }
+			.order#{$infix}-first {
+				order: -1;
+			}
 
-			.order#{$infix}-last { order: $columns + 1; }
+			.order#{$infix}-last {
+				order: $columns + 1;
+			}
 
 			@for $i from 0 through $columns {
-				.order#{$infix}-#{$i} { order: $i; }
+				.order#{$infix}-#{$i} {
+					order: $i;
+				}
 			}
 
 			// `$columns - 1` because offsetting by the width of an entire row isn't possible
 			@for $i from 0 through ($columns - 1) {
-				@if not ($infix == "" and $i == 0) { // Avoid emitting useless .offset-0
+				@if not($infix == '' and $i == 0) {
+					// Avoid emitting useless .offset-0
 					.offset#{$infix}-#{$i} {
 						@include make-col-offset($i, $columns);
 					}
@@ -66,7 +77,6 @@
 }
 
 @if $enable-nav-aware-grid-classes and $enable-grid-classes {
-
 	$nav-opened-grid-breakpoints: ();
 
 	@each $key, $value in $grid-breakpoints {
@@ -74,10 +84,19 @@
 		@if $value == 0 {
 			$bp: 0;
 		}
-		$nav-opened-grid-breakpoints: map-merge($nav-opened-grid-breakpoints, ($key: $bp));
+		$nav-opened-grid-breakpoints: map-merge(
+			$nav-opened-grid-breakpoints,
+			(
+				$key: $bp
+			)
+		);
 	}
 
-	@include make-nav-aware-grid-columns($grid-columns, $grid-gutter-width, $nav-opened-grid-breakpoints);
+	@include make-nav-aware-grid-columns(
+		$grid-columns,
+		$grid-gutter-width,
+		$nav-opened-grid-breakpoints
+	);
 
 	.navbar-close {
 		@include make-nav-aware-grid-columns($grid-columns, $grid-gutter-width, $grid-breakpoints);

--- a/src/styles/ngx-bootstrap/_modal.scss
+++ b/src/styles/ngx-bootstrap/_modal.scss
@@ -6,7 +6,9 @@ $modal-font-size: $ux-h2-font-size !default;
 $modal-header-border-radius-correction: 1px !default;
 
 .modal-header {
-	@include border-top-radius(calc(#{$modal-content-border-radius} - #{$modal-header-border-radius-correction}));
+	@include border-top-radius(
+		calc(#{$modal-content-border-radius} - #{$modal-header-border-radius-correction})
+	);
 	background-color: $modal-header-bg-color;
 	color: $modal-header-color;
 

--- a/src/styles/ngx-bootstrap/_nav.scss
+++ b/src/styles/ngx-bootstrap/_nav.scss
@@ -13,5 +13,3 @@ $nav-tabs-border-highlight-width: 3px !default;
 		margin: 0 1rem;
 	}
 }
-
-

--- a/src/styles/ngx-bootstrap/_popovers.scss
+++ b/src/styles/ngx-bootstrap/_popovers.scss
@@ -4,7 +4,6 @@ $popover-menu-item-font-color: map-get($color-background, 'lightest-contrast') !
 $popover-menu-item-hover-bg-color: map-get($color-background, 'default') !default;
 
 .nav-popover {
-
 	.popover {
 		min-height: 22px;
 
@@ -33,7 +32,7 @@ $popover-menu-item-hover-bg-color: map-get($color-background, 'default') !defaul
 				border-right-color: $popover-border-color;
 
 				&.arrow::before {
-					box-shadow: 0 1px 4px rgba(0, 0, 0, .3);
+					box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 					left: 4px;
 					transform: rotate(45deg);
 					width: 14px;
@@ -42,7 +41,6 @@ $popover-menu-item-hover-bg-color: map-get($color-background, 'default') !defaul
 		}
 	}
 }
-
 
 ul.popover-menu {
 	list-style: none;

--- a/src/styles/ngx-bootstrap/_tables.scss
+++ b/src/styles/ngx-bootstrap/_tables.scss
@@ -48,7 +48,8 @@
 
 .table-inline-edit {
 	td {
-		.form-control, .input-group .btn {
+		.form-control,
+		.input-group .btn {
 			font-size: 0.875rem;
 		}
 

--- a/src/styles/ngx-bootstrap/_variables.scss
+++ b/src/styles/ngx-bootstrap/_variables.scss
@@ -24,52 +24,52 @@ $link-hover-color: $ux-color-highlight !default;
 
 // Navs
 $nav-link-padding-x: 0 !default;
-$nav-tabs-link-hover-border-color:  transparent transparent $ux-color-highlight !default;
-$nav-tabs-link-active-bg:           transparent !default;
+$nav-tabs-link-hover-border-color: transparent transparent $ux-color-highlight !default;
+$nav-tabs-link-active-bg: transparent !default;
 $nav-tabs-link-active-border-color: transparent transparent $ux-color-primary-medium !default;
 
 // Card
-$card-border-color:                 $ux-color-dark-gray !default;
+$card-border-color: $ux-color-dark-gray !default;
 
 // Button
-$btn-disabled-opacity:              0.3 !default;
+$btn-disabled-opacity: 0.3 !default;
 
 // Forms
-$input-font-family:                 $font-family-medium !default;
-$input-font-size:                   .875rem !default;
-$input-font-size-lg:                1rem !default;
-$input-font-size-sm:                .75rem !default;
+$input-font-family: $font-family-medium !default;
+$input-font-size: 0.875rem !default;
+$input-font-size-lg: 1rem !default;
+$input-font-size-sm: 0.75rem !default;
 
-$input-color:                       map-get($color-primary, 'darker') !default;
-$input-border-color:                map-get($color-background, 'darker') !default;
-$input-placeholder-color:           map-get($color-primary, 'lighter') !default;
+$input-color: map-get($color-primary, 'darker') !default;
+$input-border-color: map-get($color-background, 'darker') !default;
+$input-placeholder-color: map-get($color-primary, 'lighter') !default;
 
-$form-check-input-gutter:           0 !default;
+$form-check-input-gutter: 0 !default;
 
 // Dropdown
-$dropdown-padding-y:				0 !default;
-$dropdown-spacer:					0 !default;
-$dropdown-border-color:             $ux-color-dark-gray !default;
-$dropdown-box-shadow: 				0 1px 4px rgba(0, 0, 0, .3) !default;
-$dropdown-link-hover-bg:			$ux-color-light-gray !default;
+$dropdown-padding-y: 0 !default;
+$dropdown-spacer: 0 !default;
+$dropdown-border-color: $ux-color-dark-gray !default;
+$dropdown-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3) !default;
+$dropdown-link-hover-bg: $ux-color-light-gray !default;
 
-$dropdown-item-padding-y:           10px !default;
-$dropdown-item-padding-x:			24px !default;
+$dropdown-item-padding-y: 10px !default;
+$dropdown-item-padding-x: 24px !default;
 
 // Popovers
-$popover-bg:                        #fff !default;
-$popover-border-color:              map-get($color-background, 'default') !default;
-$popover-border-radius:             $border-radius !default;
-$popover-box-shadow:                0 1px 4px rgba(0, 0, 0, .3) !default;
-$popover-body-padding-y:            0 !default;
-$popover-body-padding-x:            0 !default;
+$popover-bg: #fff !default;
+$popover-border-color: map-get($color-background, 'default') !default;
+$popover-border-radius: $border-radius !default;
+$popover-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3) !default;
+$popover-body-padding-y: 0 !default;
+$popover-body-padding-x: 0 !default;
 
 // Tooltips
-$tooltip-font-size:                 14px !default;
-$tooltip-color:                     map-get($color-background, 'darkest-contrast') !default;
-$tooltip-bg:                        fade-out(map-get($color-background, 'darkest'), .4) !default;
-$tooltip-padding-y:                 8px !default;
-$tooltip-padding-x:                 16px !default;
+$tooltip-font-size: 14px !default;
+$tooltip-color: map-get($color-background, 'darkest-contrast') !default;
+$tooltip-bg: fade-out(map-get($color-background, 'darkest'), 0.4) !default;
+$tooltip-padding-y: 8px !default;
+$tooltip-padding-x: 16px !default;
 
 // Tables
 $table-accent-bg: $ux-color-alternate-row-fill !default;

--- a/src/test.ts
+++ b/src/test.ts
@@ -10,10 +10,7 @@ import {
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-	BrowserDynamicTestingModule,
-	platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -12,7 +12,6 @@ module.exports = {
 	'rules': {
 		'prettier/prettier': true,
 		'at-rule-empty-line-before': null,
-		'indentation': [ 'tab' ],
 		'no-descending-specificity': null,
 		'no-empty-source': null,
 		"selector-pseudo-element-no-unknown": [

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,11 +1,16 @@
 'use strict';
 
 module.exports = {
-	'extends': 'stylelint-config-recommended-scss',
+	'extends': [
+		'stylelint-config-recommended-scss',
+		'stylelint-config-prettier'
+	],
 	'plugins': [
+		'stylelint-prettier',
 		'stylelint-scss'
 	],
 	'rules': {
+		'prettier/prettier': true,
 		'at-rule-empty-line-before': null,
 		'indentation': [ 'tab' ],
 		'no-descending-specificity': null,

--- a/tslint.json
+++ b/tslint.json
@@ -20,7 +20,6 @@
       "ngx-bootstrap",
       "rxjs/Rx"
     ],
-    "indent": [ true, "tabs", 4],
     "interface-name": false,
     "max-classes-per-file": false,
     "max-line-length": false,
@@ -55,10 +54,6 @@
     "no-switch-case-fall-through": true,
     "no-use-before-declare": true,
     "no-var-requires": false,
-    "object-literal-key-quotes": [
-      true,
-      "as-needed"
-    ],
     "object-literal-sort-keys": false,
     "ordered-imports": false,
     "trailing-comma": false,

--- a/tslint.json
+++ b/tslint.json
@@ -61,10 +61,6 @@
     ],
     "object-literal-sort-keys": false,
     "ordered-imports": false,
-    "quotemark": [
-      true,
-      "single"
-    ],
     "trailing-comma": false,
 
     // codelyzer rules.  To revert to errors, remove/change severity

--- a/tslint.json
+++ b/tslint.json
@@ -1,11 +1,14 @@
 {
   "extends": [
-    "tslint:recommended"
+    "tslint:recommended",
+    "tslint-plugin-prettier",
+    "tslint-config-prettier"
   ],
   "rulesDirectory": [
     "codelyzer"
   ],
   "rules": {
+    "prettier": true,
     "array-type": false,
     "arrow-parens": false,
     "deprecation": {


### PR DESCRIPTION
- Added/updated dependencies:
1. Prettier code style processor.
2. All required configs for prettier (tslint, stylelint, and plugins)
2. Husky git hook runner.
3. lint-staged for linting only staged files during pre-commit.
4. Stylelint version 9 => 13.
- Sets prettier as the default program for tslint (and by extension ng lint) to use.
- Overrides existing tslint and stylelint configurations with prettier configuratiuons.
- Adds pre-commit hook for linting staged files prior to commit.
- Adds `npm run lint:fix` command for linting (and fixing) the entire project.