### PR TITLE
Make Flyouts use separate scss variables for easier customization

### DIFF
--- a/src/app/common/flyout/flyout.component.scss
+++ b/src/app/common/flyout/flyout.component.scss
@@ -4,6 +4,8 @@
 
 $flyout-btn-color: $ux-color-white !default;
 $flyout-btn-bg-color: $ux-color-highlight !default;
+$flyout-content-border-top-color: $ux-color-highlight !default;
+$flyout-content-border-left-color: $ux-color-highlight !default;
 $flyout-border-top: 10px !default;
 $flyout-box-shadow: 0 0.25rem 0.5rem rgba($ux-color-black, 0.2) !default;
 
@@ -109,7 +111,7 @@ $flyout-bottom-bottom: $font-line-height * 2 !default;
 
 .flyout-content {
 	overflow: auto;
-	border-top: $flyout-border-top solid $ux-color-highlight;
+	border-top: $flyout-border-top solid $flyout-content-border-top-color;
 	box-shadow: $flyout-box-shadow;
 	max-height: calc(100vh - 80px);
 	width: 0;
@@ -117,7 +119,7 @@ $flyout-bottom-bottom: $font-line-height * 2 !default;
 	.flyout-top &,
 	.flyout-bottom & {
 		border-top: none;
-		border-left: $flyout-border-top solid $ux-color-highlight;
+		border-left: $flyout-border-top solid $flyout-content-border-left-color;
 		width: auto;
 		height: 0;
 		max-height: calc(100vh - 100px);


### PR DESCRIPTION
Hello

This pull request wants to add the following SCSS variables to flyouts:

- `$flyout-content-border-top-color: $ux-color-highlight !default;`
- `$flyout-content-border-left-color: $ux-color-highlight !default;`

This allows apps built on the starter to override them without having to change `ux-color-highlight`'s value