### PR TITLE
#176 Fixing the EUA error handling

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -95,9 +95,9 @@ export function getConfiguration(configService: ConfigService) {
 			multi: true
 		},
 		[
-			{ provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+			{ provide: HTTP_INTERCEPTORS, useClass: SigninInterceptor, multi: true },
 			{ provide: HTTP_INTERCEPTORS, useClass: EuaInterceptor, multi: true },
-			{ provide: HTTP_INTERCEPTORS, useClass: SigninInterceptor, multi: true }
+			{ provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
 		]
 	]
 })


### PR DESCRIPTION
The previous provider config was letting the Auth Interceptor catch 403 errors prior to the EUA Interceptor seeing the error. This prevented users from ever accepting a newly published EUA.