### PR TITLE
fix: AsyHeaderDateFilter generating too large of date ranges

### DIFF
--- a/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.spec.ts
+++ b/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.spec.ts
@@ -1,0 +1,155 @@
+import { ChangeDetectorRef } from '@angular/core';
+
+import { DateTime, Settings } from 'luxon';
+
+import { AsyFilterHeaderColumnDef } from '../asy-abstract-header-filter.component';
+import { AsyFilterDirective } from '../asy-filter.directive';
+import { AsyHeaderDateFilterComponent } from './asy-header-date-filter.component';
+
+describe('AsyHeaderDateFilter', () => {
+	let dateFilterComponent: AsyHeaderDateFilterComponent;
+
+	let luxonNowFn: () => number;
+
+	beforeAll(() => {
+		// preserve default Settings.now function
+		luxonNowFn = Settings.now;
+
+		// override Settings.now function to provide consistent value for testing
+		const expectedNow = DateTime.utc(2022, 1, 15, 8, 30, 14, 10);
+		Settings.now = () => expectedNow.toMillis();
+	});
+
+	afterAll(() => {
+		// restore default Settings.now function
+		Settings.now = luxonNowFn;
+	});
+
+	beforeEach(() => {
+		dateFilterComponent = new AsyHeaderDateFilterComponent(
+			null as unknown as AsyFilterDirective,
+			null as unknown as AsyFilterHeaderColumnDef,
+			null as unknown as ChangeDetectorRef
+		);
+	});
+
+	it('expect empty filter when no options set', () => {
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({});
+	});
+
+	it('expect empty filter when disabled', () => {
+		dateFilterComponent.enabled = false;
+		dateFilterComponent.duration = 'day';
+		dateFilterComponent.count = 3;
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({});
+	});
+
+	it('expect proper filter for next 3 hours', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.duration = 'hour';
+		dateFilterComponent.count = 3;
+		dateFilterComponent.direction = 'next';
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 15, 8, 30, 14, 10),
+				$lte: DateTime.utc(2022, 1, 15, 11, 30, 14, 10)
+			}
+		});
+	});
+
+	it('expect proper filter for past 6 hours', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.duration = 'hour';
+		dateFilterComponent.count = 6;
+		dateFilterComponent.direction = 'past';
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 15, 2, 30, 14, 10),
+				$lte: DateTime.utc(2022, 1, 15, 8, 30, 14, 10)
+			}
+		});
+	});
+
+	it('expect proper filter for next 3 days', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.duration = 'day';
+		dateFilterComponent.count = 3;
+		dateFilterComponent.direction = 'next';
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 15),
+				$lte: DateTime.utc(2022, 1, 18).endOf('day')
+			}
+		});
+	});
+
+	it('expect proper filter for past 6 days', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.duration = 'day';
+		dateFilterComponent.count = 6;
+		dateFilterComponent.direction = 'past';
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 9),
+				$lte: DateTime.utc(2022, 1, 15).endOf('day')
+			}
+		});
+	});
+
+	it('expect proper filter for next 3 weeks', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.duration = 'week';
+		dateFilterComponent.count = 3;
+		dateFilterComponent.direction = 'next';
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 15),
+				$lte: DateTime.utc(2022, 2, 5).endOf('day')
+			}
+		});
+	});
+
+	it('expect proper filter for past 2 weeks', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.duration = 'week';
+		dateFilterComponent.count = 2;
+		dateFilterComponent.direction = 'past';
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 1),
+				$lte: DateTime.utc(2022, 1, 15).endOf('day')
+			}
+		});
+	});
+
+	it('expect proper filter for custom range', () => {
+		dateFilterComponent.id = 'dateField';
+		dateFilterComponent.enabled = true;
+		dateFilterComponent.isCustom = true;
+		dateFilterComponent.customRange = [
+			DateTime.local(2022, 1, 1).toJSDate(),
+			DateTime.local(2022, 8, 5).toJSDate()
+		];
+		const filter = dateFilterComponent._buildFilter();
+		expect(filter).toEqual({
+			dateField: {
+				$gte: DateTime.utc(2022, 1, 1),
+				$lte: DateTime.utc(2022, 8, 5).endOf('day')
+			}
+		});
+	});
+});

--- a/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.ts
+++ b/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.ts
@@ -92,7 +92,8 @@ export class AsyHeaderDateFilterComponent extends AsyAbstractHeaderFilterCompone
 
 		if (this.enabled) {
 			if (!this.isCustom) {
-				const now = DateTime.now();
+				const now = DateTime.utc();
+
 				if (this.direction === 'past') {
 					$gte = now.minus({ [this.duration]: this.count });
 					$lte = now;
@@ -100,17 +101,16 @@ export class AsyHeaderDateFilterComponent extends AsyAbstractHeaderFilterCompone
 					$gte = now;
 					$lte = now.plus({ [this.duration]: this.count });
 				}
-				$gte = $gte.startOf(this.duration);
-				$lte = $lte.endOf(this.duration);
 			} else if (this.customRange?.length === 2) {
-				$gte = DateTime.fromJSDate(this.customRange[0]);
-				$lte = DateTime.fromJSDate(this.customRange[1]);
+				$gte = DateTime.fromJSDate(this.customRange[0]).toUTC(0, { keepLocalTime: true });
+				$lte = DateTime.fromJSDate(this.customRange[1]).toUTC(0, { keepLocalTime: true });
 			}
-		}
-		// Normalize to start/end of day
-		if (this.isCustom || this.duration !== 'hour') {
-			$gte = $gte.startOf('day');
-			$lte = $lte.endOf('day');
+
+			// Normalize to start/end of day
+			if (this.isCustom || this.duration !== 'hour') {
+				$gte = $gte.startOf('day');
+				$lte = $lte.endOf('day');
+			}
 		}
 
 		return { ...($gte.isValid && $lte.isValid && { [this.id]: { $gte, $lte } }) };


### PR DESCRIPTION
When specifying a duration, the generated filter would be larger than intended by one duration.
i.e.:
1 week -> 2 weeks
3 months -> 4 months

This corrects that issue and add test coverage.