### PR TITLE
#152 Feature: Export Users

### DIFF
--- a/src/app/core/admin/user-management/admin-list-users.component.html
+++ b/src/app/core/admin/user-management/admin-list-users.component.html
@@ -31,7 +31,7 @@
 						<button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" dropdownToggle></button>
 						<ul *dropdownMenu class="dropdown-menu dropdown-menu-right" role="menu">
 							<li><a class="dropdown-item" (click)="exportCurrentView()" tabindex="0">Export Current View</a></li>
-							<li><a class="dropdown-item" (click)="exportUserData()" tabindex="0">Export Single Field</a></li>
+							<li><a class="dropdown-item" (click)="exportUserData()" tabindex="0" disabled>Export Single Field</a></li>
 						</ul>
 					</div>
 					<button routerLink="/admin/user" type="button" class="btn btn-primary ml-3">

--- a/src/app/core/admin/user-management/admin-list-users.component.html
+++ b/src/app/core/admin/user-management/admin-list-users.component.html
@@ -28,11 +28,12 @@
 					<asy-search-input placeholder="Search..." (applySearch)="searchEvent$.next($event)"></asy-search-input>
 					<div class="btn-group dropdown ml-auto" dropdown>
 						<button type="button" class="btn btn-outline-secondary" (click)="exportCurrentView()"><span class="fa fa-download"></span> Export </button>
-						<button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" dropdownToggle></button>
+						<!-- TODO Restore this when we've implemented "Export Single Field" -->
+						<!-- <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" dropdownToggle></button>
 						<ul *dropdownMenu class="dropdown-menu dropdown-menu-right" role="menu">
 							<li><a class="dropdown-item" (click)="exportCurrentView()" tabindex="0">Export Current View</a></li>
 							<li><a class="dropdown-item" (click)="exportUserData()" tabindex="0" disabled>Export Single Field</a></li>
-						</ul>
+						</ul> -->
 					</div>
 					<button routerLink="/admin/user" type="button" class="btn btn-primary ml-3">
 						<span class="fa fa-user-plus"></span> Create User

--- a/src/app/core/admin/user-management/admin-list-users.component.spec.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.spec.ts
@@ -1,0 +1,186 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { of } from 'rxjs';
+import { PagingModule, PagingResults } from 'src/app/common/paging.module';
+import { PipesModule } from 'src/app/common/pipes.module';
+import { SearchInputModule } from 'src/app/common/search-input.module';
+import { SystemAlertModule } from 'src/app/common/system-alert.module';
+import { User } from '../../auth/user.model';
+import { ConfigService } from '../../config.service';
+import { ExportConfigService } from '../../export-config.service';
+import { AdminListUsersComponent } from './admin-list-users.component';
+import { AdminUsersService } from './admin-users.service';
+
+describe('Admin List Users Component Spec', () => {
+	let adminUsersServiceSpy: any;
+	let configServiceSpy: any;
+	let exportConfigServiceSpy: any;
+	let exportResponseId: string;
+
+	const mockUsers: PagingResults<User> = {
+		elements: [],
+		totalPages: 1,
+		totalSize: 0,
+		pageNumber: 0,
+		pageSize: 20
+	};
+
+	let fixture: ComponentFixture<AdminListUsersComponent>;
+	let component: AdminListUsersComponent;
+	let rootHTMLElement: HTMLElement;
+
+	const toggleColumnCheckbox = async (checkboxLabel: string) => {
+		const allColumnCheckboxes = rootHTMLElement.querySelectorAll(
+			'.quick-select-header > .form-check > .form-check-label'
+		);
+		// default to the first element, then actually find the checkbox
+		let columnButton = allColumnCheckboxes.item(0);
+		allColumnCheckboxes.forEach(e => {
+			if (e.textContent === checkboxLabel) {
+				columnButton = e;
+			}
+		});
+		columnButton.parentElement.querySelector('input').click();
+		fixture.detectChanges();
+		await fixture.whenStable();
+	};
+
+	const clickExportButton = async () => {
+		const exportButtonElement = rootHTMLElement.querySelector('span.fa-download').parentElement;
+		expect(exportButtonElement.textContent.trim()).toEqual('Export');
+		exportButtonElement.click();
+		fixture.detectChanges();
+		await fixture.whenStable();
+	};
+
+	beforeEach(async () => {
+		exportResponseId = `${Math.random()}`;
+
+		// reset for each test
+		adminUsersServiceSpy = jasmine.createSpyObj('AdminUsersService', ['search']);
+		adminUsersServiceSpy.cache = {
+			listUsers: {}
+		};
+		adminUsersServiceSpy.search.and.returnValue(of(mockUsers));
+
+		configServiceSpy = jasmine.createSpyObj('ConfigService', ['getConfig']);
+		configServiceSpy.getConfig.and.returnValue(of({}));
+
+		exportConfigServiceSpy = jasmine.createSpyObj('ExportConfigService', ['postExportConfig']);
+		exportConfigServiceSpy.postExportConfig.and.returnValue(
+			of({
+				_id: exportResponseId
+			})
+		);
+
+		TestBed.configureTestingModule({
+			declarations: [AdminListUsersComponent],
+			imports: [
+				FormsModule,
+				RouterTestingModule,
+				PagingModule,
+				PipesModule,
+				SearchInputModule,
+				SystemAlertModule,
+				TooltipModule.forRoot()
+			],
+			providers: [
+				{ provide: AdminUsersService, useValue: adminUsersServiceSpy },
+				{ provide: ConfigService, useValue: configServiceSpy },
+				{ provide: ExportConfigService, useValue: exportConfigServiceSpy }
+			]
+		});
+
+		fixture = TestBed.createComponent(AdminListUsersComponent);
+		component = fixture.componentInstance;
+		rootHTMLElement = fixture.debugElement.nativeElement;
+	});
+
+	it('should initialize the users listing', async () => {
+		expect(adminUsersServiceSpy.search).toHaveBeenCalledTimes(0);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(0);
+		fixture.detectChanges();
+		await fixture.whenStable();
+		expect(adminUsersServiceSpy.search).toHaveBeenCalledTimes(1);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(0);
+	});
+
+	it('should enable the email column and export the current view', async () => {
+		expect(adminUsersServiceSpy.search).toHaveBeenCalledTimes(0);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(0);
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		expect(adminUsersServiceSpy.search).toHaveBeenCalledTimes(1);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(0);
+
+		// Toggle the email filter on
+		await toggleColumnCheckbox('Email');
+
+		expect(component.columns.name.show).toEqual(true);
+		expect(component.columns.email.show).toEqual(true);
+
+		// Click the export button
+		await clickExportButton();
+
+		const expectedBaseColumns = ['name', 'username', 'email', 'lastLogin'].map(key => {
+			return { key, title: component.columns[key].display };
+		});
+
+		const expectedColumns = [
+			...expectedBaseColumns,
+			// add roles explicitly
+			{ key: 'roles.user', title: 'User Role' },
+			{ key: 'roles.editor', title: 'Editor Role' },
+			{ key: 'roles.auditor', title: 'Auditor Role' },
+			{ key: 'roles.admin', title: 'Admin Role' }
+		];
+
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(1);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledWith('user', {
+			q: undefined,
+			s: undefined,
+			cols: expectedColumns,
+			sort: 'lastLogin',
+			dir: 'DESC'
+		});
+	});
+
+	it('should disable the roles column and export the current view', async () => {
+		expect(adminUsersServiceSpy.search).toHaveBeenCalledTimes(0);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(0);
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		expect(adminUsersServiceSpy.search).toHaveBeenCalledTimes(1);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(0);
+
+		// Toggle the Roles filter off
+		await toggleColumnCheckbox('Roles');
+
+		expect(component.columns.name.show).toEqual(true);
+		expect(component.columns.email.show).toEqual(false);
+		expect(component.columns.roles.show).toEqual(false);
+
+		// Click the export button
+		await clickExportButton();
+
+		const expectedBaseColumns = ['name', 'username', 'lastLogin'].map(key => {
+			return { key, title: component.columns[key].display };
+		});
+
+		const expectedColumns = [...expectedBaseColumns];
+
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledTimes(1);
+		expect(exportConfigServiceSpy.postExportConfig).toHaveBeenCalledWith('user', {
+			q: undefined,
+			s: undefined,
+			cols: expectedColumns,
+			sort: 'lastLogin',
+			dir: 'DESC'
+		});
+	});
+});

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -18,8 +18,8 @@ import { first } from 'rxjs/operators';
 import { Role } from '../../auth/role.model';
 import { User } from '../../auth/user.model';
 import { ConfigService } from '../../config.service';
-import { AdminUsersService } from './admin-users.service';
 import { ExportConfigService } from '../../export-config.service';
+import { AdminUsersService } from './admin-users.service';
 
 @UntilDestroy()
 @Component({
@@ -165,11 +165,11 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 	}
 
 	exportCurrentView() {
-		let viewColumns = Object.keys(this.columns)
+		const viewColumns = Object.keys(this.columns)
 			.filter((key: string) => this.columns[key].show)
-			.map((key: string) => ({ key: key, title: this.columns[key].display }));
+			.map((key: string) => ({ key, title: this.columns[key].display }));
 
-		let rolesIndex = viewColumns.findIndex((pair: any) => pair.key === 'roles');
+		const rolesIndex = viewColumns.findIndex((pair: any) => pair.key === 'roles');
 
 		if (rolesIndex !== -1) {
 			viewColumns.splice(

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -167,7 +167,7 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 	exportCurrentView() {
 		let viewColumns = Object.keys(this.columns)
 			.filter((key: string) => this.columns[key].show)
-			.map((key: any) => ({ key: key, title: this.columns[key].title }));
+			.map((key: string) => ({ key: key, title: this.columns[key].display }));
 
 		let rolesIndex = viewColumns.findIndex((pair: any) => pair.key === 'roles');
 

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -19,6 +19,7 @@ import { Role } from '../../auth/role.model';
 import { User } from '../../auth/user.model';
 import { ConfigService } from '../../config.service';
 import { AdminUsersService } from './admin-users.service';
+import { ExportConfigService } from '../../export-config.service';
 
 @UntilDestroy()
 @Component({
@@ -101,6 +102,7 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 		private route: ActivatedRoute,
 		private configService: ConfigService,
 		private adminUsersService: AdminUsersService,
+		private exportConfigService: ExportConfigService,
 		private alertService: SystemAlertService
 	) {
 		super();
@@ -159,11 +161,38 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 	}
 
 	exportUserData() {
-		console.error('Export User Data coming soon...');
+		console.error('Export of single user field is not yet supported.');
 	}
 
 	exportCurrentView() {
-		console.error('Export Current View coming soon...');
+		let viewColumns = Object.keys(this.columns)
+			.filter((key: string) => this.columns[key].show)
+			.map((key: any) => ({ key: key, title: this.columns[key].title }));
+
+		let rolesIndex = viewColumns.findIndex((pair: any) => pair.key === 'roles');
+
+		if (rolesIndex !== -1) {
+			viewColumns.splice(
+				rolesIndex,
+				1,
+				{ key: 'roles.user', title: 'User Role' },
+				{ key: 'roles.editor', title: 'Editor Role' },
+				{ key: 'roles.auditor', title: 'Auditor Role' },
+				{ key: 'roles.admin', title: 'Admin Role' }
+			);
+		}
+
+		this.exportConfigService
+			.postExportConfig('user', {
+				q: this.getQuery(),
+				s: this.search,
+				cols: viewColumns,
+				sort: this.pagingOptions.sortField,
+				dir: this.pagingOptions.sortDir
+			})
+			.subscribe((response: any) => {
+				window.open(`/api/admin/users/csv/${response._id}`);
+			});
 	}
 
 	columnsUpdated(updatedColumns: any) {

--- a/src/app/core/admin/user-management/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/admin-list-users.component.ts
@@ -172,14 +172,10 @@ export class AdminListUsersComponent extends AbstractPageableDataComponent<User>
 		const rolesIndex = viewColumns.findIndex((pair: any) => pair.key === 'roles');
 
 		if (rolesIndex !== -1) {
-			viewColumns.splice(
-				rolesIndex,
-				1,
-				{ key: 'roles.user', title: 'User Role' },
-				{ key: 'roles.editor', title: 'Editor Role' },
-				{ key: 'roles.auditor', title: 'Auditor Role' },
-				{ key: 'roles.admin', title: 'Admin Role' }
-			);
+			const roleColumns = Role.ROLES.map(role => {
+				return { key: `roles.${role.role}`, title: `${role.label} Role` };
+			});
+			viewColumns.splice(rolesIndex, 1, ...roleColumns);
 		}
 
 		this.exportConfigService


### PR DESCRIPTION
This change removes the no-op dropdown for "Export Current View" and "Export Single Field" from the users listing in favor of a single Export button that derives its configuration from the current table layout. The `node-rest-starter` already supports this functionality.