### PR TITLE
SearchInputComponent - supporting a minimum character count and searching on input events

### DIFF
--- a/src/app/common/search-input/search-input.component.html
+++ b/src/app/common/search-input/search-input.component.html
@@ -1,5 +1,15 @@
-<div class="search-input-container d-flex">
-	<input [placeholder]="placeholder" type="text" class="form-control" [(ngModel)]="search" (keyup)="onKeyup()">
+<div class="search-input-container d-flex" [style.width]="width">
+	<input
+		type="text"
+		[placeholder]="placeholder"
+		class="form-control"
+		[(ngModel)]="search"
+		(keyup)="onKeyup()"
+		(input)="onInput()"
+	/>
 	<span *ngIf="search.length === 0" class="icon fa fa-search"></span>
 	<span *ngIf="search.length > 0" (click)="clearSearch($event)" class="icon fa fa-times"></span>
+</div>
+<div *ngIf="showMinCountMessage" [@minCount] class="min-count">
+	<div>Searches require a minimum of {{ minSearchCharacterCount }} characters.</div>
 </div>

--- a/src/app/common/search-input/search-input.component.html
+++ b/src/app/common/search-input/search-input.component.html
@@ -10,6 +10,6 @@
 	<span *ngIf="search.length === 0" class="icon fa fa-search"></span>
 	<span *ngIf="search.length > 0" (click)="clearSearch($event)" class="icon fa fa-times"></span>
 </div>
-<div *ngIf="showMinCountMessage" [@minCount] class="min-count">
+<div *ngIf="!disableMinCountMessage && showMinCountMessage" [@minCount] class="text-muted pt-2">
 	<div class="pt-2">Searches require a minimum of {{ minSearchCharacterCount }} characters.</div>
 </div>

--- a/src/app/common/search-input/search-input.component.html
+++ b/src/app/common/search-input/search-input.component.html
@@ -11,5 +11,5 @@
 	<span *ngIf="search.length > 0" (click)="clearSearch($event)" class="icon fa fa-times"></span>
 </div>
 <div *ngIf="showMinCountMessage" [@minCount] class="min-count">
-	<div>Searches require a minimum of {{ minSearchCharacterCount }} characters.</div>
+	<div class="pt-2">Searches require a minimum of {{ minSearchCharacterCount }} characters.</div>
 </div>

--- a/src/app/common/search-input/search-input.component.html
+++ b/src/app/common/search-input/search-input.component.html
@@ -1,4 +1,4 @@
-<div class="search-input-container d-flex" [style.width]="width">
+<div class="search-input-container d-flex">
 	<input
 		type="text"
 		[placeholder]="placeholder"

--- a/src/app/common/search-input/search-input.component.scss
+++ b/src/app/common/search-input/search-input.component.scss
@@ -12,8 +12,3 @@
 	float: right;
 	z-index: 500;
 }
-
-.min-count {
-	color: map-get($palette-gray, 700);
-	font-size: 0.8rem;
-}

--- a/src/app/common/search-input/search-input.component.scss
+++ b/src/app/common/search-input/search-input.component.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/palettes';
+
 .search-input-container {
 	width: 350px;
 }
@@ -9,4 +11,13 @@
 	margin-left: -20px;
 	float: right;
 	z-index: 500;
+}
+
+.min-count {
+	color: map-get($palette-gray, 700);
+	font-size: 14px;
+
+	div {
+		padding-top: 5px;
+	}
 }

--- a/src/app/common/search-input/search-input.component.scss
+++ b/src/app/common/search-input/search-input.component.scss
@@ -15,9 +15,5 @@
 
 .min-count {
 	color: map-get($palette-gray, 700);
-	font-size: 14px;
-
-	div {
-		padding-top: 5px;
-	}
+	font-size: 0.8rem;
 }

--- a/src/app/common/search-input/search-input.component.spec.ts
+++ b/src/app/common/search-input/search-input.component.spec.ts
@@ -1,0 +1,156 @@
+import { ElementRef, EventEmitter } from '@angular/core';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { SearchInputComponent } from './search-input.component';
+
+describe('SearchInputComponent', () => {
+	let fixture: ComponentFixture<SearchInputComponent>,
+		componentInstance: SearchInputComponent,
+		inputElement: ElementRef<HTMLInputElement>;
+
+	beforeEach(() => {
+		fixture = TestBed.configureTestingModule({
+			declarations: [SearchInputComponent],
+			imports: [FormsModule, NoopAnimationsModule]
+		}).createComponent(SearchInputComponent);
+
+		componentInstance = fixture.componentInstance;
+
+		// replace the emit function of applySearch with a spy
+		componentInstance.applySearch.emit = jasmine.createSpy();
+		inputElement = fixture.debugElement.query(By.css('input'));
+
+		fixture.detectChanges();
+	});
+
+	it('should apply search on `keyup` event by default', fakeAsync(() => {
+		inputElement.nativeElement.value = 'search value';
+		fixture.detectChanges();
+		// need to trigger input event here so ngModel will set `search` property correctly
+		// this line by itself will not trigger a search
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+
+		// this line should trigger a search
+		inputElement.nativeElement.dispatchEvent(new Event('keyup'));
+		tick(350);
+
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledTimes(1);
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledWith('search value');
+	}));
+
+	it('should not apply the search if keyup is never triggered', fakeAsync(() => {
+		inputElement.nativeElement.value = 'search value';
+		fixture.detectChanges();
+		// need to trigger input event here so ngModel will set `search` property correctly
+		// this line by itself will not trigger a search
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+
+		tick(350);
+
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledTimes(0);
+	}));
+
+	it('should apply search if preferInputEvent is true and an input event is trigered', fakeAsync(() => {
+		componentInstance.preferInputEvent = true;
+		inputElement.nativeElement.value = 'search value';
+		fixture.detectChanges();
+
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+
+		tick(350);
+
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledTimes(1);
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledWith('search value');
+	}));
+
+	it('should not apply search if minSearchCharacterCount is specified not adhered to', fakeAsync(() => {
+		componentInstance.minSearchCharacterCount = 3;
+		inputElement.nativeElement.value = 'se';
+		fixture.detectChanges();
+
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		inputElement.nativeElement.dispatchEvent(new Event('keyup'));
+
+		tick(350);
+
+		expect(componentInstance.applySearch.emit).not.toHaveBeenCalled();
+	}));
+
+	it('should show warning message if minSearchCharacterCount is specified and not adhered to', fakeAsync(() => {
+		componentInstance.minSearchCharacterCount = 3;
+		inputElement.nativeElement.value = 'se';
+		fixture.detectChanges();
+
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		inputElement.nativeElement.dispatchEvent(new Event('keyup'));
+
+		tick(350);
+
+		fixture.detectChanges();
+
+		expect(
+			(fixture.debugElement.query(By.css('.min-count')).nativeElement as HTMLElement)
+				.textContent
+		).toEqual('Searches require a minimum of 3 characters.');
+	}));
+
+	it('should not show warning message if minSearchCharacterCount is specified and adhered to', fakeAsync(() => {
+		componentInstance.minSearchCharacterCount = 3;
+		inputElement.nativeElement.value = 'sea';
+		fixture.detectChanges();
+
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		inputElement.nativeElement.dispatchEvent(new Event('keyup'));
+
+		tick(350);
+
+		fixture.detectChanges();
+
+		expect(fixture.debugElement.query(By.css('.min-count'))).toBeNull();
+	}));
+
+	it('should show clear-search options if search input length > 0', () => {
+		inputElement.nativeElement.value = 'search';
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+
+		expect(fixture.debugElement.queryAll(By.css('.icon.fa.fa-times')).length).toBe(1);
+	});
+
+	it('should not show clear-search options if search input length === 0', () => {
+		inputElement.nativeElement.value = '';
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+
+		expect(fixture.debugElement.queryAll(By.css('span.icon.fa-times')).length).toBe(0);
+	});
+
+	it('should clear the search when the clearSearch span is clicked', async(() => {
+		const clearSearchSpy = spyOn(componentInstance, 'clearSearch').and.callThrough();
+
+		inputElement.nativeElement.value = 'search';
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+
+		// click the clear-search option
+		(fixture.debugElement.query(By.css('span.icon.fa-times'))
+			.nativeElement as HTMLElement).click();
+
+		fixture.detectChanges();
+
+		expect(clearSearchSpy).toHaveBeenCalledTimes(1);
+		expect(componentInstance.search).toBe('');
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledTimes(1);
+		expect(componentInstance.applySearch.emit).toHaveBeenCalledWith('');
+
+		fixture.whenRenderingDone().then(() => {
+			expect(
+				(fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement)
+					.value
+			).toBe('');
+		});
+	}));
+});

--- a/src/app/common/search-input/search-input.component.spec.ts
+++ b/src/app/common/search-input/search-input.component.spec.ts
@@ -1,5 +1,5 @@
 import { ElementRef, EventEmitter } from '@angular/core';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { async, fakeAsync, tick, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -7,9 +7,9 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SearchInputComponent } from './search-input.component';
 
 describe('SearchInputComponent', () => {
-	let fixture: ComponentFixture<SearchInputComponent>,
-		componentInstance: SearchInputComponent,
-		inputElement: ElementRef<HTMLInputElement>;
+	let fixture: ComponentFixture<SearchInputComponent>;
+	let componentInstance: SearchInputComponent;
+	let inputElement: ElementRef<HTMLInputElement>;
 
 	beforeEach(() => {
 		fixture = TestBed.configureTestingModule({

--- a/src/app/common/search-input/search-input.component.spec.ts
+++ b/src/app/common/search-input/search-input.component.spec.ts
@@ -92,7 +92,7 @@ describe('SearchInputComponent', () => {
 		fixture.detectChanges();
 
 		expect(
-			(fixture.debugElement.query(By.css('.min-count')).nativeElement as HTMLElement)
+			(fixture.debugElement.query(By.css('.text-muted')).nativeElement as HTMLElement)
 				.textContent
 		).toEqual('Searches require a minimum of 3 characters.');
 	}));
@@ -109,7 +109,39 @@ describe('SearchInputComponent', () => {
 
 		fixture.detectChanges();
 
-		expect(fixture.debugElement.query(By.css('.min-count'))).toBeNull();
+		expect(fixture.debugElement.query(By.css('.text-muted'))).toBeNull();
+	}));
+
+	it('should not show warning message if disableMinCountMessage is set when minSearchCharacterCount is adhered to', fakeAsync(() => {
+		componentInstance.minSearchCharacterCount = 3;
+		componentInstance.disableMinCountMessage = true;
+		inputElement.nativeElement.value = 'sea';
+		fixture.detectChanges();
+
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		inputElement.nativeElement.dispatchEvent(new Event('keyup'));
+
+		tick(350);
+
+		fixture.detectChanges();
+
+		expect(fixture.debugElement.query(By.css('.text-muted'))).toBeNull();
+	}));
+
+	it('should not show warning message if disableMinCountMessage is set when minSearchCharacterCount is not adhered to', fakeAsync(() => {
+		componentInstance.minSearchCharacterCount = 3;
+		componentInstance.disableMinCountMessage = true;
+		inputElement.nativeElement.value = 'se';
+		fixture.detectChanges();
+
+		inputElement.nativeElement.dispatchEvent(new Event('input'));
+		inputElement.nativeElement.dispatchEvent(new Event('keyup'));
+
+		tick(350);
+
+		fixture.detectChanges();
+
+		expect(fixture.debugElement.query(By.css('.text-muted'))).toBeNull();
 	}));
 
 	it('should show clear-search options if search input length > 0', () => {

--- a/src/app/common/search-input/search-input.component.ts
+++ b/src/app/common/search-input/search-input.component.ts
@@ -1,24 +1,69 @@
+import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
+import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
+import { Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
+
+@UntilDestroy()
 @Component({
 	selector: 'asy-search-input',
 	templateUrl: './search-input.component.html',
-	styleUrls: ['./search-input.component.scss']
+	styleUrls: ['./search-input.component.scss'],
+	animations: [
+		trigger('minCount', [
+			transition(':enter', [
+				style({ opacity: 0, height: 0 }),
+				animate('200ms ease', style({ opacity: 1, height: '*' }))
+			]),
+			transition(':leave', [
+				style({ opacity: 1, height: '*' }),
+				animate('200ms ease', style({ opacity: 0, height: 0 }))
+			])
+		])
+	]
 })
 export class SearchInputComponent {
 	@Input() placeholder = 'Search...';
 	@Output() readonly applySearch: EventEmitter<string> = new EventEmitter();
 	@Input() search = '';
+	@Input() width = '350px';
 
-	private keyupTimeout: any;
+	/**
+	 * If true, searches will be made on `input` events, otherwise searches will be made on `keyup` events
+	 */
+	@Input() preferInputEvent: boolean = false;
 
-	constructor() {}
+	/**
+	 * Specifies a minimum character count required to search.
+	 * In the event the number of characters is between 0 and the minimum, a warning message is shown beneath the search bar
+	 */
+	@Input() minSearchCharacterCount: number = 0;
+
+	searchInput$ = new Subject<void>();
+	showMinCountMessage = false;
+
+	constructor() {
+		this.searchInput$.pipe(debounceTime(350), untilDestroyed(this)).subscribe(() => {
+			if (this.search.length === 0 || this.search.length >= this.minSearchCharacterCount) {
+				this.showMinCountMessage = false;
+				this.applySearch.emit(this.search);
+			} else {
+				this.showMinCountMessage = true;
+			}
+		});
+	}
 
 	onKeyup() {
-		clearTimeout(this.keyupTimeout);
-		this.keyupTimeout = setTimeout(() => {
-			this.applySearch.emit(this.search);
-		}, 350);
+		if (!this.preferInputEvent) {
+			this.searchInput$.next();
+		}
+	}
+
+	onInput() {
+		if (this.preferInputEvent) {
+			this.searchInput$.next();
+		}
 	}
 
 	clearSearch(event?: MouseEvent) {

--- a/src/app/common/search-input/search-input.component.ts
+++ b/src/app/common/search-input/search-input.component.ts
@@ -27,7 +27,6 @@ export class SearchInputComponent {
 	@Input() placeholder = 'Search...';
 	@Output() readonly applySearch: EventEmitter<string> = new EventEmitter();
 	@Input() search = '';
-	@Input() width = '350px';
 
 	/**
 	 * If true, searches will be made on `input` events, otherwise searches will be made on `keyup` events

--- a/src/app/common/search-input/search-input.component.ts
+++ b/src/app/common/search-input/search-input.component.ts
@@ -39,7 +39,15 @@ export class SearchInputComponent {
 	 */
 	@Input() minSearchCharacterCount = 0;
 
+	/**
+	 * When set to true, the minimum search character
+	 * message count will not be displayed, even if the search
+	 * value is less than the minimum number of characters.
+	 */
+	@Input() disableMinCountMessage = false;
+
 	searchInput$ = new Subject<void>();
+
 	showMinCountMessage = false;
 
 	constructor() {

--- a/src/app/common/search-input/search-input.component.ts
+++ b/src/app/common/search-input/search-input.component.ts
@@ -32,13 +32,13 @@ export class SearchInputComponent {
 	/**
 	 * If true, searches will be made on `input` events, otherwise searches will be made on `keyup` events
 	 */
-	@Input() preferInputEvent: boolean = false;
+	@Input() preferInputEvent = false;
 
 	/**
 	 * Specifies a minimum character count required to search.
 	 * In the event the number of characters is between 0 and the minimum, a warning message is shown beneath the search bar
 	 */
-	@Input() minSearchCharacterCount: number = 0;
+	@Input() minSearchCharacterCount = 0;
 
 	searchInput$ = new Subject<void>();
 	showMinCountMessage = false;

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,12 +1,11 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
+import 'zone.js/dist/zone-testing';
 
 import { getTestBed } from '@angular/core/testing';
 import {
 	platformBrowserDynamicTesting,
 	BrowserDynamicTestingModule
 } from '@angular/platform-browser-dynamic/testing';
-
-import 'zone.js/dist/zone-testing';
 
 declare const require: any;
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,7 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+/* tslint:disable:ordered-imports */
+// we need to import this file first in order to use fakeAsync
 import 'zone.js/dist/zone-testing';
 
 import { getTestBed } from '@angular/core/testing';


### PR DESCRIPTION
This PR refactors and extends the SearchInputComponent in several ways:
- refactor the component away from using `setTimeout` and towards using debounced RxJS subjects
- add a minimum character count and a warning that will show beneath the input in the event the search value is between (noninclusive) 0 and the min
- add ability for component to optionally search on `input` events on search input element, rather than the existing `keyup` event handlers - this way, hitting no-op keys like the ctrl/cmd, shift, etc don't trigger redundant searches