### PR TITLE
fix: Only include sort values in paging object if defined.

### DIFF
--- a/src/app/common/paging/paging.model.ts
+++ b/src/app/common/paging/paging.model.ts
@@ -59,7 +59,7 @@ export class PagingOptions {
 			page: this.pageNumber,
 			size: this.pageSize,
 			...(this.sortField && { sort: this.sortField }),
-			...(this.sortDir && { sort: this.sortDir })
+			...(this.sortDir && { dir: this.sortDir })
 		};
 	}
 }

--- a/src/app/common/paging/paging.model.ts
+++ b/src/app/common/paging/paging.model.ts
@@ -58,8 +58,8 @@ export class PagingOptions {
 		return {
 			page: this.pageNumber,
 			size: this.pageSize,
-			sort: this.sortField || null,
-			dir: this.sortDir || null
+			...(this.sortField && { sort: this.sortField }),
+			...(this.sortDir && { sort: this.sortDir })
 		};
 	}
 }

--- a/src/app/core/audit/audit.service.spec.ts
+++ b/src/app/core/audit/audit.service.spec.ts
@@ -56,7 +56,7 @@ describe('Audit Service', () => {
 				expect(actual).toBe(results);
 			});
 
-			const req = httpMock.expectOne('api/audit?page=2&size=50&sort=null&dir=null');
+			const req = httpMock.expectOne('api/audit?page=2&size=50');
 			expect(req.request.method).toBe('POST');
 			expect(req.request.body).toEqual({
 				q: { actor: 'test' },
@@ -87,7 +87,7 @@ describe('Audit Service', () => {
 				expect(actual).toEqual(expectedResults);
 			});
 
-			const req = httpMock.expectOne('api/users/match?page=2&size=50&sort=null&dir=null');
+			const req = httpMock.expectOne('api/users/match?page=2&size=50');
 			expect(req.request.method).toBe('POST');
 			expect(req.request.body).toEqual({
 				q: query,


### PR DESCRIPTION
Currently, if sortField or sortDir are not defined, `toObj` will set them to null.  When the object gets converted to query parameters, they are included as the string 'null'.  This could cause issues on the backend.  Updating to only include if a value is set.