### PR TITLE
feat: add loading overlay component

### DIFF
--- a/src/app/common/loading-overlay.module.ts
+++ b/src/app/common/loading-overlay.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+
+import { LoadingOverlayComponent } from './loading-overlay/loading-overlay.component';
+import { LoadingSpinnerModule } from './loading-spinner.module';
+import { NotificationModule } from './notification.module';
+
+@NgModule({
+	imports: [NotificationModule, LoadingSpinnerModule],
+	exports: [LoadingOverlayComponent],
+	declarations: [LoadingOverlayComponent],
+	providers: []
+})
+export class LoadingOverlayModule {}

--- a/src/app/common/loading-overlay/loading-overlay.component.html
+++ b/src/app/common/loading-overlay/loading-overlay.component.html
@@ -1,0 +1,18 @@
+<div *ngIf="isLoading" class="overlay">
+	<notification *ngIf="isError"
+					 [notificationType]="'danger'"
+					 [message]="errorMessage"
+					 [showActions]="true"
+	>
+		<ng-template #notificationActions>
+			<button class="btn btn-primary" (click)="handleRetry()">
+				Retry
+			</button>
+		</ng-template>
+	</notification>
+	<div class="overlay-spinner" *ngIf="!isError">
+		<loading-spinner
+			[message]="message">
+		</loading-spinner>
+	</div>
+</div>

--- a/src/app/common/loading-overlay/loading-overlay.component.scss
+++ b/src/app/common/loading-overlay/loading-overlay.component.scss
@@ -1,0 +1,19 @@
+@import '../../../styles/shared';
+
+// Added in z-index to these classes to bring them to the front of card pageable tables
+.overlay {
+	position: absolute;
+	height: 100%;
+	width: 100%;
+	background-color: rgba(255, 255, 255, 0.75);
+	z-index: 9001;
+}
+
+.overlay-spinner {
+	color: $ux-color-black;
+	position: absolute;
+	top: 5%;
+	left: 50%;
+	transform: translate(-50%);
+	z-index: 9001;
+}

--- a/src/app/common/loading-overlay/loading-overlay.component.ts
+++ b/src/app/common/loading-overlay/loading-overlay.component.ts
@@ -1,0 +1,19 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+	selector: 'loading-overlay',
+	templateUrl: 'loading-overlay.component.html',
+	styleUrls: ['loading-overlay.component.scss']
+})
+export class LoadingOverlayComponent {
+	@Input() message = 'Loading...';
+	@Input() isLoading: boolean;
+	@Input() isError = false;
+	@Input() errorMessage: string;
+
+	@Output() readonly retry = new EventEmitter();
+
+	handleRetry() {
+		this.retry.emit(true);
+	}
+}

--- a/src/app/common/notification.module.ts
+++ b/src/app/common/notification.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+
+import { NotificationComponent } from './notification/notification.component';
+
+@NgModule({
+	imports: [],
+	exports: [NotificationComponent],
+	declarations: [NotificationComponent],
+	providers: []
+})
+export class NotificationModule {}

--- a/src/app/common/notification/notification.component.html
+++ b/src/app/common/notification/notification.component.html
@@ -1,0 +1,9 @@
+<div class="{{notificationType}}-notification notification-container"
+	 [class.small]="small">
+	<div class="float-left" [class.action-text]="showActions">
+		{{message}}
+	</div>
+	<div class="table-actions d-flex flex-grow-1 float-right" *ngIf="showActions">
+		<ng-container *ngTemplateOutlet="actionTemplate"></ng-container>
+	</div>
+</div>

--- a/src/app/common/notification/notification.component.scss
+++ b/src/app/common/notification/notification.component.scss
@@ -1,0 +1,35 @@
+@import '../../../styles/shared';
+
+.info-notification {
+	@include border($ux-color-alert-notification, 2px, 3px);
+	background: $ux-color-white;
+}
+.success-notification {
+	@include border($ux-color-alert-success, 2px, 3px);
+	background: $ux-color-white;
+}
+.warning-notification {
+	@include border($ux-color-alert-warning, 2px, 3px);
+	background: $ux-color-white;
+}
+.danger-notification {
+	@include border($ux-color-alert-error, 2px, 3px);
+	background: $ux-color-white;
+}
+
+.action-text {
+	transform: translate(0%, 25%);
+}
+.notification-container {
+	border-radius: 3px 3px 3px 3px;
+	margin: 10px 0;
+	overflow: auto;
+	padding: 10px;
+
+	&.small {
+		border-radius: 1px;
+		font-size: 1rem;
+		margin: 2px 0;
+		padding: 5px;
+	}
+}

--- a/src/app/common/notification/notification.component.spec.ts
+++ b/src/app/common/notification/notification.component.spec.ts
@@ -1,0 +1,71 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationComponent } from './notification.component';
+
+@Component({
+	template:
+		'<notification [message]="message">' +
+		'<ng-template #notificationActions id="tableActions"><button>bar</button></ng-template></notification>'
+})
+export class NotificationDefaultTestHostComponent {
+	message = 'foo';
+}
+
+@Component({
+	template:
+		'<notification [message]="message" [showActions]="true">' +
+		'<ng-template #notificationActions id="tableActions"><button>bar</button></ng-template>' +
+		'</notification>'
+})
+export class NotificationProvidedTestHostComponent {
+	message = 'foo';
+}
+
+describe('NotificationComponent', () => {
+	let defaultFixture: ComponentFixture<NotificationDefaultTestHostComponent>;
+	let defaultRootHTMLElement: HTMLElement;
+
+	let providedFixture: ComponentFixture<NotificationProvidedTestHostComponent>;
+	let providedTestHost: NotificationProvidedTestHostComponent;
+	let providedRootHTMLElement: HTMLElement;
+
+	beforeEach(() => {
+		const testbed = TestBed.configureTestingModule({
+			imports: [],
+			declarations: [
+				NotificationDefaultTestHostComponent,
+				NotificationProvidedTestHostComponent,
+				NotificationComponent
+			]
+		});
+
+		defaultFixture = testbed.createComponent(NotificationDefaultTestHostComponent);
+		defaultRootHTMLElement = defaultFixture.debugElement.nativeElement;
+		defaultFixture.detectChanges();
+
+		providedFixture = testbed.createComponent(NotificationProvidedTestHostComponent);
+		providedTestHost = providedFixture.componentInstance;
+		providedRootHTMLElement = providedFixture.debugElement.nativeElement;
+		providedFixture.detectChanges();
+	});
+
+	it('should display provided message', () => {
+		const expectedContent = 'foo';
+		defaultFixture.detectChanges();
+		expect(defaultRootHTMLElement.innerText).toContain(expectedContent);
+	});
+
+	it('should not display provided actions template', () => {
+		defaultFixture.detectChanges();
+		expect(defaultRootHTMLElement.getElementsByTagName('button').length).toBe(0);
+	});
+
+	it('should display provided actions template', () => {
+		const expectedContent = 'bar';
+		providedFixture.detectChanges();
+		expect(providedRootHTMLElement.getElementsByTagName('button')[0].innerText).toContain(
+			expectedContent
+		);
+	});
+});

--- a/src/app/common/notification/notification.component.ts
+++ b/src/app/common/notification/notification.component.ts
@@ -1,0 +1,15 @@
+import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
+
+@Component({
+	selector: 'notification',
+	templateUrl: 'notification.component.html',
+	styleUrls: ['notification.component.scss']
+})
+export class NotificationComponent {
+	@Input() readonly notificationType: 'info' | 'success' | 'warning' | 'danger';
+	@Input() readonly message: string;
+	@Input() showActions = false;
+	@Input() small = false;
+
+	@ContentChild('notificationActions', { static: true }) actionTemplate: TemplateRef<any>;
+}


### PR DESCRIPTION
This PR is to add a loading-overlay component to the starter. This component is meant to be a semi-opaque overlay for tables/graphs/areas of the page that displays the loading spinner while they're loading. In the event of a loading failure, the component will display an error and allow the users to retry.

The new components are the `loading-overlay` component itself as well as the `notification` component, which is used to display the message.

Also, what should go in the unit tests for the `loading-overlay` component? the component is just a wrapper that combines the `notification` and `loading-spinner` components, each of which has its own unit tests. Should I just test that the `*ngIf`s are working properly?

Thanks!