### PR TITLE
fix(team): Ensure role column is populated on member table

### DIFF
--- a/src/app/core/teams/list-team-members/list-team-members.component.html
+++ b/src/app/core/teams/list-team-members/list-team-members.component.html
@@ -71,7 +71,7 @@
 						class="dropdown dropdown-table-inline"
 						dropdown
 						container="body"
-						*ngIf="canManageTeam"
+						*ngIf="canManageTeam; else readOnlyRole"
 					>
 						<span class="dropdown-toggle" dropdownToggle>
 							<span class="mr-1">{{ member.roleDisplay }}</span>
@@ -86,6 +86,9 @@
 							</li>
 						</ul>
 					</div>
+					<ng-template #readOnlyRole>
+						{{ member.roleDisplay }}
+					</ng-template>
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="actions">


### PR DESCRIPTION
Currently the role column is only populated for team admins.  Add read only display of roles for other team members.