### PR TITLE
Style System Alerts

### DIFF
--- a/src/app/common/system-alert/system-alert-icon.component.html
+++ b/src/app/common/system-alert/system-alert-icon.component.html
@@ -2,4 +2,5 @@
 	<span *ngSwitchCase="'success'" class="fa fa-fw fa-check-circle"></span>
 	<span *ngSwitchCase="'warning'" class="fa fa-fw fa-exclamation"></span>
 	<span *ngSwitchCase="'danger'" class="fa fa-fw fa-exclamation-triangle"></span>
+	<span *ngSwitchCase="'info'" class="fa fa-fw fa-info-circle"></span>
 </div>

--- a/src/app/common/system-alert/system-alert.component.scss
+++ b/src/app/common/system-alert/system-alert.component.scss
@@ -1,7 +1,7 @@
 @import '../../../styles/overrides';
 @import '../../../styles/shared';
 
-.alert {
+:host ::ng-deep .alert {
 	.alert-icon {
 		margin-left: -5px;
 		margin-right: 5px;

--- a/src/app/common/system-alert/system-alert.component.scss
+++ b/src/app/common/system-alert/system-alert.component.scss
@@ -58,6 +58,7 @@
 		&.close {
 			color: $ux-color-body-text;
 			opacity: 1;
+			padding: 1rem 1.25rem;
 		}
 	}
 }

--- a/src/app/common/system-alert/system-alert.component.scss
+++ b/src/app/common/system-alert/system-alert.component.scss
@@ -54,6 +54,17 @@
 		}
 	}
 
+	&.alert-info {
+		@include border($ux-color-alert-notification, 2px, 3px);
+		background: $ux-color-white;
+
+		.alert-icon {
+			.fa-fw {
+				color: $ux-color-alert-notification;
+			}
+		}
+	}
+
 	button {
 		&.close {
 			color: $ux-color-body-text;

--- a/src/app/site/example/alerts/alerts.component.html
+++ b/src/app/site/example/alerts/alerts.component.html
@@ -1,2 +1,30 @@
-<h1>System Alerts</h1>
-<system-alert></system-alert>
+<div class="container">
+	<h1>System Alerts</h1>
+	<div class="row">
+		<div class="col-md-3">
+			<button class="mr-3 btn btn-primary" (click)="addAlert('Success', 'success')">
+				Success
+			</button>
+		</div>
+		<div class="col-md-3">
+			<button class="mr-3 btn btn-primary" (click)="addAlert('Danger', 'danger')">
+				Danger
+			</button>
+		</div>
+		<div class="col-md-3">
+			<button class="mr-3 btn btn-primary" (click)="addAlert('Warning', 'warning')">
+				Warning
+			</button>
+		</div>
+		<div class="col-md-3">
+			<button class="mr-3 btn btn-primary" (click)="addAlert('Info', 'info')">
+				Info
+			</button>
+		</div>
+	</div>
+	<div class="row mt-3">
+		<div class="col-md-12">
+			<system-alert></system-alert>
+		</div>
+	</div>
+</div>

--- a/src/app/site/example/alerts/alerts.component.html
+++ b/src/app/site/example/alerts/alerts.component.html
@@ -1,0 +1,2 @@
+<h1>System Alerts</h1>
+<system-alert></system-alert>

--- a/src/app/site/example/alerts/alerts.component.ts
+++ b/src/app/site/example/alerts/alerts.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { UntilDestroy } from '@ngneat/until-destroy';
+
+import { SystemAlertService } from '../../../common/system-alert.module';
 
 import { NavbarTopics } from '../../../core/site-navbar/navbar-topic.model';
-import { SystemAlertService } from '../../../common/system-alert.module';
+
+import { UntilDestroy } from '@ngneat/until-destroy';
 
 @UntilDestroy()
 @Component({

--- a/src/app/site/example/alerts/alerts.component.ts
+++ b/src/app/site/example/alerts/alerts.component.ts
@@ -13,9 +13,14 @@ import { UntilDestroy } from '@ngneat/until-destroy';
 export class AlertsComponent implements OnInit {
 	constructor(public alertService: SystemAlertService) {}
 	ngOnInit(): void {
+		this.alertService.clearAllAlerts();
 		this.alertService.addAlert('Success', 'success');
 		this.alertService.addAlert('Danger', 'danger');
 		this.alertService.addAlert('Warning', 'warning');
+	}
+
+	addAlert(msg: string, type: string): void {
+		this.alertService.addAlert(msg, type);
 	}
 }
 

--- a/src/app/site/example/alerts/alerts.component.ts
+++ b/src/app/site/example/alerts/alerts.component.ts
@@ -17,6 +17,7 @@ export class AlertsComponent implements OnInit {
 		this.alertService.addAlert('Success', 'success');
 		this.alertService.addAlert('Danger', 'danger');
 		this.alertService.addAlert('Warning', 'warning');
+		this.alertService.addAlert('Info', 'info');
 	}
 
 	addAlert(msg: string, type: string): void {

--- a/src/app/site/example/alerts/alerts.component.ts
+++ b/src/app/site/example/alerts/alerts.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { UntilDestroy } from '@ngneat/until-destroy';
+
+import { NavbarTopics } from '../../../core/site-navbar/navbar-topic.model';
+import { SystemAlertService } from '../../../common/system-alert.module';
+
+@UntilDestroy()
+@Component({
+	templateUrl: './alerts.component.html'
+})
+export class AlertsComponent implements OnInit {
+	constructor(public alertService: SystemAlertService) {}
+	ngOnInit(): void {
+		this.alertService.addAlert('Success', 'success');
+		this.alertService.addAlert('Danger', 'danger');
+		this.alertService.addAlert('Warning', 'warning');
+	}
+}
+
+NavbarTopics.registerTopic({
+	id: 'alerts',
+	title: 'Alerts',
+	ordinal: 8,
+	path: 'alerts',
+	iconClass: 'fa-exclamation-circle',
+	hasSomeRoles: ['user']
+});

--- a/src/app/site/example/example-routing.module.ts
+++ b/src/app/site/example/example-routing.module.ts
@@ -10,6 +10,7 @@ import { ExploreComponent } from './explore.component';
 import { FormsComponent } from './forms/forms.component';
 import { GridComponent } from './grid/grid.component';
 import { ExampleLoadingOverlayComponent } from './loading-overlay/example-loading-overlay.component';
+import { AlertsComponent } from './alerts/alerts.component';
 import { ModalComponent } from './modal/modal.component';
 import { SearchComponent } from './search.component';
 import { WelcomeComponent } from './welcome.component';
@@ -55,6 +56,11 @@ import { WelcomeComponent } from './welcome.component';
 			{
 				path: 'loading-overlay',
 				component: ExampleLoadingOverlayComponent,
+				canActivate: [AuthGuard]
+			},
+			{
+				path: 'alerts',
+				component: AlertsComponent,
 				canActivate: [AuthGuard]
 			},
 			{

--- a/src/app/site/example/example-routing.module.ts
+++ b/src/app/site/example/example-routing.module.ts
@@ -6,11 +6,11 @@ import { AdminComponent } from '../../common/admin.module';
 import { AuthGuard } from '../../core/auth/auth.guard';
 
 import { AdminExampleComponent } from './admin/admin-example.component';
+import { AlertsComponent } from './alerts/alerts.component';
 import { ExploreComponent } from './explore.component';
 import { FormsComponent } from './forms/forms.component';
 import { GridComponent } from './grid/grid.component';
 import { ExampleLoadingOverlayComponent } from './loading-overlay/example-loading-overlay.component';
-import { AlertsComponent } from './alerts/alerts.component';
 import { ModalComponent } from './modal/modal.component';
 import { SearchComponent } from './search.component';
 import { WelcomeComponent } from './welcome.component';

--- a/src/app/site/example/example.module.ts
+++ b/src/app/site/example/example.module.ts
@@ -7,10 +7,12 @@ import { NgSelectModule } from '@ng-select/ng-select';
 import { AdminModule } from '../../common/admin.module';
 import { LoadingOverlayModule } from '../../common/loading-overlay.module';
 import { ModalModule, ModalService } from '../../common/modal.module';
+import { SystemAlertModule } from '../../common/system-alert.module';
 
 import { AuthGuard } from '../../core/core.module';
 
 import { AdminExampleComponent } from './admin/admin-example.component';
+import { AlertsComponent } from './alerts/alerts.component';
 import { ExampleRoutingModule } from './example-routing.module';
 import { ExploreComponent } from './explore.component';
 import { FormsComponent } from './forms/forms.component';
@@ -30,7 +32,8 @@ import { WelcomeComponent } from './welcome.component';
 		NgSelectModule,
 		ModalModule,
 		LoadingOverlayModule,
-		CommonModule
+		CommonModule,
+		SystemAlertModule
 	],
 	exports: [],
 	declarations: [
@@ -43,7 +46,8 @@ import { WelcomeComponent } from './welcome.component';
 		AdminExampleComponent,
 		FormModalComponent,
 		ModalComponent,
-		ExampleLoadingOverlayComponent
+		ExampleLoadingOverlayComponent,
+		AlertsComponent
 	],
 	providers: [AuthGuard, ModalService, ExampleHelpComponent]
 })


### PR DESCRIPTION
Many UX elements in the app are styled through variables defined in `_colors.scss`. System Alerts should be too. Currently, they are not getting styled and are untouchable `ngx-boostrap/alerts` (see https://valor-software.com/ngx-bootstrap/#/alerts#basic). This aims to fix that.

Also included are

- Add System Alerts to the example app for visibility
- Center dismissible button vertically

If this is something that looks good, I suggest we go further and...

- Add support for more `scss` variables in `_colors.scss` such as `$ux-color-alert-success-text`, `$ux-color-alert-success-border`, `$ux-color-alert-success-icon`, etc in order to allow for more customization
- Add support for an alert of type `info` to align with bootstrap's alerts. (Currently we are only styling success, warning, and danger).

Note: This may effect teams that are not aware of how they are using the `SystemAlertService`, as it will now use values in `_colors.scss` and not the default bootstrap colors.