### PR TITLE
feat(teams): UI Support for nested teams

### DIFF
--- a/src/app/core/config.model.ts
+++ b/src/app/core/config.model.ts
@@ -21,6 +21,7 @@ interface TeamConfig {
 	implicitMembers: {
 		strategy: string;
 	};
+	nestedTeams?: boolean;
 }
 
 interface UserPreferencesConfig {
@@ -40,7 +41,7 @@ export interface Config {
 	banner: BannerConfig;
 	copyright: BannerConfig;
 
-	teams: TeamConfig;
+	teams?: TeamConfig;
 
 	feedback?: FeedbackConfig;
 

--- a/src/app/core/teams/create-team/create-team.component.html
+++ b/src/app/core/teams/create-team/create-team.component.html
@@ -22,7 +22,8 @@
 		<!-- Team Name -->
 		<div class="form-group pt-4">
 			<label class="form-required" for="name">Team Name</label>
-			<input type="text" class="form-control" id="name" name="name" [(ngModel)]="team.name" required/>
+			<input type="text" class="form-control" id="name" name="name"
+				   placeholder="Enter team name..." [(ngModel)]="team.name" required/>
 		</div>
 
 		<!-- Team Admin -->
@@ -43,7 +44,20 @@
 		<!-- Description -->
 		<div class="form-group">
 			<label for="description">Description</label>
-			<textarea rows="3" class="form-control" id="description" name="description" [(ngModel)]="team.description"></textarea>
+			<textarea rows="3" class="form-control" id="description" name="description"
+					  placeholder="Enter description..." [(ngModel)]="team.description"></textarea>
+		</div>
+
+		<!-- Team Parent -->
+		<div class="form-group" *ngIf="nestedTeamsEnabled">
+			<label for="parent">Parent Team</label>
+			<app-team-select-input
+				id="parent" name="parent"
+				placeholder="Select parent..."
+				class="d-block"
+				style="width: 400px;"
+				[(ngModel)]="team.parent">
+			</app-team-select-input>
 		</div>
 
 		<!-- Implicit Teams Members -->

--- a/src/app/core/teams/list-teams/list-teams.component.html
+++ b/src/app/core/teams/list-teams/list-teams.component.html
@@ -1,17 +1,21 @@
 <section>
-	<h1 class="mb-3">
-		Teams
-		<small>View and manage team membership and roles</small>
-	</h1>
+	<ng-container *ngIf="!embedded">
+		<h1 class="mb-3">
+			Teams
+			<small>View and manage team membership and roles</small>
+		</h1>
 
-	<!-- Alert Notifications -->
-	<system-alert></system-alert>
+		<!-- Alert Notifications -->
+		<system-alert></system-alert>
 
-	<div class="pt-2">
+	</ng-container>
+
+	<div [class.pt-2]="!embedded">
 
 		<div class="d-flex mb-3 align-items-center">
 			<asy-search-input placeholder="Search teams..." (applySearch)="searchEvent$.next($event)"></asy-search-input>
-			<button routerLink="/team/create" type="button" class="btn btn-primary ml-auto" *ngIf="canCreateTeam">
+			<button [routerLink]="['/team/create']" [queryParams]="{ parent: parent?._id }"
+					type="button" class="btn btn-primary ml-auto" *ngIf="canCreateTeam">
 				<span class="fa fa-plus"></span> Create Team
 			</button>
 		</div>

--- a/src/app/core/teams/team-select-input/team-select-input.component.html
+++ b/src/app/core/teams/team-select-input/team-select-input.component.html
@@ -1,0 +1,6 @@
+<ng-select
+	[items]="options$ | async"
+	[(ngModel)]="value"
+	[placeholder]="placeholder"
+	bindLabel="name">
+</ng-select>

--- a/src/app/core/teams/team-select-input/team-select-input.component.ts
+++ b/src/app/core/teams/team-select-input/team-select-input.component.ts
@@ -1,0 +1,70 @@
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ControlValueAccessor, NgModel, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { NgSelectComponent } from '@ng-select/ng-select';
+
+import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
+import { Observable } from 'rxjs';
+import { Team } from '../team.model';
+import { TeamsService } from '../teams.service';
+
+@UntilDestroy()
+@Component({
+	selector: 'app-team-select-input',
+	templateUrl: './team-select-input.component.html',
+	styleUrls: ['./team-select-input.component.scss'],
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: TeamSelectInputComponent,
+			multi: true
+		}
+	]
+})
+export class TeamSelectInputComponent implements ControlValueAccessor, OnDestroy, OnInit {
+	@ViewChild(NgModel, { static: true })
+	model: NgModel;
+
+	@Input() placeholder: string;
+
+	private innerValue: Team;
+	private changed = new Array<(value: Team) => void>();
+	private touched = new Array<() => void>();
+
+	options$: Observable<Team[]>;
+
+	constructor(private teamsService: TeamsService) {}
+
+	ngOnDestroy() {}
+
+	ngOnInit() {
+		this.options$ = this.teamsService.getTeamsCanManageResources().pipe(untilDestroyed(this));
+	}
+
+	get value(): Team {
+		return this.innerValue;
+	}
+
+	set value(value: Team) {
+		if (this.innerValue !== value) {
+			this.writeValue(value);
+			this.propagateChange();
+		}
+	}
+
+	writeValue(value: Team) {
+		this.innerValue = value;
+	}
+
+	registerOnChange(fn: (value: Team) => void) {
+		this.changed.push(fn);
+	}
+
+	registerOnTouched(fn: () => void) {
+		this.touched.push(fn);
+	}
+
+	propagateChange() {
+		this.changed.forEach(f => f(this.innerValue));
+	}
+}

--- a/src/app/core/teams/team.model.ts
+++ b/src/app/core/teams/team.model.ts
@@ -10,10 +10,13 @@ export class Team {
 		public created?: number,
 		public implicitMembers?: boolean,
 		public requiresExternalRoles?: string[],
-		public requiresExternalTeams?: string[]
+		public requiresExternalTeams?: string[],
+		public parent?: Team,
+		public ancestors?: Team[]
 	) {
 		this.requiresExternalRoles = requiresExternalRoles || [];
 		this.requiresExternalTeams = requiresExternalTeams || [];
+		this.ancestors = ancestors || [];
 	}
 
 	setFromModel(model: any): Team {
@@ -26,6 +29,11 @@ export class Team {
 			this.requiresExternalRoles = model.requiresExternalRoles || [];
 			this.requiresExternalTeams = model.requiresExternalTeams || [];
 			this.numResources = model.numResources;
+			this.ancestors = model.ancestors;
+
+			if (model.parent) {
+				this.parent = new Team().setFromModel(model.parent);
+			}
 		}
 
 		return this;

--- a/src/app/core/teams/teams.module.ts
+++ b/src/app/core/teams/teams.module.ts
@@ -21,6 +21,7 @@ import { TeamsHelpComponent } from './help/teams-help.component';
 import { ListTeamMembersComponent } from './list-team-members/list-team-members.component';
 import { ListTeamsComponent } from './list-teams/list-teams.component';
 import { TeamAuthorizationService } from './team-authorization.service';
+import { TeamSelectInputComponent } from './team-select-input/team-select-input.component';
 import { TeamsRoutingModule } from './teams-routing.module';
 import { TeamsResolve } from './teams.resolver';
 import { TeamsService } from './teams.service';
@@ -52,7 +53,9 @@ import { ViewTeamComponent } from './view-team/view-team.component';
 		ListTeamMembersComponent,
 		ListTeamsComponent,
 		ViewTeamComponent,
-		TeamsHelpComponent
+		TeamsHelpComponent,
+		TeamSelectInputComponent,
+		TeamSelectInputComponent
 	],
 	providers: [
 		TeamAuthorizationService,

--- a/src/app/core/teams/view-team/view-team.component.html
+++ b/src/app/core/teams/view-team/view-team.component.html
@@ -11,6 +11,7 @@
 <ng-container *ngIf="team; else noTeam">
 <div class="d-flex mb-3">
 	<h1>{{ team.name }} (Date Created: {{ team.created | utcDate:'MM/DD/YYYY' }})</h1>
+
 	<button type="button" class="btn btn-link ml-auto" (click)="remove()" *ngIf="canManageTeam">
 		Delete Team
 	</button>
@@ -69,6 +70,17 @@
 							</div>
 						</div>
 
+						<div class="form-group" *ngIf="team.parent">
+							<label class="col col-form-label">Parent</label>
+							<div class="col col-form-readonly-value">
+								<div>
+									<a class="text-decoration-underline" [routerLink]="['/team', team.parent._id || team.parent]">
+										{{ team.parent.name }}
+									</a>
+								</div>
+							</div>
+						</div>
+
 						<div class="form-group"
 							 *ngIf="team.implicitMembers && implicitMembersStrategy === 'roles'
 								&& (team.requiresExternalRoles?.length > 0 || isEditing)">
@@ -106,6 +118,17 @@
 					<button class="btn btn-primary ml-2" type="button" [disabled]="!editTeamForm.form.valid"
 							(click)="saveEdit()">Save</button>
 				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col col-na-xl-7 col-12" *ngIf="nestedTeamsEnabled">
+		<div class="card">
+			<div class="card-header d-flex align-items-center">
+				<h2>Sub-Teams</h2>
+			</div>
+			<div class="card-body">
+				<app-list-teams [parent]="team" [embedded]="true"></app-list-teams>
 			</div>
 		</div>
 	</div>

--- a/src/app/core/teams/view-team/view-team.component.ts
+++ b/src/app/core/teams/view-team/view-team.component.ts
@@ -25,6 +25,7 @@ export class ViewTeamComponent implements OnInit {
 	team: Team;
 	_team: any;
 
+	nestedTeamsEnabled = false;
 	implicitMembersStrategy: string = null;
 
 	canManageTeam = false;
@@ -49,6 +50,7 @@ export class ViewTeamComponent implements OnInit {
 			.pipe(first(), untilDestroyed(this))
 			.subscribe((config: Config) => {
 				this.implicitMembersStrategy = config?.teams?.implicitMembers?.strategy;
+				this.nestedTeamsEnabled = config?.teams?.nestedTeams ?? false;
 			});
 
 		this.route.data


### PR DESCRIPTION
When nested teams are enabled in app config:
Team select input component added.
Create Team form updated with option to select parent team.
View team updated with sub-teams grid.