### PR TITLE
redirect authorized users to homepage when visiting unauthorized page

### DIFF
--- a/src/app/core/auth/auth.guard.ts
+++ b/src/app/core/auth/auth.guard.ts
@@ -108,6 +108,11 @@ export class AuthGuard implements CanActivate {
 				this.router.navigate(['/unauthorized']);
 				return false;
 			}
+
+			// redirect a user to the homepage if they are authorized
+			if (missingRoles.length === 0 && state.url === '/unauthorized') {
+				this.router.navigate(['']);
+			}
 		}
 
 		return true;


### PR DESCRIPTION
During the sign-up process, some users will end up on the unauthorized page when they're missing roles to access pages. However, if they get assigned the valid role, and they refresh the page, they should automatically be redirected instead of staying on the unauthorized page if they are now authorized.