### PR TITLE
fix: Cache Entries sort by created column

### DIFF
--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -32,12 +32,12 @@
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="value">
-				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Value</th>
+				<th cdk-header-cell *cdkHeaderCellDef>Value</th>
 				<td cdk-cell *cdkCellDef="let entry" class="hide-overflow" style="max-width: 300px">
 					{{ entry.value | json }}
 				</td>
 			</ng-container>
-			<ng-container cdkColumnDef="timestamp">
+			<ng-container cdkColumnDef="ts">
 				<th cdk-header-cell asy-sort-header *cdkHeaderCellDef>Created</th>
 				<td cdk-cell *cdkCellDef="let entry">
 					<div class="text-nowrap" tooltip="{{ entry.ts | utcDate }}" container="body">

--- a/src/app/core/admin/cache-entries/cache-entries.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.component.ts
@@ -22,14 +22,14 @@ import { CacheEntry } from './cache-entry.model';
 	templateUrl: './cache-entries.component.html'
 })
 export class CacheEntriesComponent implements OnDestroy, OnInit {
-	displayedColumns = ['key', 'value', 'timestamp', 'actionsMenu'];
+	displayedColumns = ['key', 'value', 'ts', 'actionsMenu'];
 
 	dataSource = new AsyTableDataSource<CacheEntry>(
 		(request) => this.loadData(request.pagingOptions, request.search, request.filter),
 		null,
 		{
-			sortField: 'key',
-			sortDir: SortDirection.asc
+			sortField: 'ts',
+			sortDir: SortDirection.desc
 		}
 	);
 


### PR DESCRIPTION
* Sorting by the created column was not working properly, due to sending the wrong property value to server.
* Also disabled sorting by value column.