### PR TITLE
BLOC-580 Add Preview Buttons to Message Components / EUA List

### DIFF
--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.html
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.html
@@ -53,6 +53,9 @@
 							</span>
 							<ul *dropdownMenu class="dropdown-menu dropdown-menu-right mt-2">
 								<li>
+									<a class="dropdown-item" (click)="previewEndUserAgreement(eua.euaModel)">Preview</a>
+								</li>
+								<li>
 									<a class="dropdown-item" [routerLink]="['/admin/eua', eua.euaModel._id]">Edit</a>
 								</li>
 								<li>

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.spec.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { of } from 'rxjs';
+import { ModalService } from 'src/app/common/modal.module';
+import { SystemAlertService } from 'src/app/common/system-alert.module';
+import { AdminListEuasComponent } from './admin-list-euas.component';
+import { EuaService } from './eua.service';
+
+describe('Admin List End User Agreements Component', () => {
+	let activatedRoute: any;
+	let endUserAgreementServiceSpy: any;
+	let modalServiceSpy: any;
+
+	let fixture: ComponentFixture<AdminListEuasComponent>;
+	let rootHTMLElement: HTMLElement;
+	let component: AdminListEuasComponent;
+
+	beforeEach(() => {
+		activatedRoute = {
+			params: of({})
+		};
+		endUserAgreementServiceSpy = jasmine.createSpyObj('EuaService', ['search']);
+		endUserAgreementServiceSpy.search.and.callFake(() => {
+			return of();
+		});
+		endUserAgreementServiceSpy.cache = {};
+		modalServiceSpy = jasmine.createSpyObj('ModalService', ['alert']);
+		modalServiceSpy.alert.and.callFake(() => {
+			return of();
+		});
+		const testBed = TestBed.configureTestingModule({
+			declarations: [AdminListEuasComponent],
+			imports: [ModalModule.forRoot(), RouterTestingModule],
+			providers: [
+				{ provide: ActivatedRoute, useValue: activatedRoute },
+				{ provide: EuaService, useValue: endUserAgreementServiceSpy },
+				{ provide: ModalService, useValue: modalServiceSpy },
+				SystemAlertService
+			]
+		});
+		fixture = testBed.createComponent(AdminListEuasComponent);
+		component = fixture.componentInstance;
+		rootHTMLElement = fixture.debugElement.nativeElement;
+	});
+
+	it('Should Exist', () => {
+		fixture.detectChanges();
+		expect(component).toBeDefined();
+	});
+
+	it('Should Open a Modal When Preview End User Agreement', () => {
+		fixture.detectChanges();
+		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(0);
+		component.previewEndUserAgreement({});
+		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
@@ -185,7 +185,6 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 	 * @param endUserAgreement - the end user agreement used to populate the modal
 	 */
 	previewEndUserAgreement(endUserAgreement: any) {
-		console.log(endUserAgreement);
 		const { text, title } = endUserAgreement;
 		this.modalService.alert(title, text);
 	}

--- a/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/admin-list-euas.component.ts
@@ -178,4 +178,15 @@ export class AdminListEuasComponent extends AbstractPageableDataComponent<EndUse
 
 		return this.euaService.search(query, search, pagingOptions, {});
 	}
+
+	/**
+	 * Opens a preview modal containing the text and title of this end user agreement.
+	 *
+	 * @param endUserAgreement - the end user agreement used to populate the modal
+	 */
+	previewEndUserAgreement(endUserAgreement: any) {
+		console.log(endUserAgreement);
+		const { text, title } = endUserAgreement;
+		this.modalService.alert(title, text);
+	}
 }

--- a/src/app/core/admin/messages/create-message.component.spec.ts
+++ b/src/app/core/admin/messages/create-message.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { of } from 'rxjs';
+import { ModalService } from 'src/app/common/modal.module';
+import { SystemAlertService } from 'src/app/common/system-alert.module';
+import { ConfigService } from '../../config.service';
+import { Message, MessageType } from '../../messages/message.class';
+import { MessageService } from '../../messages/message.service';
+import { CreateMessageComponent } from './create-message.component';
+
+describe('Create Message Component', () => {
+	let configServiceSpy: any;
+	let messageServiceSpy: any;
+	let modalServiceSpy: any;
+
+	let fixture: ComponentFixture<CreateMessageComponent>;
+	let rootHTMLElement: HTMLElement;
+	let component: CreateMessageComponent;
+
+	const dateTime = new Date().getTime();
+	const message: Message[] = [
+		new Message().setFromModel({
+			_id: '1234567890',
+			title: 'Test Message',
+			type: MessageType.INFO,
+			body: '<b>Test Message</b>',
+			updated: dateTime,
+			created: dateTime,
+			creator: 'Test Creator'
+		})
+	];
+
+	beforeEach(() => {
+		configServiceSpy = jasmine.createSpyObj('ConfigService', ['getConfig']);
+		configServiceSpy.getConfig.and.returnValue(of({}));
+		messageServiceSpy = jasmine.createSpyObj('MessageService', ['create']);
+		messageServiceSpy.create.and.callFake(() => {
+			return of(message);
+		});
+		modalServiceSpy = jasmine.createSpyObj('ModalService', ['alert']);
+		modalServiceSpy.alert.and.callFake(() => {
+			return of();
+		});
+		const testBed = TestBed.configureTestingModule({
+			declarations: [CreateMessageComponent],
+			imports: [ModalModule.forRoot(), RouterTestingModule],
+			providers: [
+				{ provide: ConfigService, useValue: configServiceSpy },
+				{ provide: MessageService, useValue: messageServiceSpy },
+				{ provide: ModalService, useValue: modalServiceSpy },
+				SystemAlertService
+			]
+		});
+		fixture = testBed.createComponent(CreateMessageComponent);
+		component = fixture.componentInstance;
+		rootHTMLElement = fixture.debugElement.nativeElement;
+	});
+
+	it('Should Exist', () => {
+		fixture.detectChanges();
+		expect(component).toBeDefined();
+	});
+
+	it('Should Have a Preview Button', () => {
+		fixture.detectChanges();
+		const buttons = rootHTMLElement.querySelectorAll('button');
+		let foundPreviewButton = false;
+		buttons.forEach(button => {
+			if (button.innerText === 'Preview') {
+				foundPreviewButton = true;
+			}
+		});
+		expect(foundPreviewButton).toBeTrue();
+	});
+
+	it('Should Open a Modal When Preview Message', () => {
+		fixture.detectChanges();
+		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(0);
+		component.previewMessage();
+		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/app/core/admin/messages/create-message.component.ts
+++ b/src/app/core/admin/messages/create-message.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { UntilDestroy } from '@ngneat/until-destroy';
+import { ModalService } from 'src/app/common/modal.module';
 import { SystemAlertService } from 'src/app/common/system-alert.module';
 import { ConfigService } from '../../config.service';
 import { Message, MessageType } from '../../messages/message.class';
@@ -16,12 +17,13 @@ export class CreateMessageComponent extends ManageMessageComponent {
 	mode = 'admin-create';
 
 	constructor(
+		protected modalService: ModalService,
 		router: Router,
 		configService: ConfigService,
 		alertService: SystemAlertService,
 		private messageService: MessageService
 	) {
-		super(router, configService, alertService);
+		super(modalService, router, configService, alertService);
 	}
 
 	initialize() {

--- a/src/app/core/admin/messages/edit-message.component.spec.ts
+++ b/src/app/core/admin/messages/edit-message.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
+import { ModalModule } from 'ngx-bootstrap/modal';
 import { of } from 'rxjs';
 import { ModalService } from 'src/app/common/modal.module';
 import { SystemAlertService } from 'src/app/common/system-alert.module';

--- a/src/app/core/admin/messages/edit-message.component.spec.ts
+++ b/src/app/core/admin/messages/edit-message.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { BsModalService, ModalModule } from 'ngx-bootstrap/modal';
+import { of } from 'rxjs';
+import { ModalService } from 'src/app/common/modal.module';
+import { SystemAlertService } from 'src/app/common/system-alert.module';
+import { ConfigService } from '../../config.service';
+import { Message, MessageType } from '../../messages/message.class';
+import { MessageService } from '../../messages/message.service';
+import { UpdateMessageComponent } from './edit-message.component';
+
+describe('Update Message Component', () => {
+	let configServiceSpy: any;
+	let messageServiceSpy: any;
+	let modalServiceSpy: any;
+
+	let fixture: ComponentFixture<UpdateMessageComponent>;
+	let rootHTMLElement: HTMLElement;
+	let component: UpdateMessageComponent;
+
+	const dateTime = new Date().getTime();
+	const message: Message[] = [
+		new Message().setFromModel({
+			_id: '1234567890',
+			title: 'Test Message',
+			type: MessageType.INFO,
+			body: '<b>Test Message</b>',
+			updated: dateTime,
+			created: dateTime,
+			creator: 'Test Creator'
+		})
+	];
+
+	beforeEach(() => {
+		configServiceSpy = jasmine.createSpyObj('ConfigService', ['getConfig']);
+		configServiceSpy.getConfig.and.returnValue(of({}));
+		messageServiceSpy = jasmine.createSpyObj('MessageService', ['create', 'get']);
+		messageServiceSpy.create.and.callFake(() => {
+			return of(message);
+		});
+		messageServiceSpy.get.and.callFake(() => {
+			return of(message);
+		});
+		modalServiceSpy = jasmine.createSpyObj('ModalService', ['alert']);
+		modalServiceSpy.alert.and.callFake(() => {
+			return of();
+		});
+		const testBed = TestBed.configureTestingModule({
+			declarations: [UpdateMessageComponent],
+			imports: [ModalModule.forRoot(), RouterTestingModule],
+			providers: [
+				{ provide: ConfigService, useValue: configServiceSpy },
+				{ provide: MessageService, useValue: messageServiceSpy },
+				{ provide: ModalService, useValue: modalServiceSpy },
+				SystemAlertService
+			]
+		});
+		fixture = testBed.createComponent(UpdateMessageComponent);
+		component = fixture.componentInstance;
+		rootHTMLElement = fixture.debugElement.nativeElement;
+	});
+
+	it('Should Exist', () => {
+		fixture.detectChanges();
+		expect(component).toBeDefined();
+	});
+
+	it('Should Have a Preview Button', () => {
+		fixture.detectChanges();
+		const buttons = rootHTMLElement.querySelectorAll('button');
+		let foundPreviewButton = false;
+		buttons.forEach(button => {
+			if (button.innerText === 'Preview') {
+				foundPreviewButton = true;
+			}
+		});
+		expect(foundPreviewButton).toBeTrue();
+	});
+
+	it('Should Open a Modal When Preview Message', () => {
+		fixture.detectChanges();
+		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(0);
+		component.previewMessage();
+		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/app/core/admin/messages/edit-message.component.ts
+++ b/src/app/core/admin/messages/edit-message.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
+import { ModalService } from 'src/app/common/modal.module';
 import { SystemAlertService } from 'src/app/common/system-alert.module';
 import { ConfigService } from '../../config.service';
 import { Message } from '../../messages/message.class';
@@ -18,13 +19,14 @@ export class UpdateMessageComponent extends ManageMessageComponent {
 	private id: string;
 
 	constructor(
+		protected modalService: ModalService,
 		router: Router,
 		protected route: ActivatedRoute,
 		configService: ConfigService,
 		alertService: SystemAlertService,
 		protected messageService: MessageService
 	) {
-		super(router, configService, alertService);
+		super(modalService, router, configService, alertService);
 	}
 
 	initialize() {

--- a/src/app/core/admin/messages/list-messages.component.html
+++ b/src/app/core/admin/messages/list-messages.component.html
@@ -44,6 +44,9 @@
 						</span>
 						<ul *dropdownMenu class="dropdown-menu dropdown-menu-right mt-2">
 							<li>
+								<a class="dropdown-item" (click)="previewMessage(message)">Preview</a>
+							</li>
+							<li>
 								<a class="dropdown-item" [routerLink]="['/admin/message', message._id]">Edit</a>
 							</li>
 							<li>

--- a/src/app/core/admin/messages/list-messages.component.ts
+++ b/src/app/core/admin/messages/list-messages.component.ts
@@ -114,4 +114,14 @@ export class ListMessagesComponent extends AbstractPageableDataComponent<Message
 				}
 			);
 	}
+
+	/**
+	 * Opens a preview modal containing the body and title of this message.
+	 *
+	 * @param message - the message used to populate the modal
+	 */
+	previewMessage(message: Message) {
+		const { body, title } = message;
+		this.modalService.alert(title, body);
+	}
 }

--- a/src/app/core/admin/messages/manage-message.component.html
+++ b/src/app/core/admin/messages/manage-message.component.html
@@ -37,6 +37,7 @@
 		<div class="form-group">
 			<div class="text-right">
 				<button type="button" class="btn btn-link mr-2" [routerLink]="['/admin/messages']">Cancel</button>
+				<button type="button" class="btn btn-outline-secondary mr-2" (click)="previewMessage()">Preview</button>
 				<button type="submit" class="btn btn-primary" [disabled]="okDisabled">{{okButtonText}}</button>
 			</div>
 		</div>

--- a/src/app/core/admin/messages/manage-message.component.ts
+++ b/src/app/core/admin/messages/manage-message.component.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { untilDestroyed } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
+import { ModalService } from 'src/app/common/modal.module';
 import { SystemAlertService } from 'src/app/common/system-alert.module';
 import { ConfigService } from '../../config.service';
 import { Message } from '../../messages/message.class';
@@ -30,6 +31,7 @@ export abstract class ManageMessageComponent implements OnInit {
 	protected navigateOnSuccess: string;
 
 	constructor(
+		protected modalService: ModalService,
 		protected router: Router,
 		protected configService: ConfigService,
 		public alertService: SystemAlertService

--- a/src/app/core/admin/messages/manage-message.component.ts
+++ b/src/app/core/admin/messages/manage-message.component.ts
@@ -52,6 +52,11 @@ export abstract class ManageMessageComponent implements OnInit {
 
 	abstract submitMessage(message: Message): Observable<any>;
 
+	previewMessage() {
+		const { body, title } = this.message;
+		this.modalService.alert(title, body);
+	}
+
 	submit() {
 		this.submitMessage(this.message)
 			.pipe(untilDestroyed(this))


### PR DESCRIPTION
**Changes**
* Added preview button to base message and message list template
* Added preview drop-down item to EUA list template
* Added event handlers to pop up modal previewing title / content as HTML
* Added tests

**How to Verify**
* Go to the message list
* Create a message
* Verify that you can click the preview button in the message screen
* Go back to the message list
* Verify that the hamburger menu for a message shows a preview option (which opens the same modal)
* Go to the EUA list
* Create an EUA (the preview button here already existed)
* Go back to the EUA list
* Verify that the hamburger menu for an EUA shows a preview option (which opens a modal)