### PR TITLE
fix: Reset table paging to first page when sort/filter changes

### DIFF
--- a/src/app/common/table/asy-table-data-source.ts
+++ b/src/app/common/table/asy-table-data-source.ts
@@ -1,7 +1,7 @@
 import { DataSource } from '@angular/cdk/collections';
 
 import isEmpty from 'lodash/isEmpty';
-import { combineLatest, BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
+import { combineLatest, BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { debounceTime, map, switchMap, tap } from 'rxjs/operators';
 
 import {
@@ -82,6 +82,12 @@ export class AsyTableDataSource<T> extends DataSource<T> {
 
 		this.subscription = param$
 			.pipe(
+				tap(() => {
+					this.pageChangeEvent$.next({
+						pageNumber: 0,
+						pageSize: this.pageChangeEvent$.value.pageSize
+					});
+				}),
 				switchMap(([search, filter]) =>
 					pagingOptions$.pipe(map((pagingOptions) => [pagingOptions, search, filter]))
 				),


### PR DESCRIPTION
Fixes bug where invalid page is requested if sort/filter results in less pages than the current page.

i.e. User is viewing page 2 of table, but then applies a sort/filter that results in only one page of results.  App currently still requests page 2, even though it has no data.