### PR TITLE
style: Cleanup table column styles

### DIFF
--- a/src/app/common/table/sort/asy-sort-header/asy-sort-header.component.html
+++ b/src/app/common/table/sort/asy-sort-header/asy-sort-header.component.html
@@ -1,4 +1,4 @@
-<div class="hide-overflow" tabindex="0" role="button">
+<div class="text-nowrap" tabindex="0" role="button">
 	<ng-content></ng-content>
 
 	<span class="fa-stack" *ngIf="sortable">

--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -40,7 +40,7 @@
 			<ng-container cdkColumnDef="timestamp">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Created</th>
 				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow" tooltip="{{ entry.ts | utcDate }}" container="body">
+					<div class="text-nowrap" tooltip="{{ entry.ts | utcDate }}" container="body">
 						{{ entry.ts | agoDate: false }}
 					</div>
 				</td>

--- a/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.html
+++ b/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.html
@@ -55,35 +55,31 @@
 				</ng-container>
 				<ng-container cdkColumnDef="title">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Title</th>
-					<td cdk-cell *cdkCellDef="let eua">
-						<div class="hide-overflow">
-							{{ eua.euaModel.title }}
-						</div>
+					<td cdk-cell *cdkCellDef="let eua" class="hide-overflow">
+						{{ eua.euaModel.title }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="text">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Text</th>
-					<td cdk-cell *cdkCellDef="let eua">
-						<div class="hide-overflow" style="max-width: 400px">
-							{{ eua.euaModel.text }}
-						</div>
+					<td cdk-cell *cdkCellDef="let eua" class="hide-overflow">
+						{{ eua.euaModel.text }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="created">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Created</th>
-					<td cdk-cell *cdkCellDef="let eua">
+					<td cdk-cell *cdkCellDef="let eua" class="text-nowrap">
 						{{ eua.euaModel.created | utcDate }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="published">
-					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>published</th>
-					<td cdk-cell *cdkCellDef="let eua">
+					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Published</th>
+					<td cdk-cell *cdkCellDef="let eua" class="text-nowrap">
 						{{ eua.euaModel.published | utcDate }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="updated">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Updated</th>
-					<td cdk-cell *cdkCellDef="let eua">
+					<td cdk-cell *cdkCellDef="let eua" class="text-nowrap">
 						{{ eua.euaModel.updated | utcDate }}
 					</td>
 				</ng-container>

--- a/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.scss
+++ b/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.scss
@@ -5,3 +5,7 @@
 	flex-direction: column;
 	height: 100%;
 }
+
+.cdk-column-text {
+	max-width: 400px;
+}

--- a/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.html
+++ b/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.html
@@ -52,35 +52,33 @@
 				class="table table-striped"
 			>
 				<ng-container cdkColumnDef="creator.name">
-					<th cdk-header-cell *cdkHeaderCellDef>
-						<div class="hide-overflow">Submitted By</div>
-					</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.creator?.name }}</div>
+					<th cdk-header-cell *cdkHeaderCellDef>Submitted By</th>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.creator?.name }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="creator.username">
 					<th cdk-header-cell *cdkHeaderCellDef>Username</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.creator?.username }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.creator?.username }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="creator.email">
 					<th cdk-header-cell *cdkHeaderCellDef>Email</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.creator?.email }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.creator?.email }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="creator.organization">
 					<th cdk-header-cell *cdkHeaderCellDef>Organization</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.creator?.organization }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.creator?.organization }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="created">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Submitted Date</th>
 					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow" tooltip="{{ feedback?.created | utcDate }}">
+						<div class="text-nowrap" tooltip="{{ feedback?.created | utcDate }}">
 							{{ feedback?.created | agoDate }}
 						</div>
 					</td>
@@ -88,15 +86,15 @@
 				<ng-container cdkColumnDef="updated">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Updated</th>
 					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow" tooltip="{{ feedback?.updated | utcDate }}">
+						<div class="text-nowrap" tooltip="{{ feedback?.updated | utcDate }}">
 							{{ feedback?.updated | agoDate }}
 						</div>
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="type">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Type</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.type | titlecase }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="text-nowrap">
+						{{ feedback?.type | titlecase }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="body">
@@ -107,20 +105,20 @@
 				</ng-container>
 				<ng-container cdkColumnDef="browser">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Browser</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.browser }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.browser }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="os">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>OS</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.os }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.os }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="url">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Submitted From</th>
-					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="hide-overflow">{{ feedback?.url }}</div>
+					<td cdk-cell *cdkCellDef="let feedback" class="hide-overflow">
+						{{ feedback?.url }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="status">

--- a/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.scss
+++ b/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.scss
@@ -9,7 +9,7 @@ $dropdown-min-width: 100px;
 }
 
 .cdk-column-body {
-	max-width: 300px;
+	min-width: 400px;
 	white-space: pre-wrap;
 }
 

--- a/src/app/core/admin/messages/list-messages/list-messages.component.html
+++ b/src/app/core/admin/messages/list-messages/list-messages.component.html
@@ -49,13 +49,13 @@
 			</ng-container>
 			<ng-container cdkColumnDef="created">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Created</th>
-				<td cdk-cell *cdkCellDef="let message">
+				<td cdk-cell *cdkCellDef="let message" class="text-nowrap">
 					{{ message.created | utcDate }}
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="updated">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Updated</th>
-				<td cdk-cell *cdkCellDef="let message">
+				<td cdk-cell *cdkCellDef="let message" class="text-nowrap">
 					{{ message.updated | utcDate }}
 				</td>
 			</ng-container>

--- a/src/app/core/admin/user-management/list-users/admin-list-users.component.html
+++ b/src/app/core/admin/user-management/list-users/admin-list-users.component.html
@@ -69,10 +69,8 @@
 				</ng-container>
 				<ng-container cdkColumnDef="username">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Username</th>
-					<td cdk-cell *cdkCellDef="let user">
-						<div class="hide-overflow">
-							{{ user.userModel.username }}
-						</div>
+					<td cdk-cell *cdkCellDef="let user" class="text-nowrap">
+						{{ user.userModel.username }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="organization">
@@ -97,7 +95,7 @@
 					<th cdk-header-cell *cdkHeaderCellDef>EUA</th>
 					<td cdk-cell *cdkCellDef="let user">
 						<div
-							class="hide-overflow"
+							class="text-nowrap"
 							tooltip="{{ user.userModel.acceptedEua | utcDate }}"
 							container="body"
 						>
@@ -109,7 +107,7 @@
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Last Login</th>
 					<td cdk-cell *cdkCellDef="let user">
 						<div
-							class="hide-overflow"
+							class="text-nowrap"
 							tooltip="{{ user.userModel.lastLogin | utcDate }}"
 							container="body"
 						>
@@ -119,30 +117,26 @@
 				</ng-container>
 				<ng-container cdkColumnDef="created">
 					<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Created</th>
-					<td cdk-cell *cdkCellDef="let user">
+					<td cdk-cell *cdkCellDef="let user" class="text-nowrap">
 						{{ user.userModel.created | utcDate }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="updated">
 					<th cdk-header-cell *cdkHeaderCellDef>Updated</th>
-					<td cdk-cell *cdkCellDef="let user">
+					<td cdk-cell *cdkCellDef="let user" class="text-nowrap">
 						{{ user.userModel.updated | utcDate }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="externalRoles">
 					<th cdk-header-cell *cdkHeaderCellDef>External Roles</th>
-					<td cdk-cell *cdkCellDef="let user">
-						<div class="hide-overflow">
-							{{ user.userModel.externalRoles }}
-						</div>
+					<td cdk-cell *cdkCellDef="let user" class="hide-overflow">
+						{{ user.userModel.externalRoles | join: ', ' }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="externalGroups">
 					<th cdk-header-cell *cdkHeaderCellDef>External Groups</th>
-					<td cdk-cell *cdkCellDef="let user">
-						<div class="hide-overflow">
-							{{ user.userModel.externalGroups }}
-						</div>
+					<td cdk-cell *cdkCellDef="let user" class="hide-overflow">
+						{{ user.userModel.externalGroups | join: ', ' }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="roles">
@@ -153,8 +147,8 @@
 					<td cdk-cell *cdkCellDef="let user">
 						<ng-container *ngFor="let role of possibleRoles">
 							<div
-								*ngIf="user.userModel.roles && user.userModel.roles[role.role]"
-								class="user-role"
+								*ngIf="user.userModel.roles?.[role.role]"
+								class="user-role text-nowrap"
 								[ngClass]="{
 									'user-role-external':
 										user.userModel.localRoles &&

--- a/src/app/core/admin/user-management/list-users/admin-list-users.component.scss
+++ b/src/app/core/admin/user-management/list-users/admin-list-users.component.scss
@@ -5,3 +5,12 @@
 	flex-direction: column;
 	height: 100%;
 }
+
+.cdk-column-externalRoles,
+.cdk-column-externalGroups {
+	max-width: 200px;
+}
+
+.user-role-external::after {
+	content: '(external)';
+}

--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.html
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.html
@@ -19,13 +19,11 @@
 					Actor
 					<asy-header-filter typeahead-filter audit-actor-filter></asy-header-filter>
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						<asy-audit-component
-							[auditObject]="entry.audit.actor"
-							auditType="user"
-						></asy-audit-component>
-					</div>
+				<td cdk-cell *cdkCellDef="let entry" class="text-nowrap">
+					<asy-audit-component
+						[auditObject]="entry.audit.actor"
+						auditType="user"
+					></asy-audit-component>
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="created">
@@ -34,10 +32,8 @@
 					Timestamp
 					<asy-header-filter date-filter></asy-header-filter>
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						{{ entry?.created | utcDate }}
-					</div>
+				<td cdk-cell *cdkCellDef="let entry" class="text-nowrap">
+					{{ entry?.created | utcDate }}
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="audit.action">
@@ -50,10 +46,8 @@
 						[showSearch]="true"
 					></asy-header-filter>
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						{{ entry?.audit?.action }}
-					</div>
+				<td cdk-cell *cdkCellDef="let entry" class="text-nowrap">
+					{{ entry?.audit?.action }}
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="audit.auditType">
@@ -66,34 +60,30 @@
 						[showSearch]="true"
 					></asy-header-filter>
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						{{ entry?.audit?.auditType }}
-					</div>
+				<td cdk-cell *cdkCellDef="let entry" class="text-nowrap">
+					{{ entry?.audit?.auditType }}
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="object">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Object</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						<asy-audit-component
-							[auditObject]="entry.audit.object?.after ?? entry.audit.object"
-							[auditType]="entry.audit.auditType"
-						></asy-audit-component>
-						<div>
-							<small *ngIf="entry.isViewDetailsAction">
-								<a
-									class="btn-icon no-href"
-									[hidden]="(entry.audit.object ?? null) === null"
-									(click)="viewMore(entry, 'viewDetails')"
-								>
-									<span class="fa fa-eye"></span><span>View Details</span>
-								</a>
-							</small>
-							<small style="opacity: 0.5" *ngIf="entry.audit.action === 'save'"
-								><span>No Changes Detected</span></small
+				<td cdk-cell *cdkCellDef="let entry" class="hide-overflow">
+					<asy-audit-component
+						[auditObject]="entry.audit.object?.after ?? entry.audit.object"
+						[auditType]="entry.audit.auditType"
+					></asy-audit-component>
+					<div>
+						<small *ngIf="entry.isViewDetailsAction">
+							<a
+								class="btn-icon no-href"
+								[hidden]="(entry.audit.object ?? null) === null"
+								(click)="viewMore(entry, 'viewDetails')"
 							>
-						</div>
+								<span class="fa fa-eye"></span><span>View Details</span>
+							</a>
+						</small>
+						<small style="opacity: 0.5" *ngIf="entry.audit.action === 'save'"
+							><span>No Changes Detected</span></small
+						>
 					</div>
 				</td>
 			</ng-container>
@@ -102,29 +92,27 @@
 					<span class="fa fa-history"></span>
 					Before
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						<asy-audit-component
-							[auditObject]="entry.audit.object?.before"
-							[auditType]="entry.audit.auditType"
-						></asy-audit-component>
-						<div>
-							<small *ngIf="entry.isViewChangesAction">
-								<a
-									class="btn-icon no-href"
-									[hidden]="(entry.audit.object?.before ?? null) === null"
-									tooltip="See details of the update"
-									placement="bottom"
-									container="body"
-									(click)="viewMore(entry, 'viewChanges')"
-								>
-									<span class="fa fa-eye"></span><span>View Changes</span>
-								</a>
-							</small>
-							<small style="opacity: 0.5" *ngIf="entry.audit.action === 'save'"
-								><span>No Changes Detected</span></small
+				<td cdk-cell *cdkCellDef="let entry" class="hide-overflow">
+					<asy-audit-component
+						[auditObject]="entry.audit.object?.before"
+						[auditType]="entry.audit.auditType"
+					></asy-audit-component>
+					<div>
+						<small *ngIf="entry.isViewChangesAction">
+							<a
+								class="btn-icon no-href"
+								[hidden]="(entry.audit.object?.before ?? null) === null"
+								tooltip="See details of the update"
+								placement="bottom"
+								container="body"
+								(click)="viewMore(entry, 'viewChanges')"
 							>
-						</div>
+								<span class="fa fa-eye"></span><span>View Changes</span>
+							</a>
+						</small>
+						<small style="opacity: 0.5" *ngIf="entry.audit.action === 'save'"
+							><span>No Changes Detected</span></small
+						>
 					</div>
 				</td>
 			</ng-container>
@@ -133,10 +121,8 @@
 					<span class="fa fa-file-text-o"></span>
 					Message
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						{{ entry?.message }}
-					</div>
+				<td cdk-cell *cdkCellDef="let entry" class="text-nowrap">
+					{{ entry?.message }}
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="masqueradingUser">
@@ -144,10 +130,8 @@
 					<span class="fa fa-user-secret"></span>
 					Masquerading User
 				</th>
-				<td cdk-cell *cdkCellDef="let entry">
-					<div class="hide-overflow">
-						{{ entry?.audit.masqueradingUser }}
-					</div>
+				<td cdk-cell *cdkCellDef="let entry" class="text-nowrap">
+					{{ entry?.audit.masqueradingUser }}
 				</td>
 			</ng-container>
 			<tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/core/teams/add-members-modal/add-members-modal.component.html
+++ b/src/app/core/teams/add-members-modal/add-members-modal.component.html
@@ -39,10 +39,8 @@
 
 			<tbody>
 				<tr *ngFor="let invited of addedMembers; let i = index" class="table-row">
-					<td>
-						<div class="hide-overflow" [attr.title]="invited.username">
-							{{ invited.username }}
-						</div>
+					<td class="text-nowrap">
+						{{ invited.username }}
 					</td>
 					<td>
 						<div class="dropdown dropdown-table-inline" dropdown>

--- a/src/app/core/teams/list-teams/list-teams.component.html
+++ b/src/app/core/teams/list-teams/list-teams.component.html
@@ -39,19 +39,17 @@
 		<table cdk-table [dataSource]="dataSource" asySort asyFilter class="table table-striped">
 			<ng-container cdkColumnDef="name">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Name</th>
-				<td cdk-cell *cdkCellDef="let team">
-					<div class="hide-overflow">
-						<a class="text-decoration-underline" [routerLink]="['/team', team._id]">{{
-							team.name
-						}}</a>
-					</div>
+				<td cdk-cell *cdkCellDef="let team" class="text-nowrap">
+					<a class="text-decoration-underline" [routerLink]="['/team', team._id]">{{
+						team.name
+					}}</a>
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="created">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Created</th>
 				<td cdk-cell *cdkCellDef="let team">
 					<div
-						class="hide-overflow"
+						class="text-nowrap"
 						tooltip="{{ team.created | utcDate }}"
 						container="body"
 					>
@@ -62,9 +60,7 @@
 			<ng-container cdkColumnDef="description">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Description</th>
 				<td cdk-cell *cdkCellDef="let team">
-					<div class="hide-overflow" style="white-space: pre-wrap">
-						{{ team.description }}
-					</div>
+					{{ team.description }}
 				</td>
 			</ng-container>
 			<tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/core/teams/list-teams/list-teams.component.scss
+++ b/src/app/core/teams/list-teams/list-teams.component.scss
@@ -5,3 +5,7 @@
 	flex-direction: column;
 	height: 100%;
 }
+
+.cdk-column-description {
+	white-space: pre-wrap;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -76,10 +76,6 @@ h6 {
 	}
 }
 
-.user-role-external::after {
-	content: '(external)';
-}
-
 .page-body {
 	display: flex;
 	flex-direction: column;

--- a/src/styles/ngx-bootstrap/_tables.scss
+++ b/src/styles/ngx-bootstrap/_tables.scss
@@ -9,6 +9,10 @@ $anchored-table-min-height: 375px !default;
 	.table {
 		margin-bottom: 0;
 	}
+
+	th {
+		white-space: nowrap;
+	}
 }
 
 .table {


### PR DESCRIPTION
Cleans up column styles on various tables.
  * apply styling directly to `td`s where appropriate and remove unnecessary divs
  * replace uses of `hide-overflow` with  `text-nowrap` where appropriate
  * apply `text-nowrap` to all `th`s by default`
  * favor use of `cdk-column-*` classes over inline styles