### PR TITLE
change interceptors to be chainable with bypass

### DIFF
--- a/src/app/core/auth/abstract.interceptor.ts
+++ b/src/app/core/auth/abstract.interceptor.ts
@@ -15,9 +15,7 @@ export abstract class AbstractHttpInterceptor implements HttpInterceptor {
 	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(req).pipe(
 			catchError(err => {
-				if (!err.bypassAuthInterceptors) {
-					this.handleError(err, req);
-				}
+				this.handleError(err, req);
 				return throwError(err);
 			})
 		);

--- a/src/app/core/auth/abstract.interceptor.ts
+++ b/src/app/core/auth/abstract.interceptor.ts
@@ -6,17 +6,17 @@ import { throwError, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /**
- * HTTP Interceptor
+ * Abstract HTTP Interceptor
  */
 @Injectable()
-export abstract class Interceptor implements HttpInterceptor {
+export abstract class AbstractHttpInterceptor implements HttpInterceptor {
 	protected constructor(public router: Router) {}
 
 	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(req).pipe(
 			catchError(err => {
 				if (!err.bypassAuthInterceptors) {
-					this.handleError(err);
+					this.handleError(err, req);
 				}
 				return throwError(err);
 			})
@@ -36,14 +36,7 @@ export abstract class Interceptor implements HttpInterceptor {
 	}
 
 	/**
-	 * Set a flag in the error to alert future interceptors to pass the error through
-	 */
-	bypassRemainingInterceptors(err: any) {
-		err.bypassAuthInterceptors = true;
-	}
-
-	/**
 	 * Implement this in any interceptors extending the AuthInterceptor class
 	 */
-	abstract handleError(err: any): void;
+	abstract handleError(err: any, req: HttpRequest<any>): void;
 }

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -1,17 +1,19 @@
+import { HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
-import { Interceptor } from './interceptor';
+import { AbstractHttpInterceptor } from './abstract.interceptor';
 
 /**
  * HTTP Interceptor that will interpret authentication related HTTP calls
  */
 @Injectable()
-export class AuthInterceptor extends Interceptor {
-	handleError(err: any): void {
-		const { status, type, message, url } = this.parseError(err);
-		if (status === 403) {
-			this.router.navigate(['/access'], { state: { status, type, message, url } });
-			this.bypassRemainingInterceptors(err);
+export class AuthInterceptor extends AbstractHttpInterceptor {
+	handleError(err: any, req: HttpRequest<any>): void {
+		if (!req.headers.has('bypass-auth-interceptor')) {
+			const { status, type, message, url } = this.parseError(err);
+			if (status === 403) {
+				this.router.navigate(['/access'], { state: { status, type, message, url } });
+			}
 		}
 	}
 }

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -1,51 +1,17 @@
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
 
-import { throwError, Observable } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Interceptor } from './interceptor';
 
 /**
- * HTTP Interceptor that will interpret authentication-related HTTP calls
+ * HTTP Interceptor that will interpret authentication related HTTP calls
  */
 @Injectable()
-export class AuthInterceptor implements HttpInterceptor {
-	constructor(public router: Router) {}
-
-	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-		return next.handle(req).pipe(
-			catchError(err => {
-				if (!err.bypassAuthInterceptors) {
-					this.handleError(err);
-				}
-				return throwError(err);
-			})
-		);
-	}
-
-	/**
-	 * Grab all the useful stuff out of the error response
-	 */
-	parseError(err: any) {
-		const status = err?.status ?? 200;
-		const type = err?.error?.type ?? '';
-		const url = err?.url ?? '';
-		const message = err?.error?.message ?? '';
-
-		return { status, type, message, url };
-	}
-
-	/**
-	 * Set a flag in the error to alert future interceptors to pass the error through
-	 */
-	bypassRemainingInterceptors(err: any) {
-		err.bypassAuthInterceptors = true;
-	}
-
-	/**
-	 * Default error handler. Override this in any interceptors extending the AuthInterceptor class
-	 */
+export class AuthInterceptor extends Interceptor {
 	handleError(err: any): void {
-		this.router.navigate(['/access'], { state: this.parseError(err) });
+		const { status, type, message, url } = this.parseError(err);
+		if (status === 403) {
+			this.router.navigate(['/access'], { state: { status, type, message, url } });
+			this.bypassRemainingInterceptors(err);
+		}
 	}
 }

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -15,7 +15,7 @@ export class AuthInterceptor implements HttpInterceptor {
 	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(req).pipe(
 			catchError(err => {
-				if (err.bypassAuthInterceptors) {
+				if (!err.bypassAuthInterceptors) {
 					this.handleError(err);
 				}
 				return throwError(err);

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -4,41 +4,48 @@ import { Router } from '@angular/router';
 
 import { throwError, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { SessionService } from './session.service';
 
 /**
  * HTTP Interceptor that will interpret authentication-related HTTP calls
  */
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-	constructor(private router: Router, private sessionService: SessionService) {
-		// Nothing here
-	}
+	constructor(public router: Router) {}
 
 	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 		return next.handle(req).pipe(
 			catchError(err => {
-				// Grab all the useful stuff out of the error response
-				const status = err?.status ?? 200;
-				const type = err?.error?.type ?? '';
-				const url = err?.url ?? '';
-				const message = err?.error?.message ?? '';
-
-				const stateObject = { status, type, message, url };
-
-				// Go to signin if the user isn't logged in and wasn't already on the signin page
-				if (401 === status && !url.endsWith('auth/signin')) {
-					this.router.navigate(['/signin']);
-				} else if (403 === status) {
-					if ('eua' === type) {
-						this.router.navigate(['/eua']);
-					} else {
-						this.router.navigate(['/access'], { state: stateObject });
-					}
+				if (err.bypassAuthInterceptors) {
+					this.handleError(err);
 				}
-
 				return throwError(err);
 			})
 		);
+	}
+
+	/**
+	 * Grab all the useful stuff out of the error response
+	 */
+	parseError(err: any) {
+		const status = err?.status ?? 200;
+		const type = err?.error?.type ?? '';
+		const url = err?.url ?? '';
+		const message = err?.error?.message ?? '';
+
+		return { status, type, message, url };
+	}
+
+	/**
+	 * Set a flag in the error to alert future interceptors to pass the error through
+	 */
+	bypassRemainingInterceptors(err: any) {
+		err.bypassAuthInterceptors = true;
+	}
+
+	/**
+	 * Default error handler. Override this in any interceptors extending the AuthInterceptor class
+	 */
+	handleError(err: any): void {
+		this.router.navigate(['/access'], { state: this.parseError(err) });
 	}
 }

--- a/src/app/core/auth/eua.interceptor.ts
+++ b/src/app/core/auth/eua.interceptor.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
 
-import { AuthInterceptor } from './auth.interceptor';
+import { Interceptor } from './interceptor';
 
+/**
+ * HTTP Interceptor that will interpret EUA related HTTP calls
+ */
 @Injectable()
-export class EuaAuthInterceptor extends AuthInterceptor {
+export class EuaAuthInterceptor extends Interceptor {
 	handleError(err: any): void {
 		const { status, type } = this.parseError(err);
 		if (status === 403 && type === 'eua') {

--- a/src/app/core/auth/eua.interceptor.ts
+++ b/src/app/core/auth/eua.interceptor.ts
@@ -1,0 +1,11 @@
+import { AuthInterceptor } from './auth.interceptor';
+
+export class EuaAuthInterceptor extends AuthInterceptor {
+	handleError(err: any): void {
+		const { status, type } = this.parseError(err);
+		if (status === 403 && type === 'eua') {
+			this.router.navigate(['/eua']);
+			this.bypassRemainingInterceptors(err);
+		}
+	}
+}

--- a/src/app/core/auth/eua.interceptor.ts
+++ b/src/app/core/auth/eua.interceptor.ts
@@ -1,5 +1,8 @@
+import { Injectable } from '@angular/core';
+
 import { AuthInterceptor } from './auth.interceptor';
 
+@Injectable()
 export class EuaAuthInterceptor extends AuthInterceptor {
 	handleError(err: any): void {
 		const { status, type } = this.parseError(err);

--- a/src/app/core/auth/eua.interceptor.ts
+++ b/src/app/core/auth/eua.interceptor.ts
@@ -1,17 +1,16 @@
 import { Injectable } from '@angular/core';
 
-import { Interceptor } from './interceptor';
+import { AbstractHttpInterceptor } from './abstract.interceptor';
 
 /**
  * HTTP Interceptor that will interpret EUA related HTTP calls
  */
 @Injectable()
-export class EuaAuthInterceptor extends Interceptor {
+export class EuaInterceptor extends AbstractHttpInterceptor {
 	handleError(err: any): void {
 		const { status, type } = this.parseError(err);
 		if (status === 403 && type === 'eua') {
 			this.router.navigate(['/eua']);
-			this.bypassRemainingInterceptors(err);
 		}
 	}
 }

--- a/src/app/core/auth/interceptor.ts
+++ b/src/app/core/auth/interceptor.ts
@@ -1,0 +1,49 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { throwError, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+/**
+ * HTTP Interceptor
+ */
+@Injectable()
+export abstract class Interceptor implements HttpInterceptor {
+	protected constructor(public router: Router) {}
+
+	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+		return next.handle(req).pipe(
+			catchError(err => {
+				if (!err.bypassAuthInterceptors) {
+					this.handleError(err);
+				}
+				return throwError(err);
+			})
+		);
+	}
+
+	/**
+	 * Grab all the useful stuff out of the error response
+	 */
+	parseError(err: any) {
+		const status = err?.status ?? 200;
+		const type = err?.error?.type ?? '';
+		const url = err?.url ?? '';
+		const message = err?.error?.message ?? '';
+
+		return { status, type, message, url };
+	}
+
+	/**
+	 * Set a flag in the error to alert future interceptors to pass the error through
+	 */
+	bypassRemainingInterceptors(err: any) {
+		err.bypassAuthInterceptors = true;
+	}
+
+	/**
+	 * Implement this in any interceptors extending the AuthInterceptor class
+	 */
+	abstract handleError(err: any): void;
+}

--- a/src/app/core/auth/signin.interceptor.ts
+++ b/src/app/core/auth/signin.interceptor.ts
@@ -1,5 +1,8 @@
+import { Injectable } from '@angular/core';
+
 import { AuthInterceptor } from './auth.interceptor';
 
+@Injectable()
 export class SigninAuthInterceptor extends AuthInterceptor {
 	handleError(err: any): void {
 		const { status, url } = this.parseError(err);

--- a/src/app/core/auth/signin.interceptor.ts
+++ b/src/app/core/auth/signin.interceptor.ts
@@ -1,0 +1,11 @@
+import { AuthInterceptor } from './auth.interceptor';
+
+export class SigninAuthInterceptor extends AuthInterceptor {
+	handleError(err: any): void {
+		const { status, url } = this.parseError(err);
+		if (status === 401 && !url.endsWith('auth/signin')) {
+			this.router.navigate(['/signin']);
+			this.bypassRemainingInterceptors(err);
+		}
+	}
+}

--- a/src/app/core/auth/signin.interceptor.ts
+++ b/src/app/core/auth/signin.interceptor.ts
@@ -1,17 +1,16 @@
 import { Injectable } from '@angular/core';
 
-import { Interceptor } from './interceptor';
+import { AbstractHttpInterceptor } from './abstract.interceptor';
 
 /**
  * HTTP Interceptor that will interpret Sign In related HTTP calls
  */
 @Injectable()
-export class SigninAuthInterceptor extends Interceptor {
+export class SigninInterceptor extends AbstractHttpInterceptor {
 	handleError(err: any): void {
 		const { status, url } = this.parseError(err);
 		if (status === 401 && !url.endsWith('auth/signin')) {
 			this.router.navigate(['/signin']);
-			this.bypassRemainingInterceptors(err);
 		}
 	}
 }

--- a/src/app/core/auth/signin.interceptor.ts
+++ b/src/app/core/auth/signin.interceptor.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
 
-import { AuthInterceptor } from './auth.interceptor';
+import { Interceptor } from './interceptor';
 
+/**
+ * HTTP Interceptor that will interpret Sign In related HTTP calls
+ */
 @Injectable()
-export class SigninAuthInterceptor extends AuthInterceptor {
+export class SigninAuthInterceptor extends Interceptor {
 	handleError(err: any): void {
 		const { status, url } = this.parseError(err);
 		if (status === 401 && !url.endsWith('auth/signin')) {

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -18,7 +18,9 @@ import { AuthInterceptor } from './auth/auth.interceptor';
 import { AuthenticationService } from './auth/authentication.service';
 import { AuthorizationDirective } from './auth/authorization.directive';
 import { AuthorizationService } from './auth/authorization.service';
+import { EuaAuthInterceptor } from './auth/eua.interceptor';
 import { SessionService } from './auth/session.service';
+import { SigninAuthInterceptor } from './auth/signin.interceptor';
 import { ConfigService } from './config.service';
 import { CoreRoutingModule } from './core-routing.module';
 import { UserEuaComponent } from './eua/user-eua.component';
@@ -92,7 +94,11 @@ export function getConfiguration(configService: ConfigService) {
 			deps: [ConfigService],
 			multi: true
 		},
-		{ provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
+		[
+			{ provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+			{ provide: HTTP_INTERCEPTORS, useClass: EuaAuthInterceptor, multi: true },
+			{ provide: HTTP_INTERCEPTORS, useClass: SigninAuthInterceptor, multi: true }
+		]
 	]
 })
 export class CoreModule {

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -18,9 +18,9 @@ import { AuthInterceptor } from './auth/auth.interceptor';
 import { AuthenticationService } from './auth/authentication.service';
 import { AuthorizationDirective } from './auth/authorization.directive';
 import { AuthorizationService } from './auth/authorization.service';
-import { EuaAuthInterceptor } from './auth/eua.interceptor';
+import { EuaInterceptor } from './auth/eua.interceptor';
 import { SessionService } from './auth/session.service';
-import { SigninAuthInterceptor } from './auth/signin.interceptor';
+import { SigninInterceptor } from './auth/signin.interceptor';
 import { ConfigService } from './config.service';
 import { CoreRoutingModule } from './core-routing.module';
 import { UserEuaComponent } from './eua/user-eua.component';
@@ -96,8 +96,8 @@ export function getConfiguration(configService: ConfigService) {
 		},
 		[
 			{ provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
-			{ provide: HTTP_INTERCEPTORS, useClass: EuaAuthInterceptor, multi: true },
-			{ provide: HTTP_INTERCEPTORS, useClass: SigninAuthInterceptor, multi: true }
+			{ provide: HTTP_INTERCEPTORS, useClass: EuaInterceptor, multi: true },
+			{ provide: HTTP_INTERCEPTORS, useClass: SigninInterceptor, multi: true }
 		]
 	]
 })


### PR DESCRIPTION
The changes in this PR are to enable a more customizable auth interceptor chain. The idea is to be able to chain together interceptors on top of the default interceptor and, if necessary, bypass interceptors lower down on the chain and pass the error though.

I separated out the signin and eua interceptor code into individual interceptors to serve as an illustration of how we can chain these together and be examples for what other custom interceptors that people add to their application modules could look like.