### PR TITLE
feat: Add match any/all option to asy-header-list-filter

### DIFF
--- a/src/app/common/table/filter/_shared.scss
+++ b/src/app/common/table/filter/_shared.scss
@@ -1,12 +1,17 @@
 @import '../../../../styles/overrides';
 @import '../../../../styles/shared';
 
-$filter-dropdown-font-size: 0.75rem;
+$filter-dropdown-font-size: 0.75rem !default;
+$filter-dropdown-max-height: 250px !default;
 
 .dropdown-menu {
 	font-size: $filter-dropdown-font-size;
 	margin-top: 0.5rem;
-	max-height: 205px;
+	max-height: $filter-dropdown-max-height;
+
+	input {
+		font-size: $filter-dropdown-font-size;
+	}
 
 	.search {
 		width: 250px;

--- a/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.scss
+++ b/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.scss
@@ -6,10 +6,6 @@
 	padding: 0.75rem 0;
 	width: 196px;
 
-	input {
-		font-size: $filter-dropdown-font-size;
-	}
-
 	.input-group {
 		::ng-deep .ng-select-container {
 			border-radius: 0 $border-radius $border-radius 0;

--- a/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.html
+++ b/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.html
@@ -59,5 +59,28 @@
 				</div>
 			</ng-container>
 		</div>
+		<ng-container *ngIf="showMatch">
+			<div class="divider dropdown-divider my-0 mx-3"></div>
+			<div class="my-1">
+				<label class="mb-0 mr-3">Match:</label>
+				<div
+					class="form-check form-check-inline"
+					*ngFor="let operatorOption of [false, true]; index as i"
+				>
+					<input
+						class="form-check-input"
+						type="radio"
+						name="operator-option-radio"
+						id="operator-option-{{ i }}"
+						[value]="operatorOption"
+						[(ngModel)]="matchAll"
+						(ngModelChange)="onFilterChange()"
+					/>
+					<label class="form-check-label" for="operator-option-{{ i }}">{{
+						operatorOption ? 'All' : 'Any'
+					}}</label>
+				</div>
+			</div>
+		</ng-container>
 	</div>
 </span>

--- a/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.ts
+++ b/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.ts
@@ -14,7 +14,7 @@ import {
 } from '../asy-abstract-header-filter.component';
 import { AsyFilterDirective } from '../asy-filter.directive';
 
-type BuildFilterFunction = (options: ListFilterOption[]) => any;
+type BuildFilterFunction = (options: ListFilterOption[], matchAll?: boolean) => any;
 
 export type ListFilterOption = {
 	display: string;
@@ -34,7 +34,11 @@ export class AsyHeaderListFilterComponent extends AsyAbstractHeaderFilterCompone
 
 	search = '';
 
+	matchAll = false;
+
 	@Input() showSearch = false;
+
+	@Input() showMatch = false;
 
 	@Input()
 	buildFilterFunc?: BuildFilterFunction;
@@ -54,11 +58,14 @@ export class AsyHeaderListFilterComponent extends AsyAbstractHeaderFilterCompone
 
 	_buildFilter() {
 		if (this.buildFilterFunc) {
-			return this.buildFilterFunc(this._options);
+			return this.buildFilterFunc(this._options, this.matchAll);
 		}
 
 		const active = this._options.filter((o) => o.active).map((o) => o.value);
 		if (active.length > 0) {
+			if (this.showMatch && this.matchAll) {
+				return { $and: active.map((a) => ({ [this.id]: a })) };
+			}
 			return { [this.id]: { $in: active } };
 		}
 
@@ -73,7 +80,7 @@ export class AsyHeaderListFilterComponent extends AsyAbstractHeaderFilterCompone
 				value: option.value
 			}));
 		if (active.length > 0) {
-			return { options: active };
+			return { options: active, matchAll: this.matchAll };
 		}
 		return undefined;
 	}
@@ -90,6 +97,7 @@ export class AsyHeaderListFilterComponent extends AsyAbstractHeaderFilterCompone
 
 	_restoreState(state: any) {
 		if (state) {
+			this.matchAll = this.showMatch && (state.matchAll ?? false);
 			this._setActiveOptions(state.options as ListFilterOption[]);
 			this.onFilterChange();
 		}


### PR DESCRIPTION
Adds option to pick match type (any/all) to asy-header-list-filter.  Useful for filtering on columns that have multiple values.