### PR TITLE
fix(teams): Track search/filters for sub team list separate from team list

### DIFF
--- a/src/app/core/teams/list-teams/base-list-teams.component.ts
+++ b/src/app/core/teams/list-teams/base-list-teams.component.ts
@@ -1,0 +1,75 @@
+import {
+	Directive,
+	Input,
+	OnChanges,
+	OnDestroy,
+	OnInit,
+	Optional,
+	SimpleChanges
+} from '@angular/core';
+
+import cloneDeep from 'lodash/cloneDeep';
+import { Observable } from 'rxjs';
+
+import { PagingOptions, PagingResults } from '../../../common/paging.module';
+import { SystemAlertService } from '../../../common/system-alert/system-alert.service';
+import { AsyTableDataSource } from '../../../common/table/asy-table-data-source';
+import { AuthorizationService } from '../../auth/authorization.service';
+import { Team } from '../team.model';
+import { TeamsService } from '../teams.service';
+
+@Directive()
+export abstract class BaseListTeamsComponent implements OnChanges, OnDestroy, OnInit {
+	@Input()
+	parent?: Team;
+
+	@Input()
+	embedded = false;
+
+	canCreateTeam = false;
+
+	displayedColumns = ['name', 'created', 'description'];
+
+	protected constructor(
+		private teamsService: TeamsService,
+		private alertService: SystemAlertService,
+		private authorizationService: AuthorizationService,
+		public dataSource: AsyTableDataSource<Team>
+	) {}
+
+	ngOnInit() {
+		this.alertService.clearAllAlerts();
+
+		this.canCreateTeam = this.authorizationService.hasSomeRoles(['editor', 'admin']);
+	}
+
+	ngOnDestroy() {
+		this.dataSource.disconnect();
+	}
+
+	ngOnChanges(changes: SimpleChanges) {
+		if (changes['parent']) {
+			this.dataSource.reload();
+		}
+	}
+
+	loadData(
+		pagingOptions: PagingOptions,
+		search: string,
+		query: any
+	): Observable<PagingResults<Team>> {
+		if (this.parent) {
+			query = cloneDeep(query);
+			if (!query.$and) {
+				query.$and = [];
+			}
+			query.$and.push({ parent: this.parent._id });
+		}
+
+		return this.teamsService.search(pagingOptions, query, search, {});
+	}
+
+	clearFilters() {
+		this.dataSource.search('');
+	}
+}

--- a/src/app/core/teams/list-teams/list-sub-teams.component.ts
+++ b/src/app/core/teams/list-teams/list-sub-teams.component.ts
@@ -6,12 +6,14 @@ import { AuthorizationService } from '../../auth/authorization.service';
 import { Team } from '../team.model';
 import { TeamsService } from '../teams.service';
 import { BaseListTeamsComponent } from './base-list-teams.component';
+import { ListTeamsComponent } from './list-teams.component';
 
 @Component({
+	selector: 'app-list-sub-teams',
 	templateUrl: './list-teams.component.html',
 	styleUrls: ['./list-teams.component.scss']
 })
-export class ListTeamsComponent
+export class ListSubTeamsComponent
 	extends BaseListTeamsComponent
 	implements OnChanges, OnDestroy, OnInit
 {
@@ -26,7 +28,7 @@ export class ListTeamsComponent
 			authorizationService,
 			new AsyTableDataSource<Team>(
 				(request) => this.loadData(request.pagingOptions, request.search, request.filter),
-				'list-teams-component',
+				'list-sub-teams-component',
 				{
 					sortField: 'name',
 					sortDir: 'ASC'

--- a/src/app/core/teams/teams.module.ts
+++ b/src/app/core/teams/teams.module.ts
@@ -20,6 +20,7 @@ import { AddMembersModalComponent } from './add-members-modal/add-members-modal.
 import { CreateTeamComponent } from './create-team/create-team.component';
 import { TeamsHelpComponent } from './help/teams-help.component';
 import { ListTeamMembersComponent } from './list-team-members/list-team-members.component';
+import { ListSubTeamsComponent } from './list-teams/list-sub-teams.component';
 import { ListTeamsComponent } from './list-teams/list-teams.component';
 import { TeamAuthorizationService } from './team-authorization.service';
 import { TeamSelectInputComponent } from './team-select-input/team-select-input.component';
@@ -56,6 +57,7 @@ import { ViewTeamComponent } from './view-team/view-team.component';
 		CreateTeamComponent,
 		ListTeamMembersComponent,
 		ListTeamsComponent,
+		ListSubTeamsComponent,
 		ViewTeamComponent,
 		TeamsHelpComponent,
 		TeamSelectInputComponent,

--- a/src/app/core/teams/view-team/general-details/general-details.component.html
+++ b/src/app/core/teams/view-team/general-details/general-details.component.html
@@ -160,7 +160,7 @@
 				<h2>Sub-Teams</h2>
 			</div>
 			<div class="card-body">
-				<app-list-teams [parent]="team" [embedded]="true"></app-list-teams>
+				<app-list-sub-teams [parent]="team" [embedded]="true"></app-list-sub-teams>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
The sub team table on the view team page reuses the same component as the list team page.  This had the side effect that any search/filter applied to the list team page would automatically be applied to the sub team table as well.

This solves that issue, but moving the current logic in the list-team component into an abstract component and having list-team and a new list-sub-team component extend from it.  This allows each of these to specify their own data sources with distinct storage keys.