### PR TITLE
Import overrides at the top of shared

### DIFF
--- a/src/app/common/admin/admin.component.scss
+++ b/src/app/common/admin/admin.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../core/site-container/shared';
 
 $admin-section-padding-y: $site-content-padding-y;

--- a/src/app/common/breadcrumb/breadcrumb.component.scss
+++ b/src/app/common/breadcrumb/breadcrumb.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 @import '../../core/site-navbar/shared';
 

--- a/src/app/common/flyout/flyout.component.scss
+++ b/src/app/common/flyout/flyout.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 @import '../../../styles/ngx-bootstrap/shared';
 

--- a/src/app/common/loading-spinner/loading-spinner.component.scss
+++ b/src/app/common/loading-spinner/loading-spinner.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 
 $loading-spinner-border: 5px !default;

--- a/src/app/common/paging/pager/pager.component.scss
+++ b/src/app/common/paging/pager/pager.component.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 
 $pager-status-warning-color: $ux-color-alert-warning !default;

--- a/src/app/common/paging/quick-filters/quick-filters.component.scss
+++ b/src/app/common/paging/quick-filters/quick-filters.component.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 
 .quick-select {

--- a/src/app/common/paging/sortable-table-header/sortable-table-header.component.scss
+++ b/src/app/common/paging/sortable-table-header/sortable-table-header.component.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 
 .low-opacity {

--- a/src/app/common/system-alert/system-alert.component.scss
+++ b/src/app/common/system-alert/system-alert.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 
 :host ::ng-deep .alert {

--- a/src/app/core/admin/feedback/admin-list-feedback.component.scss
+++ b/src/app/core/admin/feedback/admin-list-feedback.component.scss
@@ -1,4 +1,4 @@
-@import 'src/styles/colors';
+@import 'src/styles/shared';
 
 $dropdown-min-width: 100px;
 

--- a/src/app/core/feedback/feedback-flyout/feedback-flyout.component.scss
+++ b/src/app/core/feedback/feedback-flyout/feedback-flyout.component.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 
 :host {

--- a/src/app/core/help/help.component.scss
+++ b/src/app/core/help/help.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 @import '../../../styles/ngx-bootstrap/shared';
 

--- a/src/app/core/messages/_shared.scss
+++ b/src/app/core/messages/_shared.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 
 $card-icon-width: 31px;

--- a/src/app/core/messages/recent-messages/recent-messages.component.scss
+++ b/src/app/core/messages/recent-messages/recent-messages.component.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 @import '../shared';
 

--- a/src/app/core/messages/view-all-messages/view-all-messages.component.scss
+++ b/src/app/core/messages/view-all-messages/view-all-messages.component.scss
@@ -1,4 +1,3 @@
-@import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 @import '../shared';
 

--- a/src/app/core/signin/signin.component.scss
+++ b/src/app/core/signin/signin.component.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/colors';
+@import 'src/styles/shared';
 
 .signin-container {
 	width: 240px;

--- a/src/app/core/site-container/site-container.component.scss
+++ b/src/app/core/site-container/site-container.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 @import './shared';
 

--- a/src/app/core/site-navbar/site-navbar.component.scss
+++ b/src/app/core/site-navbar/site-navbar.component.scss
@@ -1,4 +1,3 @@
-@import '../../../styles/overrides';
 @import '../../../styles/shared';
 
 @import '../site-container/shared';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,4 @@
-@import 'styles/overrides';
 @import 'styles/shared';
-
 @import 'styles/display';
 @import 'styles/links';
 @import 'styles/selection';

--- a/src/styles/_shared.scss
+++ b/src/styles/_shared.scss
@@ -1,3 +1,4 @@
+@import 'overrides';
 @import 'globals';
 @import 'colors';
 @import 'typography';


### PR DESCRIPTION
Hello

As per a comment by @jrassa #210 

> Actually, it wouldn't be a bad idea to update shared to import the overrides, since the 2 almost always are imported together (and probably should be if they are not).

Importing overrides at the top of shared just makes things easier for developers in their components.