### PR TITLE
build: Prevent bundling of duplicate versions of rxjs

### DIFF
--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.spec.ts
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.spec.ts
@@ -7,7 +7,7 @@ import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
-import { of } from 'rxjs/index';
+import { of } from 'rxjs';
 import { DirectivesModule } from '../../../common/directives.module';
 import { PagingModule, PagingResults } from '../../../common/paging.module';
 import { PipesModule } from '../../../common/pipes.module';

--- a/src/app/core/auth/authorization.service.spec.ts
+++ b/src/app/core/auth/authorization.service.spec.ts
@@ -1,6 +1,6 @@
 import { inject, TestBed } from '@angular/core/testing';
 
-import { BehaviorSubject, Observable } from 'rxjs/index';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { AuthorizationService } from './authorization.service';
 import { Role } from './role.model';
 import { Session } from './session.model';

--- a/src/app/core/auth/session.service.ts
+++ b/src/app/core/auth/session.service.ts
@@ -4,7 +4,7 @@ import { NavigationExtras, Router } from '@angular/router';
 
 import assign from 'lodash/assign';
 import isEmpty from 'lodash/isEmpty';
-import { of, pipe, BehaviorSubject, Observable } from 'rxjs/index';
+import { of, pipe, BehaviorSubject, Observable } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 import { ConfigService } from '../config.service';
 import { AuthenticationService } from './authentication.service';

--- a/src/app/site/example/shared/example-mock.service.ts
+++ b/src/app/site/example/shared/example-mock.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import { Observable, of } from 'rxjs/index';
+import { Observable, of } from 'rxjs';
 
 import { Example } from './example.model';
 import { ExampleService } from './example.service';

--- a/src/app/site/example/shared/example-rest.service.ts
+++ b/src/app/site/example/shared/example-rest.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import { Observable } from 'rxjs/index';
+import { Observable } from 'rxjs';
 
 import { Example } from './example.model';
 import { ExampleService } from './example.service';

--- a/src/app/site/example/shared/example.service.ts
+++ b/src/app/site/example/shared/example.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { Observable } from 'rxjs/index';
+import { Observable } from 'rxjs';
 
 import { Example } from './example.model';
 


### PR DESCRIPTION
Caused by several instances of importing from `rxjs/index` vs `rxjs`.