### PR TITLE
Adjust display of messages so that they default to a column layout rather than a horizontal layout

### DIFF
--- a/src/app/core/messages/_shared.scss
+++ b/src/app/core/messages/_shared.scss
@@ -7,7 +7,8 @@ $card-icon-width: 31px;
 	border: none;
 	-webkit-box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.298039215686275);
 	box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.298039215686275);
-	display: inline-block;
+	display: block;
+	margin: auto;
 
 	.col-alert-icon {
 		max-width: $card-icon-width;


### PR DESCRIPTION
The card-message styles default to display horizontally when viewed on a widescreen. This PR changes the cards to always display in a centered column instead.

Resolves #146