### PR TITLE
ci: update node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - name: Git checkout


### PR DESCRIPTION
We previously moved from node 10 to node 12.  Dropping 10.x from build matrix and adding 14.x.