### PR TITLE
fix: ensure help components are available in prod build

### DIFF
--- a/src/app/core/help/help.module.ts
+++ b/src/app/core/help/help.module.ts
@@ -30,6 +30,6 @@ import { HelpComponent } from './help.component';
 		HelpTopicComponent,
 		HelpTopicWrapperComponent
 	],
-	providers: [HelpTopics]
+	providers: [HelpTopics, GettingStartedHelpComponent]
 })
 export class HelpModule {}

--- a/src/app/core/teams/teams.module.ts
+++ b/src/app/core/teams/teams.module.ts
@@ -54,6 +54,12 @@ import { ViewTeamComponent } from './view-team/view-team.component';
 		ViewTeamComponent,
 		TeamsHelpComponent
 	],
-	providers: [TeamAuthorizationService, TeamsService, TeamsResolve, ModalService]
+	providers: [
+		TeamAuthorizationService,
+		TeamsService,
+		TeamsResolve,
+		ModalService,
+		TeamsHelpComponent
+	]
 })
 export class TeamsModule {}

--- a/src/app/site/example/example.module.ts
+++ b/src/app/site/example/example.module.ts
@@ -43,6 +43,6 @@ import { WelcomeComponent } from './welcome.component';
 		ModalComponent,
 		ExampleLoadingOverlayComponent
 	],
-	providers: [AuthGuard, ModalService]
+	providers: [AuthGuard, ModalService, ExampleHelpComponent]
 })
 export class ExampleModule {}


### PR DESCRIPTION
Help components are registered and loaded dynamically.  As such they aren't referenced anywhere and were being tree-shaken out of the prod build.
Adding these components to the providers list of their module to ensure that they are included in prod build.