### PR TITLE
feat: Improve accessibility of navbar

### DIFF
--- a/src/app/common/directives.module.ts
+++ b/src/app/common/directives.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 
+import { LinkAccessibilityDirective } from './directives/link-accessibility.directive';
 import { SkipToDirective } from './directives/skip-to.directive';
 
 @NgModule({
 	imports: [],
-	exports: [SkipToDirective],
-	declarations: [SkipToDirective],
+	exports: [SkipToDirective, LinkAccessibilityDirective],
+	declarations: [SkipToDirective, LinkAccessibilityDirective],
 	providers: []
 })
 export class DirectivesModule {}

--- a/src/app/common/directives/link-accessibility.directive.ts
+++ b/src/app/common/directives/link-accessibility.directive.ts
@@ -1,9 +1,10 @@
 import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
 
 /**
- * Used to mark where in a page the "Skip to main content" link
- * should skip to. It is ideally placed on the page's main heading:
- * the h1 element. This directive should only be used once per page
+ * Used to enable link for keyboard accessibility.
+ * This is only necessary for interactibles using that do not have a
+ * href attribute, because those will naturally be ignored by
+ * the tabbing structure.
  */
 @Directive({
 	selector: '[linkAccessibility]'

--- a/src/app/common/directives/link-accessibility.directive.ts
+++ b/src/app/common/directives/link-accessibility.directive.ts
@@ -1,0 +1,22 @@
+import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
+
+/**
+ * Used to mark where in a page the "Skip to main content" link
+ * should skip to. It is ideally placed on the page's main heading:
+ * the h1 element. This directive should only be used once per page
+ */
+@Directive({
+	selector: '[linkAccessibility]'
+})
+export class LinkAccessibilityDirective {
+	constructor(private elRef: ElementRef, private renderer: Renderer2) {
+		const el = elRef.nativeElement;
+		renderer.setAttribute(el, 'tabIndex', '0');
+	}
+
+	@HostListener('keydown.enter', ['$event'])
+	onEnter(event: Event) {
+		let targetEl = event.target;
+		targetEl?.dispatchEvent(new Event('click'));
+	}
+}

--- a/src/app/common/directives/link-accessibility.directive.ts
+++ b/src/app/common/directives/link-accessibility.directive.ts
@@ -23,9 +23,7 @@ export class LinkAccessibilityDirective {
 		targetEl?.dispatchEvent(new Event('click'));
 
 		if (targetEl?.attributes.href) {
-			const hrefVal = targetEl?.attributes.href.value;
-			const path = hrefVal[0] === '#' ? hrefVal.substring(1) : hrefVal;
-			this.router.navigate([path]);
+			window.location.href = targetEl?.attributes.href.value;
 		}
 	}
 }

--- a/src/app/common/directives/link-accessibility.directive.ts
+++ b/src/app/common/directives/link-accessibility.directive.ts
@@ -16,6 +16,7 @@ export class LinkAccessibilityDirective {
 	}
 
 	@HostListener('keydown.enter', ['$event'])
+	@HostListener('keydown.space', ['$event'])
 	onEnter(event: Event) {
 		let targetEl = event.target;
 		targetEl?.dispatchEvent(new Event('click'));

--- a/src/app/common/directives/link-accessibility.directive.ts
+++ b/src/app/common/directives/link-accessibility.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
+import { Router } from '@angular/router';
 
 /**
  * Used to enable link for keyboard accessibility.
@@ -10,7 +11,7 @@ import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
 	selector: '[linkAccessibility]'
 })
 export class LinkAccessibilityDirective {
-	constructor(private elRef: ElementRef, private renderer: Renderer2) {
+	constructor(private elRef: ElementRef, private renderer: Renderer2, private router: Router) {
 		const el = elRef.nativeElement;
 		renderer.setAttribute(el, 'tabIndex', '0');
 	}
@@ -18,7 +19,13 @@ export class LinkAccessibilityDirective {
 	@HostListener('keydown.enter', ['$event'])
 	@HostListener('keydown.space', ['$event'])
 	onEnter(event: Event) {
-		let targetEl = event.target;
+		let targetEl: any = event.target;
 		targetEl?.dispatchEvent(new Event('click'));
+
+		if (targetEl?.attributes.href) {
+			const hrefVal = targetEl?.attributes.href.value;
+			const path = hrefVal[0] === '#' ? hrefVal.substring(1) : hrefVal;
+			this.router.navigate([path]);
+		}
 	}
 }

--- a/src/app/common/directives/link-accessibility.directive.ts
+++ b/src/app/common/directives/link-accessibility.directive.ts
@@ -1,5 +1,4 @@
 import { Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
-import { Router } from '@angular/router';
 
 /**
  * Used to enable link for keyboard accessibility.
@@ -11,19 +10,14 @@ import { Router } from '@angular/router';
 	selector: '[linkAccessibility]'
 })
 export class LinkAccessibilityDirective {
-	constructor(private elRef: ElementRef, private renderer: Renderer2, private router: Router) {
+	constructor(private elRef: ElementRef, private renderer: Renderer2) {
 		const el = elRef.nativeElement;
 		renderer.setAttribute(el, 'tabIndex', '0');
 	}
 
 	@HostListener('keydown.enter', ['$event'])
-	@HostListener('keydown.space', ['$event'])
 	onEnter(event: Event) {
 		let targetEl: any = event.target;
 		targetEl?.dispatchEvent(new Event('click'));
-
-		if (targetEl?.attributes.href) {
-			window.location.href = targetEl?.attributes.href.value;
-		}
 	}
 }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -11,6 +11,7 @@ import { firstValueFrom } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 import { AdminTopics } from '../common/admin/admin-topic.model';
+import { DirectivesModule } from '../common/directives.module';
 import { LoadingSpinnerModule } from '../common/loading-spinner.module';
 import { SystemAlertModule } from '../common/system-alert.module';
 import { AboutComponent } from './about.component';
@@ -75,7 +76,8 @@ export function getConfiguration(configService: ConfigService) {
 		LoadingSpinnerModule,
 		SystemAlertModule,
 		MessagesModule,
-		MasqueradeModule
+		MasqueradeModule,
+		DirectivesModule
 	],
 	exports: [
 		SiteContainerComponent,

--- a/src/app/core/site-navbar/site-navbar.component.html
+++ b/src/app/core/site-navbar/site-navbar.component.html
@@ -3,10 +3,10 @@
 	<ul class="nav nav-logo">
 		<!-- Logo -->
 		<li class="element element-logo">
-			<a href="/#/" [hidden]="navbarOpen" linkAccessibility>
+			<a href="/#/" [hidden]="navbarOpen">
 				<img class="logo" src="/assets/images/nav-logo-icon.png" alt="Logo" />
 			</a>
-			<a href="/#/" [hidden]="!navbarOpen" linkAccessibility>
+			<a href="/#/" [hidden]="!navbarOpen">
 				<img class="logo" src="/assets/images/nav-logo.png" alt="Logo" />
 			</a>
 		</li>
@@ -24,7 +24,6 @@
 						[isDisabled]="navbarOpen"
 						routerLinkActive="active-link"
 						[routerLink]="navbarItem.path"
-						linkAccessibility
 					>
 						<span class="fa-solid fa-fw {{ navbarItem.iconClass }}"></span>
 						<span [hidden]="!navbarOpen">{{ navbarItem.title }}</span>
@@ -64,7 +63,6 @@
 									{ clearCachedFilter: true }
 								]"
 								(click)="adminNavPopover.hide()"
-								linkAccessibility
 							>
 								{{ adminItem.title }}
 							</a>
@@ -82,7 +80,6 @@
 					[isDisabled]="navbarOpen"
 					routerLinkActive="active-link"
 					routerLink="/audit"
-					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-file-text"></span>
 					<span [hidden]="!navbarOpen">Audit Logs</span>
@@ -98,7 +95,6 @@
 					[isDisabled]="navbarOpen"
 					routerLinkActive="active-link"
 					routerLink="/teams"
-					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-users"></span>
 					<span [hidden]="!navbarOpen">Teams</span>
@@ -135,18 +131,14 @@
 				<ng-template #userNav>
 					<ul class="popover-menu" role="menu">
 						<!-- User Signout -->
-						<li><a href="/api/auth/signout" linkAccessibility>Sign out</a></li>
+						<li><a href="/api/auth/signout">Sign out</a></li>
 						<li *ngIf="session?.user?.eua">
-							<a [routerLink]="['/eua']" linkAccessibility>View EUA</a>
+							<a [routerLink]="['/eua']">View EUA</a>
 						</li>
 
 						<!-- User Preferences -->
 						<li *ngIf="showUserPreferencesLink">
-							<a
-								[routerLink]="userPreferencesLink"
-								(click)="userNavPopover.hide()"
-								linkAccessibility
-							>
+							<a [routerLink]="userPreferencesLink" (click)="userNavPopover.hide()">
 								User Preferences
 							</a>
 						</li>
@@ -157,11 +149,10 @@
 									routerLink="/masquerade"
 									(click)="userNavPopover.hide()"
 									*ngIf="!isMasquerade && canMasquerade"
-									linkAccessibility
 								>
 									Masquerade
 								</a>
-								<a routerLink="/masquerade" *ngIf="isMasquerade" linkAccessibility>
+								<a routerLink="/masquerade" *ngIf="isMasquerade">
 									Clear Masquerade
 								</a>
 							</li>
@@ -181,7 +172,6 @@
 					[isDisabled]="navbarOpen"
 					routerLinkActive="active-link"
 					routerLink="masquerade"
-					linkAccessibility
 				>
 					<span class="fa-stack">
 						<span class="fa-solid fa-circle fa-stack-2x"></span>
@@ -247,9 +237,7 @@
 					<ul class="popover-menu" role="menu">
 						<!-- Help -->
 						<li>
-							<a routerLink="/help" (click)="helpNavPopover.hide()" linkAccessibility>
-								Help Docs
-							</a>
+							<a routerLink="/help" (click)="helpNavPopover.hide()"> Help Docs </a>
 						</li>
 
 						<!-- Feedback -->
@@ -265,25 +253,14 @@
 
 						<!-- API Docs -->
 						<li *ngIf="showApiDocsLink">
-							<a
-								[href]="apiDocsLink"
-								target="_blank"
-								(click)="helpNavPopover.hide()"
-								linkAccessibility
-							>
+							<a [href]="apiDocsLink" target="_blank" (click)="helpNavPopover.hide()">
 								API Docs
 							</a>
 						</li>
 
 						<!-- About -->
 						<li>
-							<a
-								routerLink="/about"
-								(click)="helpNavPopover.hide()"
-								linkAccessibility
-							>
-								About
-							</a>
+							<a routerLink="/about" (click)="helpNavPopover.hide()"> About </a>
 						</li>
 					</ul>
 				</ng-template>

--- a/src/app/core/site-navbar/site-navbar.component.html
+++ b/src/app/core/site-navbar/site-navbar.component.html
@@ -3,10 +3,10 @@
 	<ul class="nav nav-logo">
 		<!-- Logo -->
 		<li class="element element-logo">
-			<a href="/#/" [hidden]="navbarOpen">
+			<a href="/#/" [hidden]="navbarOpen" linkAccessibility>
 				<img class="logo" src="/assets/images/nav-logo-icon.png" alt="Logo" />
 			</a>
-			<a href="/#/" [hidden]="!navbarOpen">
+			<a href="/#/" [hidden]="!navbarOpen" linkAccessibility>
 				<img class="logo" src="/assets/images/nav-logo.png" alt="Logo" />
 			</a>
 		</li>
@@ -24,6 +24,7 @@
 						[isDisabled]="navbarOpen"
 						routerLinkActive="active-link"
 						[routerLink]="navbarItem.path"
+						linkAccessibility
 					>
 						<span class="fa-solid fa-fw {{ navbarItem.iconClass }}"></span>
 						<span [hidden]="!navbarOpen">{{ navbarItem.title }}</span>
@@ -48,6 +49,7 @@
 					[outsideClick]="true"
 					(onShown)="adminNavOpen = true"
 					(onHidden)="adminNavOpen = false"
+					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-cog"></span>
 					<span [hidden]="!navbarOpen">Admin</span>
@@ -62,6 +64,7 @@
 									{ clearCachedFilter: true }
 								]"
 								(click)="adminNavPopover.hide()"
+								linkAccessibility
 							>
 								{{ adminItem.title }}
 							</a>
@@ -79,6 +82,7 @@
 					[isDisabled]="navbarOpen"
 					routerLinkActive="active-link"
 					routerLink="/audit"
+					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-file-text"></span>
 					<span [hidden]="!navbarOpen">Audit Logs</span>
@@ -94,6 +98,7 @@
 					[isDisabled]="navbarOpen"
 					routerLinkActive="active-link"
 					routerLink="/teams"
+					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-users"></span>
 					<span [hidden]="!navbarOpen">Teams</span>
@@ -114,6 +119,7 @@
 					[outsideClick]="true"
 					(onShown)="userNavOpen = true"
 					(onHidden)="userNavOpen = false"
+					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-user-circle" *ngIf="!isMasquerade"></span>
 					<span class="fa-stack" *ngIf="isMasquerade">
@@ -129,12 +135,18 @@
 				<ng-template #userNav>
 					<ul class="popover-menu" role="menu">
 						<!-- User Signout -->
-						<li><a href="/api/auth/signout">Sign out</a></li>
-						<li *ngIf="session?.user?.eua"><a [routerLink]="['/eua']">View EUA</a></li>
+						<li><a href="/api/auth/signout" linkAccessibility>Sign out</a></li>
+						<li *ngIf="session?.user?.eua">
+							<a [routerLink]="['/eua']" linkAccessibility>View EUA</a>
+						</li>
 
 						<!-- User Preferences -->
 						<li *ngIf="showUserPreferencesLink">
-							<a [routerLink]="userPreferencesLink" (click)="userNavPopover.hide()">
+							<a
+								[routerLink]="userPreferencesLink"
+								(click)="userNavPopover.hide()"
+								linkAccessibility
+							>
 								User Preferences
 							</a>
 						</li>
@@ -145,11 +157,13 @@
 									routerLink="/masquerade"
 									(click)="userNavPopover.hide()"
 									*ngIf="!isMasquerade && canMasquerade"
-									>Masquerade</a
+									linkAccessibility
 								>
-								<a routerLink="/masquerade" *ngIf="isMasquerade"
-									>Clear Masquerade</a
-								>
+									Masquerade
+								</a>
+								<a routerLink="/masquerade" *ngIf="isMasquerade" linkAccessibility>
+									Clear Masquerade
+								</a>
 							</li>
 						</ng-container>
 					</ul>
@@ -167,6 +181,7 @@
 					[isDisabled]="navbarOpen"
 					routerLinkActive="active-link"
 					routerLink="masquerade"
+					linkAccessibility
 				>
 					<span class="fa-stack">
 						<span class="fa-solid fa-circle fa-stack-2x"></span>
@@ -194,6 +209,7 @@
 					[outsideClick]="true"
 					(onShown)="messagesNavOpen = true"
 					(onHidden)="messagesNavOpen = false"
+					linkAccessibility
 				>
 					<span
 						class="fa-solid fa-fw fa-bell"
@@ -221,6 +237,7 @@
 					[outsideClick]="true"
 					(onShown)="helpNavOpen = true"
 					(onHidden)="helpNavOpen = false"
+					linkAccessibility
 				>
 					<span class="fa-solid fa-fw fa-question-circle"></span>
 					<span [hidden]="!navbarOpen">Help</span>
@@ -230,26 +247,43 @@
 					<ul class="popover-menu" role="menu">
 						<!-- Help -->
 						<li>
-							<a routerLink="/help" (click)="helpNavPopover.hide()">Help Docs</a>
+							<a routerLink="/help" (click)="helpNavPopover.hide()" linkAccessibility>
+								Help Docs
+							</a>
 						</li>
 
 						<!-- Feedback -->
 						<li *isAuthenticated="true; and: showFeedbackOption">
-							<a class="link" (click)="showFeedbackModal(); helpNavPopover.hide()"
-								>Give Feedback</a
+							<a
+								class="link"
+								(click)="showFeedbackModal(); helpNavPopover.hide()"
+								linkAccessibility
 							>
+								Give Feedback
+							</a>
 						</li>
 
 						<!-- API Docs -->
 						<li *ngIf="showApiDocsLink">
-							<a [href]="apiDocsLink" target="_blank" (click)="helpNavPopover.hide()"
-								>API Docs</a
+							<a
+								[href]="apiDocsLink"
+								target="_blank"
+								(click)="helpNavPopover.hide()"
+								linkAccessibility
 							>
+								API Docs
+							</a>
 						</li>
 
 						<!-- About -->
 						<li>
-							<a routerLink="/about" (click)="helpNavPopover.hide()">About</a>
+							<a
+								routerLink="/about"
+								(click)="helpNavPopover.hide()"
+								linkAccessibility
+							>
+								About
+							</a>
 						</li>
 					</ul>
 				</ng-template>
@@ -262,7 +296,7 @@
 		<li class="element element-divider element-divider-collapse"></li>
 
 		<!-- Collapse/Expand -->
-		<li class="element" (click)="toggleNavbar()">
+		<li class="element" (click)="toggleNavbar()" linkAccessibility>
 			<a tooltip="Expand" placement="left" container="body" [isDisabled]="navbarOpen">
 				<span
 					class="fa-solid fa-fw fa-angle-double-right"


### PR DESCRIPTION
Updated navbar links so you can now navigate to them using keyboard tabbing. This happened because <a> elements with no href attribute will be ignored, and to a user with navigating the website through keyboard alone, those links will be completely inaccessible. This commit adds a directive that adds the `tabindex="0"`, and then forces an artificial click on submit to copy native link behavior