### PR TITLE
fix: Ensure audit page actor filter runs properly

### DIFF
--- a/src/app/core/audit/list-audit-entries/audit-actor-filter.directive.ts
+++ b/src/app/core/audit/list-audit-entries/audit-actor-filter.directive.ts
@@ -17,7 +17,7 @@ export class AuditActorFilterDirective implements OnInit {
 	) {}
 
 	ngOnInit() {
-		this.typeaheadFilter.typeaheadFunc = this.typeaheadSearch;
+		this.typeaheadFilter.typeaheadFunc = this.typeaheadSearch.bind(this);
 		this.typeaheadFilter.buildFilterFunc = this.buildFilter;
 	}
 


### PR DESCRIPTION
Needed to bind this when setting typeaheadFunc on the filter to ensure function is executed in proper context.