### PR TITLE
fix: sort headers styling now indicates what column is sorted on

### DIFF
--- a/src/app/common/table/sort/asy-sort-header/asy-sort-header.component.scss
+++ b/src/app/common/table/sort/asy-sort-header/asy-sort-header.component.scss
@@ -3,11 +3,11 @@
 .fa-solid,
 .fa-brands {
 	opacity: 0.3;
-}
 
-.fa.sorted {
-	color: $ux-color-primary;
-	opacity: 1;
+	&.sorted {
+		color: $ux-color-primary;
+		opacity: 1;
+	}
 }
 
 .fa-stack {


### PR DESCRIPTION
**Before**
<img width="700" alt="screenshot_2023-02-07_at_1 08 39_pm" src="https://user-images.githubusercontent.com/10501914/217330119-954f31ec-cc25-4b4c-b742-272022d72f8f.png">
<img width="729" alt="screenshot_2023-02-07_at_1 08 44_pm" src="https://user-images.githubusercontent.com/10501914/217330121-705fb9fe-593a-48a3-86f7-dd5e4766d9ae.png">

**After**
<img width="751" alt="screenshot_2023-02-07_at_1 08 16_pm" src="https://user-images.githubusercontent.com/10501914/217330117-3685a75d-4db8-48c0-b673-5076eca6da00.png">
<img width="679" alt="screenshot_2023-02-07_at_1 10 08_pm" src="https://user-images.githubusercontent.com/10501914/217330123-373ecd72-2ff9-49e4-ac9e-acd52a686233.png">