### PR TITLE
css: square button support.

### DIFF
--- a/src/app/site/example/forms/forms.component.html
+++ b/src/app/site/example/forms/forms.component.html
@@ -1,4 +1,4 @@
-<form style="max-width: 800px;">
+<form style="max-width: 900px;">
 
 	<h1 class="pb-3">Bootstrap Form Examples</h1>
 
@@ -185,6 +185,11 @@
 
 	<h2 class="pt-4">Submit Button w/ progress indicator</h2>
 	<button type="button" class="mr-3 btn btn-primary btn-submit" (click)="submit($event)">Submit</button>
+
+	<h3 class="pt-3">Square Buttons <small>(for use with fa-fw icons)</small></h3>
+	<button type="button" class="mr-3 btn btn-primary btn-square btn-sm"><span class="fa fa-fw fa-upload"></span></button>
+	<button type="button" class="mr-3 btn btn-primary btn-square"><span class="fa fa-fw fa-upload"></span></button>
+	<button type="button" class="mr-3 btn btn-primary btn-square btn-lg"><span class="fa fa-fw fa-upload"></span></button>
 
 	<h2 class="pt-4">File Input</h2>
 

--- a/src/styles/ngx-bootstrap/_buttons.scss
+++ b/src/styles/ngx-bootstrap/_buttons.scss
@@ -52,12 +52,22 @@ $btn-submit-linear-animation: $btn-submit-linear-animation-name
 		);
 	}
 
+	&.btn-square {
+		padding: $input-btn-padding-square;
+	}
+
 	&.btn-large {
 		@include font-normal($font-size-lg);
+		&.btn-square {
+			padding: $input-btn-padding-square-lg;
+		}
 	}
 
 	&.btn-sm {
 		@include font-normal($font-size-sm);
+		&.btn-square {
+			padding: $input-btn-padding-square-sm;
+		}
 	}
 
 	&.btn-outline-primary,

--- a/src/styles/ngx-bootstrap/_buttons.scss
+++ b/src/styles/ngx-bootstrap/_buttons.scss
@@ -36,6 +36,10 @@ $btn-submit-linear-animation: $btn-submit-linear-animation-name
 	$btn-submit-linear-animation-duration $btn-submit-animation-iteration-count
 	$btn-submit-linear-animation-timing-function;
 
+$btn-padding-square: $input-btn-padding-y !default;
+$btn-padding-square-sm: $input-btn-padding-y-sm !default;
+$btn-padding-square-lg: $input-btn-padding-y-lg !default;
+
 .btn {
 	@include font-normal($btn-font-size);
 
@@ -53,20 +57,20 @@ $btn-submit-linear-animation: $btn-submit-linear-animation-name
 	}
 
 	&.btn-square {
-		padding: $input-btn-padding-square;
+		padding: $btn-padding-square;
 	}
 
 	&.btn-large {
 		@include font-normal($font-size-lg);
 		&.btn-square {
-			padding: $input-btn-padding-square-lg;
+			padding: $btn-padding-square-lg;
 		}
 	}
 
 	&.btn-sm {
 		@include font-normal($font-size-sm);
 		&.btn-square {
-			padding: $input-btn-padding-square-sm;
+			padding: $btn-padding-square-sm;
 		}
 	}
 

--- a/src/styles/ngx-bootstrap/_buttons.scss
+++ b/src/styles/ngx-bootstrap/_buttons.scss
@@ -60,7 +60,7 @@ $btn-padding-square-lg: $input-btn-padding-y-lg !default;
 		padding: $btn-padding-square;
 	}
 
-	&.btn-large {
+	&.btn-lg {
 		@include font-normal($font-size-lg);
 		&.btn-square {
 			padding: $btn-padding-square-lg;


### PR DESCRIPTION
This change adds the `btn-square` css class to:

- `btn`
- `btn-sm`
- `btn-lg`

This class uses uniform button padding all-the-way-around on the default/sm/large button elements, which allows for more accurate centering of things like font-awesome icons in conjunction with the `fa-fw` fixed-width class.