### PR TITLE
refactor: Return UrlTrees from AuthGuard and let angular handle routing

### DIFF
--- a/src/app/core/auth/auth.guard.spec.ts
+++ b/src/app/core/auth/auth.guard.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
 
 import { of } from 'rxjs';
 
@@ -15,9 +15,9 @@ import SpyObj = jasmine.SpyObj;
 
 describe('AuthGuard', () => {
 	let guard: AuthGuard;
+	let router: Router;
 	let sessionService: SessionService;
 
-	let routerSpy: SpyObj<Router>;
 	let configServiceSpy: SpyObj<ConfigService>;
 	let authServiceSpy: SpyObj<AuthenticationService>;
 
@@ -26,8 +26,6 @@ describe('AuthGuard', () => {
 	};
 
 	beforeEach(() => {
-		routerSpy = jasmine.createSpyObj('Router', ['navigate']);
-
 		configServiceSpy = jasmine.createSpyObj('ConfigService', ['getConfig']);
 		configServiceSpy.getConfig.and.returnValue(of(defaultConfig as Config));
 
@@ -40,7 +38,6 @@ describe('AuthGuard', () => {
 
 		TestBed.configureTestingModule({
 			providers: [
-				{ provide: Router, useValue: routerSpy },
 				{ provide: ConfigService, useValue: configServiceSpy },
 				{ provide: AuthenticationService, useValue: authServiceSpy },
 				{ provide: SessionService },
@@ -49,6 +46,7 @@ describe('AuthGuard', () => {
 			]
 		});
 		guard = TestBed.inject(AuthGuard);
+		router = TestBed.inject(Router);
 		sessionService = TestBed.inject(SessionService);
 	});
 
@@ -74,8 +72,8 @@ describe('AuthGuard', () => {
 			spyOn(sessionService, 'getSession').and.returnValue(of({} as Session));
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(false);
-				expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/signin']);
+				expect(result instanceof UrlTree).toBe(true);
+				expect(result.toString()).toBe('/signin');
 				done();
 			});
 		});
@@ -91,8 +89,8 @@ describe('AuthGuard', () => {
 			const route = {} as unknown as ActivatedRouteSnapshot;
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(false);
-				expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/unauthorized']);
+				expect(result instanceof UrlTree).toBe(true);
+				expect(result.toString()).toBe('/unauthorized');
 				done();
 			});
 		});
@@ -110,7 +108,6 @@ describe('AuthGuard', () => {
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
 				expect(result).toBe(true);
-				expect(routerSpy.navigate).toHaveBeenCalledTimes(0);
 				done();
 			});
 		});
@@ -129,8 +126,8 @@ describe('AuthGuard', () => {
 			} as unknown as ActivatedRouteSnapshot;
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(false);
-				expect(routerSpy.navigate).toHaveBeenCalledOnceWith(['/unauthorized']);
+				expect(result instanceof UrlTree).toBe(true);
+				expect(result.toString()).toBe('/unauthorized');
 				done();
 			});
 		});
@@ -149,8 +146,8 @@ describe('AuthGuard', () => {
 			} as unknown as ActivatedRouteSnapshot;
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(false);
-				expect(routerSpy.navigate).toHaveBeenCalledWith(['/unauthorized']);
+				expect(result instanceof UrlTree).toBe(true);
+				expect(result.toString()).toBe('/unauthorized');
 				done();
 			});
 		});
@@ -170,7 +167,6 @@ describe('AuthGuard', () => {
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
 				expect(result).toBe(true);
-				expect(routerSpy.navigate).toHaveBeenCalledTimes(0);
 				done();
 			});
 		});
@@ -190,30 +186,9 @@ describe('AuthGuard', () => {
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
 				expect(result).toBe(true);
-				expect(routerSpy.navigate).toHaveBeenCalledTimes(0);
 				done();
 			});
 		});
-
-		// it('should redirect to homepage if authenticated user was previously on auauthorized page', done => {
-		// 	authServiceSpy.reloadCurrentUser.and.returnValue(
-		// 		of({
-		// 			name: 'test',
-		// 			username: 'test',
-		// 			roles: { user: true }
-		// 		})
-		// 	);
-		//
-		// 	const route = ({} as unknown) as ActivatedRouteSnapshot;
-		//
-		// 	guard
-		// 		.canActivate(route, { url: '/unauthorized' } as RouterStateSnapshot)
-		// 		.subscribe(result => {
-		// 			expect(result).toBe(true);
-		// 			expect(routerSpy.navigate).toHaveBeenCalledWith(['']);
-		// 			done();
-		// 		});
-		// });
 
 		it('should redirect to eua page for authenticated user who has not accepted latest eua', (done) => {
 			authServiceSpy.reloadCurrentUser.and.returnValue(
@@ -228,8 +203,8 @@ describe('AuthGuard', () => {
 			const route = { data: { requiresEua: true } } as unknown as ActivatedRouteSnapshot;
 
 			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(false);
-				expect(routerSpy.navigate).toHaveBeenCalledWith(['/eua']);
+				expect(result instanceof UrlTree).toBe(true);
+				expect(result.toString()).toBe('/eua');
 				done();
 			});
 		});

--- a/src/app/core/auth/auth.guard.ts
+++ b/src/app/core/auth/auth.guard.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import {
+	ActivatedRouteSnapshot,
+	CanActivate,
+	Router,
+	RouterStateSnapshot,
+	UrlTree
+} from '@angular/router';
 
 import { combineLatest, of, Observable } from 'rxjs';
 import { first, map, switchMap } from 'rxjs/operators';
@@ -19,7 +25,10 @@ export class AuthGuard implements CanActivate {
 		private authorizationService: AuthorizationService
 	) {}
 
-	canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+	canActivate(
+		route: ActivatedRouteSnapshot,
+		state: RouterStateSnapshot
+	): Observable<boolean | UrlTree> {
 		// Default to requiring authentication if guard is present
 		const requiresAuthentication = route.data?.['requiresAuthentication'] ?? true;
 
@@ -57,11 +66,10 @@ export class AuthGuard implements CanActivate {
 		);
 	}
 
-	checkAccess(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+	checkAccess(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree {
 		// The user still isn't authenticated
 		if (!this.authorizationService.isAuthenticated()) {
-			this.router.navigate(['/signin']);
-			return false;
+			return this.router.parseUrl('/signin');
 		}
 
 		if (!this.authorizationService.isAdmin()) {
@@ -73,8 +81,7 @@ export class AuthGuard implements CanActivate {
 			const requiresEua = route.data?.['requiresEua'] ?? true;
 
 			if (requiresEua && !this.authorizationService.isEuaCurrent()) {
-				this.router.navigate(['/eua']);
-				return false;
+				return this.router.parseUrl('/eua');
 			}
 
 			// -----------------------------------------------------------
@@ -101,14 +108,8 @@ export class AuthGuard implements CanActivate {
 				state.url !== '/unauthorized'
 			) {
 				// The user doesn't have the needed roles to view the page
-				this.router.navigate(['/unauthorized']);
-				return false;
+				return this.router.parseUrl('/unauthorized');
 			}
-
-			// redirect a user to the homepage if they are authorized
-			// if (missingRoles.length === 0 && state.url === '/unauthorized') {
-			// 	this.router.navigate(['']);
-			// }
 		}
 
 		return true;


### PR DESCRIPTION
Previously we would redirect and return false from the AuthGuard.  By returning a UrlTree instead, Angular will handle the routing.  This will prevent potential conflicts if multiple guards are rerouting.