### PR TITLE
#168 Allowing help documentation to be viewed by all user types

### DIFF
--- a/src/app/core/help/help-routing.module.ts
+++ b/src/app/core/help/help-routing.module.ts
@@ -19,8 +19,6 @@ export class HelpBreadcrumbResolver implements Resolve<string> {
 			{
 				path: 'help',
 				component: HelpComponent,
-				canActivate: [AuthGuard],
-				data: { roles: ['user'] },
 				children: [
 					/**
 					 * Default Route


### PR DESCRIPTION
This allows help documentation to be viewed by all user types: anonymous, authenticated, and authorized.

Resolves #168 