### PR TITLE
feat(team): View Team page update

### DIFF
--- a/src/app/common/multi-select-input/multi-select-input.component.html
+++ b/src/app/common/multi-select-input/multi-select-input.component.html
@@ -10,5 +10,6 @@
 	(focus)="onTouched()"
 	placeholder="{{ placeholder }}"
 	[(ngModel)]="value"
+	[readonly]="readonly"
 >
 </ng-select>

--- a/src/app/common/multi-select-input/multi-select-input.component.ts
+++ b/src/app/common/multi-select-input/multi-select-input.component.ts
@@ -15,6 +15,8 @@ import { ControlValueAccessor, NgModel, NG_VALUE_ACCESSOR } from '@angular/forms
 export class MultiSelectInputComponent implements ControlValueAccessor {
 	@Input() placeholder = '';
 
+	@Input() readonly = false;
+
 	@ViewChild(NgModel) model?: NgModel;
 
 	autocompleteOpen = false;

--- a/src/app/core/teams/team-topic.model.ts
+++ b/src/app/core/teams/team-topic.model.ts
@@ -1,0 +1,6 @@
+import { Topic, TopicRegistry } from '../../common/topic.model';
+
+export type TeamTopic = Topic;
+
+const teamTopics = new TopicRegistry<TeamTopic>();
+export { teamTopics as TeamTopics };

--- a/src/app/core/teams/teams-routing.module.ts
+++ b/src/app/core/teams/teams-routing.module.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from '../auth/auth.guard';
 import { CreateTeamComponent } from './create-team/create-team.component';
 import { ListTeamsComponent } from './list-teams/list-teams.component';
 import { TeamsResolve } from './teams.resolver';
+import { GeneralDetailsComponent } from './view-team/general-details/general-details.component';
 import { ViewTeamComponent } from './view-team/view-team.component';
 
 @NgModule({
@@ -29,7 +30,21 @@ import { ViewTeamComponent } from './view-team/view-team.component';
 				data: { roles: ['user'] },
 				resolve: {
 					team: TeamsResolve
-				}
+				},
+				children: [
+					/**
+					 * Default Route
+					 */
+					{
+						path: '',
+						redirectTo: 'general',
+						pathMatch: 'full'
+					},
+					{
+						path: 'general',
+						component: GeneralDetailsComponent
+					}
+				]
 			}
 		])
 	],

--- a/src/app/core/teams/teams.module.ts
+++ b/src/app/core/teams/teams.module.ts
@@ -22,9 +22,11 @@ import { ListTeamMembersComponent } from './list-team-members/list-team-members.
 import { ListTeamsComponent } from './list-teams/list-teams.component';
 import { TeamAuthorizationService } from './team-authorization.service';
 import { TeamSelectInputComponent } from './team-select-input/team-select-input.component';
+import { TeamTopics } from './team-topic.model';
 import { TeamsRoutingModule } from './teams-routing.module';
 import { TeamsResolve } from './teams.resolver';
 import { TeamsService } from './teams.service';
+import { GeneralDetailsComponent } from './view-team/general-details/general-details.component';
 import { ViewTeamComponent } from './view-team/view-team.component';
 
 @NgModule({
@@ -55,7 +57,8 @@ import { ViewTeamComponent } from './view-team/view-team.component';
 		ListTeamsComponent,
 		ViewTeamComponent,
 		TeamsHelpComponent,
-		TeamSelectInputComponent
+		TeamSelectInputComponent,
+		GeneralDetailsComponent
 	],
 	providers: [
 		TeamAuthorizationService,
@@ -66,3 +69,10 @@ import { ViewTeamComponent } from './view-team/view-team.component';
 	]
 })
 export class TeamsModule {}
+
+TeamTopics.registerTopic({
+	id: 'general',
+	title: 'General',
+	ordinal: 0,
+	path: 'general'
+});

--- a/src/app/core/teams/view-team/general-details/general-details.component.html
+++ b/src/app/core/teams/view-team/general-details/general-details.component.html
@@ -1,0 +1,167 @@
+<div class="cards row pb-5" *ngIf="team">
+	<div class="col col-na-xl-7 col-12">
+		<div class="card">
+			<div class="card-header d-flex align-items-center">
+				<h2>Members</h2>
+			</div>
+			<div class="card-body">
+				<list-team-members [team]="team"></list-team-members>
+			</div>
+		</div>
+	</div>
+
+	<div class="col col-na-xl-5 col-12">
+		<div class="card">
+			<div class="card-header d-flex align-items-center">
+				<h2>Details</h2>
+				<button
+					class="btn btn-outline-secondary ml-3"
+					type="button"
+					[disabled]="isEditing"
+					*ngIf="canManageTeam"
+					(click)="edit()"
+				>
+					<span class="fa fa-lg fa-pencil"></span>
+				</button>
+				<div class="inline-edit-header-btns ml-auto" *ngIf="isEditing">
+					<button class="btn btn-outline-secondary" type="button" (click)="cancelEdit()">
+						Cancel
+					</button>
+					<button
+						class="btn btn-primary ml-2"
+						type="button"
+						[disabled]="!editTeamForm.form.valid"
+						(click)="saveEdit()"
+					>
+						Save
+					</button>
+				</div>
+			</div>
+			<div class="card-body" [class.editing]="isEditing">
+				<form id="edit-team-form" #editTeamForm="ngForm">
+					<div class="form-inline-edit mb-3">
+						<div class="form-group">
+							<label class="col col-form-label">Name</label>
+							<div class="col col-form-readonly-value" *ngIf="!isEditing">
+								<div>{{ team.name || '' | titlecase }}</div>
+							</div>
+							<div class="col" *ngIf="isEditing">
+								<input
+									class="form-control"
+									placeholder="Enter name"
+									name="name"
+									[(ngModel)]="_team.name"
+									required
+								/>
+							</div>
+						</div>
+
+						<div class="form-group">
+							<label class="col col-form-label">Description</label>
+							<div class="col col-form-readonly-value" *ngIf="!isEditing">
+								<div style="white-space: pre-wrap">{{ team.description }}</div>
+							</div>
+							<div class="col" *ngIf="isEditing">
+								<textarea
+									class="form-control"
+									placeholder="Enter description"
+									name="description"
+									[(ngModel)]="_team.description"
+								>
+								</textarea>
+							</div>
+						</div>
+
+						<div class="form-group">
+							<label class="col col-form-label">Date Created</label>
+							<div class="col col-form-readonly-value">
+								<div>{{ team.created | utcDate: 'yyyy-MM-dd' }}</div>
+							</div>
+						</div>
+
+						<div class="form-group" *ngIf="team.parent">
+							<label class="col col-form-label">Parent</label>
+							<div class="col col-form-readonly-value">
+								<div>
+									<a
+										class="text-decoration-underline"
+										[routerLink]="['/team', team.parent._id || team.parent]"
+									>
+										{{ team.parent.name }}
+									</a>
+								</div>
+							</div>
+						</div>
+
+						<div
+							class="form-group"
+							*ngIf="
+								team.implicitMembers &&
+								implicitMembersStrategy === 'roles' &&
+								((team.requiresExternalRoles?.length || 0) > 0 || isEditing)
+							"
+						>
+							<label class="col col-form-label">External Roles</label>
+							<div class="col col-form-readonly-value" *ngIf="!isEditing">
+								<div>{{ team.requiresExternalRoles | join: ', ' }}</div>
+							</div>
+							<div class="col" *ngIf="isEditing">
+								<asy-multi-select-input
+									placeholder="Start typing a role..."
+									name="externalRoles"
+									[(ngModel)]="_team.requiresExternalRoles"
+								></asy-multi-select-input>
+							</div>
+						</div>
+
+						<div
+							class="form-group"
+							*ngIf="
+								team.implicitMembers &&
+								implicitMembersStrategy === 'teams' &&
+								((team.requiresExternalTeams?.length || 0) > 0 || isEditing)
+							"
+						>
+							<label class="col col-form-label">External Teams</label>
+							<div class="col col-form-readonly-value" *ngIf="!isEditing">
+								<div>{{ team.requiresExternalTeams | join: ', ' }}</div>
+							</div>
+							<div class="col" *ngIf="isEditing">
+								<asy-multi-select-input
+									placeholder="Start typing a team..."
+									name="externalTeams"
+									[(ngModel)]="_team.requiresExternalTeams"
+								></asy-multi-select-input>
+							</div>
+						</div>
+					</div>
+				</form>
+
+				<div class="inline-edit-btns text-right" *ngIf="isEditing">
+					<button class="btn btn-outline-secondary" type="button" (click)="cancelEdit()">
+						Cancel
+					</button>
+					<button
+						class="btn btn-primary ml-2"
+						type="button"
+						[disabled]="!editTeamForm.form.valid"
+						(click)="saveEdit()"
+					>
+						Save
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="col col-na-xl-7 col-12" *ngIf="nestedTeamsEnabled">
+		<div class="card">
+			<div class="card-header d-flex align-items-center">
+				<h2>Sub-Teams</h2>
+			</div>
+			<div class="card-body">
+				<app-list-teams [parent]="team" [embedded]="true"></app-list-teams>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/app/core/teams/view-team/general-details/general-details.component.ts
+++ b/src/app/core/teams/view-team/general-details/general-details.component.ts
@@ -1,0 +1,97 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { first, map, switchMap, tap } from 'rxjs/operators';
+
+import { SystemAlertService } from '../../../../common/system-alert/system-alert.service';
+import { AuthorizationService } from '../../../auth/authorization.service';
+import { SessionService } from '../../../auth/session.service';
+import { ConfigService } from '../../../config.service';
+import { TeamAuthorizationService } from '../../team-authorization.service';
+import { Team } from '../../team.model';
+import { TeamsService } from '../../teams.service';
+
+@UntilDestroy()
+@Component({
+	selector: 'app-general-details',
+	templateUrl: './general-details.component.html',
+	styleUrls: ['./general-details.component.scss']
+})
+export class GeneralDetailsComponent implements OnInit {
+	team?: Team;
+	_team: any;
+
+	nestedTeamsEnabled = false;
+	implicitMembersStrategy?: string;
+
+	canManageTeam = false;
+
+	isEditing = false;
+
+	constructor(
+		private router: Router,
+		private route: ActivatedRoute,
+		private alertService: SystemAlertService,
+		private configService: ConfigService,
+		private sessionService: SessionService,
+		private teamsService: TeamsService,
+		private authorizationService: AuthorizationService,
+		private teamAuthorizationService: TeamAuthorizationService
+	) {}
+
+	ngOnInit(): void {
+		this.configService
+			.getConfig()
+			.pipe(first(), untilDestroyed(this))
+			.subscribe((config) => {
+				this.implicitMembersStrategy = config?.teams?.implicitMembers?.strategy;
+				this.nestedTeamsEnabled = config?.teams?.nestedTeams ?? false;
+			});
+
+		this.route.parent?.data
+			.pipe(
+				map((data) => data['team']),
+				untilDestroyed(this)
+			)
+			.subscribe((team) => {
+				this.updateTeam(team);
+			});
+	}
+
+	updateTeam(team: Team) {
+		if (team) {
+			this.team = team;
+			this.canManageTeam =
+				this.authorizationService.isAdmin() || this.teamAuthorizationService.isAdmin(team);
+		} else {
+			this.router.navigate(['resource/invalid', { type: 'team' }]);
+		}
+	}
+
+	edit() {
+		this._team = new Team().setFromModel(this.team);
+		this.isEditing = true;
+	}
+
+	cancelEdit() {
+		this.isEditing = false;
+	}
+
+	saveEdit() {
+		this.teamsService
+			.update(this._team)
+			.pipe(
+				tap((team: Team | null) => {
+					this.isEditing = false;
+					if (team) {
+						this.team = team;
+						this.alertService.addAlert('Updated team metadata', 'success', 5000);
+					}
+				}),
+				switchMap(() => this.sessionService.reloadSession()),
+				untilDestroyed(this)
+			)
+			.subscribe();
+	}
+}

--- a/src/app/core/teams/view-team/view-team.component.html
+++ b/src/app/core/teams/view-team/view-team.component.html
@@ -1,17 +1,16 @@
-<!-- Alert Notifications -->
-<system-alert></system-alert>
+<section class="view-team-container" *ngIf="team; else noTeam">
+	<!-- Alert Notifications -->
+	<system-alert></system-alert>
 
-<!-- Show a breadcrumb to the list teams page -->
-<div class="mb-3">
-	<a class="back-link mb-1" routerLink="/teams">
-		<span class="fa fa-angle-double-left"></span> Back to Teams
-	</a>
-</div>
+	<!-- Show a breadcrumb to the list teams page -->
+	<div class="mb-3">
+		<a class="back-link mb-1" routerLink="/teams">
+			<span class="fa fa-angle-double-left"></span> Back to Teams
+		</a>
+	</div>
 
-<ng-container *ngIf="team; else noTeam">
 	<div class="d-flex mb-3">
 		<h1>{{ team.name }}</h1>
-
 		<button
 			type="button"
 			class="btn btn-link ml-auto"
@@ -22,181 +21,20 @@
 		</button>
 	</div>
 
-	<div class="cards row">
-		<div class="col col-na-xl-7 col-12">
-			<div class="card">
-				<div class="card-header d-flex align-items-center">
-					<h2>Members</h2>
-				</div>
-				<div class="card-body">
-					<list-team-members [team]="team"></list-team-members>
-				</div>
-			</div>
-		</div>
+	<ul class="nav nav-tabs">
+		<li *ngFor="let topic of topics" class="nav-item" role="presentation">
+			<a
+				class="nav-link"
+				[routerLink]="['/team/', team._id, topic.path]"
+				routerLinkActive="active"
+			>
+				{{ topic.title }}
+			</a>
+		</li>
+	</ul>
 
-		<div class="col col-na-xl-5 col-12">
-			<div class="card">
-				<div class="card-header d-flex align-items-center">
-					<h2>Details</h2>
-					<button
-						class="btn btn-outline-secondary ml-3"
-						type="button"
-						[disabled]="isEditing"
-						*ngIf="canManageTeam"
-						(click)="edit()"
-					>
-						<span class="fa fa-lg fa-pencil"></span>
-					</button>
-					<div class="inline-edit-header-btns ml-auto" *ngIf="isEditing">
-						<button
-							class="btn btn-outline-secondary"
-							type="button"
-							(click)="cancelEdit()"
-						>
-							Cancel
-						</button>
-						<button
-							class="btn btn-primary ml-2"
-							type="button"
-							[disabled]="!editTeamForm.form.valid"
-							(click)="saveEdit()"
-						>
-							Save
-						</button>
-					</div>
-				</div>
-				<div class="card-body" [class.editing]="isEditing">
-					<form id="edit-team-form" #editTeamForm="ngForm">
-						<div class="form-inline-edit mb-3">
-							<div class="form-group">
-								<label class="col col-form-label">Name</label>
-								<div class="col col-form-readonly-value" *ngIf="!isEditing">
-									<div>{{ team.name || '' | titlecase }}</div>
-								</div>
-								<div class="col" *ngIf="isEditing">
-									<input
-										class="form-control"
-										placeholder="Enter name"
-										name="name"
-										[(ngModel)]="_team.name"
-										required
-									/>
-								</div>
-							</div>
-
-							<div class="form-group">
-								<label class="col col-form-label">Description</label>
-								<div class="col col-form-readonly-value" *ngIf="!isEditing">
-									<div style="white-space: pre-wrap">{{ team.description }}</div>
-								</div>
-								<div class="col" *ngIf="isEditing">
-									<textarea
-										class="form-control"
-										placeholder="Enter description"
-										name="description"
-										[(ngModel)]="_team.description"
-									>
-									</textarea>
-								</div>
-							</div>
-
-							<div class="form-group">
-								<label class="col col-form-label">Date Created</label>
-								<div class="col col-form-readonly-value">
-									<div>{{ team.created | utcDate: 'yyyy-MM-dd' }}</div>
-								</div>
-							</div>
-
-							<div class="form-group" *ngIf="team.parent">
-								<label class="col col-form-label">Parent</label>
-								<div class="col col-form-readonly-value">
-									<div>
-										<a
-											class="text-decoration-underline"
-											[routerLink]="['/team', team.parent._id || team.parent]"
-										>
-											{{ team.parent.name }}
-										</a>
-									</div>
-								</div>
-							</div>
-
-							<div
-								class="form-group"
-								*ngIf="
-									team.implicitMembers &&
-									implicitMembersStrategy === 'roles' &&
-									((team.requiresExternalRoles?.length || 0) > 0 || isEditing)
-								"
-							>
-								<label class="col col-form-label">External Roles</label>
-								<div class="col col-form-readonly-value" *ngIf="!isEditing">
-									<div>{{ team.requiresExternalRoles | join: ', ' }}</div>
-								</div>
-								<div class="col" *ngIf="isEditing">
-									<asy-multi-select-input
-										placeholder="Start typing a role..."
-										name="externalRoles"
-										[(ngModel)]="_team.requiresExternalRoles"
-									></asy-multi-select-input>
-								</div>
-							</div>
-
-							<div
-								class="form-group"
-								*ngIf="
-									team.implicitMembers &&
-									implicitMembersStrategy === 'teams' &&
-									((team.requiresExternalTeams?.length || 0) > 0 || isEditing)
-								"
-							>
-								<label class="col col-form-label">External Teams</label>
-								<div class="col col-form-readonly-value" *ngIf="!isEditing">
-									<div>{{ team.requiresExternalTeams | join: ', ' }}</div>
-								</div>
-								<div class="col" *ngIf="isEditing">
-									<asy-multi-select-input
-										placeholder="Start typing a team..."
-										name="externalTeams"
-										[(ngModel)]="_team.requiresExternalTeams"
-									></asy-multi-select-input>
-								</div>
-							</div>
-						</div>
-					</form>
-
-					<div class="inline-edit-btns text-right" *ngIf="isEditing">
-						<button
-							class="btn btn-outline-secondary"
-							type="button"
-							(click)="cancelEdit()"
-						>
-							Cancel
-						</button>
-						<button
-							class="btn btn-primary ml-2"
-							type="button"
-							[disabled]="!editTeamForm.form.valid"
-							(click)="saveEdit()"
-						>
-							Save
-						</button>
-					</div>
-				</div>
-			</div>
-		</div>
-
-		<div class="col col-na-xl-7 col-12" *ngIf="nestedTeamsEnabled">
-			<div class="card">
-				<div class="card-header d-flex align-items-center">
-					<h2>Sub-Teams</h2>
-				</div>
-				<div class="card-body">
-					<app-list-teams [parent]="team" [embedded]="true"></app-list-teams>
-				</div>
-			</div>
-		</div>
+	<div class="view-team-section-container">
+		<router-outlet></router-outlet>
 	</div>
-</ng-container>
-
+</section>
 <ng-template #noTeam> Error: Team not found </ng-template>

--- a/src/app/core/teams/view-team/view-team.component.scss
+++ b/src/app/core/teams/view-team/view-team.component.scss
@@ -1,0 +1,15 @@
+@use 'sass:math';
+@import '../../site-container/shared';
+
+$view-team-section-padding-y: $site-content-padding-y;
+
+.view-team-container {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+
+	.view-team-section-container {
+		height: 100%;
+		padding: math.div($view-team-section-padding-y, 2) 0;
+	}
+}

--- a/src/app/core/teams/view-team/view-team.component.ts
+++ b/src/app/core/teams/view-team/view-team.component.ts
@@ -12,15 +12,18 @@ import { AuthorizationService } from '../../auth/authorization.service';
 import { SessionService } from '../../auth/session.service';
 import { ConfigService } from '../../config.service';
 import { TeamAuthorizationService } from '../team-authorization.service';
+import { TeamTopic, TeamTopics } from '../team-topic.model';
 import { Team } from '../team.model';
 import { TeamsService } from '../teams.service';
 
 @UntilDestroy()
 @Component({
 	selector: 'app-view-team',
-	templateUrl: './view-team.component.html'
+	templateUrl: './view-team.component.html',
+	styleUrls: ['./view-team.component.scss']
 })
 export class ViewTeamComponent implements OnInit {
+	topics: TeamTopic[] = [];
 	team?: Team;
 	_team: any;
 
@@ -41,7 +44,9 @@ export class ViewTeamComponent implements OnInit {
 		private authorizationService: AuthorizationService,
 		private sessionService: SessionService,
 		private teamAuthorizationService: TeamAuthorizationService
-	) {}
+	) {
+		this.topics = TeamTopics.getTopics();
+	}
 
 	ngOnInit() {
 		this.configService

--- a/src/styles/ngx-bootstrap/_cards.scss
+++ b/src/styles/ngx-bootstrap/_cards.scss
@@ -18,6 +18,14 @@ $card-selected-check-size: 2rem !default;
 			margin-bottom: 0;
 		}
 	}
+
+	&.flex-row {
+		.card-header {
+			height: auto;
+			border-bottom: 0;
+			border-right: $border-width solid $border-color;
+		}
+	}
 }
 
 .card-selectable {

--- a/src/styles/ngx-bootstrap/_nav.scss
+++ b/src/styles/ngx-bootstrap/_nav.scss
@@ -12,4 +12,29 @@ $nav-tabs-border-highlight-width: 3px !default;
 		font-size: $font-size-base;
 		margin: 0 1rem;
 	}
+
+	&.flex-column {
+		border-bottom: 0;
+
+		.card.flex-row & {
+			margin: -1 * $card-spacer-y -1 * $card-spacer-x;
+		}
+
+		.nav-link {
+			border-width: 0 0 0 $nav-tabs-border-highlight-width;
+			margin: 0;
+			padding: $nav-link-padding-y;
+
+			@include hover-focus {
+				border-color: transparent transparent transparent $ux-color-highlight;
+			}
+		}
+
+		.nav-link.active,
+		.nav-item.show .nav-link {
+			color: $nav-tabs-link-active-color;
+			background-color: $nav-tabs-link-active-bg;
+			border-color: transparent transparent transparent $ux-color-primary-medium;
+		}
+	}
 }


### PR DESCRIPTION
Add tabbed interface similar to how admin pages works.  Current view team page content is now under 'General' tab.
This will allow downstream applications to add additional app specific team tabs without having to update core team code.