### PR TITLE
refactor(team): Update display of member role

### DIFF
--- a/src/app/core/teams/team-authorization.service.ts
+++ b/src/app/core/teams/team-authorization.service.ts
@@ -51,7 +51,7 @@ export class TeamAuthorizationService {
 	}
 
 	public isMember(team: Pick<Team, '_id'>): boolean {
-		return this.hasRole(team, TeamRole.VIEW_ONLY.role);
+		return this.hasRole(team, TeamRole.MEMBER.role);
 	}
 
 	public isEditor(team: Pick<Team, '_id'>): boolean {

--- a/src/app/core/teams/team-member.model.ts
+++ b/src/app/core/teams/team-member.model.ts
@@ -47,7 +47,7 @@ export class TeamMember extends User {
 			this.explicit = (userModel.teams?.length ?? 0) > 0;
 
 			if (null != team) {
-				this.role = this.getRoleInTeam(team) ?? TeamRole.VIEW_ONLY.role;
+				this.role = this.getRoleInTeam(team) ?? TeamRole.MEMBER.role;
 				this.roleDisplay = TeamRole.getDisplay(this.role);
 
 				this.explicit = userModel.teams.map((t: any) => t._id).includes(team._id);

--- a/src/app/core/teams/team-role.model.ts
+++ b/src/app/core/teams/team-role.model.ts
@@ -1,6 +1,6 @@
 export class TeamRole {
-	public static VIEW_ONLY: TeamRole = new TeamRole(
-		'View Only',
+	public static MEMBER: TeamRole = new TeamRole(
+		'Member',
 		'This user can view resources within this team.',
 		'member'
 	);
@@ -23,7 +23,7 @@ export class TeamRole {
 	constructor(public label: string, public description: string, public role: string) {}
 
 	public static get ROLES(): TeamRole[] {
-		return [this.VIEW_ONLY, this.EDITOR, this.ADMIN, this.BLOCKED];
+		return [this.MEMBER, this.EDITOR, this.ADMIN, this.BLOCKED];
 	}
 
 	static getDisplay(role: string): string {


### PR DESCRIPTION
Currently the `member` team role is displayed in the UI as `View Only`.  I am not sure the reason behind this, but it has been a cause for confusion.  This updates the display to `Member`.