### PR TITLE
fix: header/footer banner overflow

### DIFF
--- a/src/app/core/site-container/_shared.scss
+++ b/src/app/core/site-container/_shared.scss
@@ -1,14 +1,11 @@
 @import '../../../styles/shared';
 
-$header-banner-height: $font-line-height !default;
 $header-banner-bg: map-get($color-background, 'darkest') !default;
 $header-banner-color: map-get($color-background, 'darkest-contrast') !default;
 
-$footer-banner-height: $font-line-height !default;
 $footer-banner-bg: map-get($color-background, 'darkest') !default;
 $footer-banner-color: map-get($color-background, 'darkest-contrast') !default;
 
-$copyright-banner-height: $font-line-height !default;
 $copyright-banner-bg: map-get($color-background, 'default') !default;
 $copyright-banner-color: map-get($color-background, 'default-contrast') !default;
 

--- a/src/app/core/site-container/site-container.component.scss
+++ b/src/app/core/site-container/site-container.component.scss
@@ -23,19 +23,16 @@ $skip-link-z-index: 10002;
 .copyright-banner {
 	background-color: $copyright-banner-bg;
 	color: $copyright-banner-color;
-	height: $copyright-banner-height;
 }
 
 .footer-banner {
 	background-color: $footer-banner-bg;
 	color: $footer-banner-color;
-	height: $footer-banner-height;
 }
 
 .header-banner {
 	background-color: $header-banner-bg;
 	color: $header-banner-color;
-	height: $header-banner-height;
 }
 
 .site-content {


### PR DESCRIPTION
If banner content is too long to fit within the banner it will overflow on top of the element below it.  This is due to the use of explicit heights.  These are a holdover from the old site layout that relied on fixed positions and margins.  They are no longer needed since #228.
Removing them will allo the banner to grow to contain the content.