### PR TITLE
refactor: Update AuthGuard configuration

### DIFF
--- a/src/app/core/admin/admin-routes.ts
+++ b/src/app/core/admin/admin-routes.ts
@@ -12,8 +12,7 @@ export const ADMIN_ROUTES: Routes = [
 	{
 		path: '',
 		component: AdminComponent,
-		canActivate: [authGuard],
-		data: { roles: ['admin'] },
+		canActivate: [authGuard('admin')],
 		children: [
 			/**
 			 * Default Route

--- a/src/app/core/audit/audit-routes.ts
+++ b/src/app/core/audit/audit-routes.ts
@@ -6,8 +6,7 @@ export const AUDIT_ROUTES = [
 	{
 		path: '',
 		component: ListAuditEntriesComponent,
-		canActivate: [authGuard],
-		data: { roles: ['auditor'] },
+		canActivate: [authGuard('auditor')],
 		providers: [AuditService]
 	}
 ];

--- a/src/app/core/auth/auth.guard.spec.ts
+++ b/src/app/core/auth/auth.guard.spec.ts
@@ -5,7 +5,7 @@ import { of } from 'rxjs';
 
 import { Config } from '../config.model';
 import { ConfigService } from '../config.service';
-import { AuthGuard } from './auth.guard';
+import { AuthGuard, authGuard } from './auth.guard';
 import { AuthenticationService } from './authentication.service';
 import { AuthorizationService } from './authorization.service';
 import { Session } from './session.model';
@@ -14,10 +14,6 @@ import { SessionService } from './session.service';
 import SpyObj = jasmine.SpyObj;
 
 describe('AuthGuard', () => {
-	// eslint-disable-next-line deprecation/deprecation
-	let guard: AuthGuard;
-	let sessionService: SessionService;
-
 	let configServiceSpy: SpyObj<ConfigService>;
 	let authServiceSpy: SpyObj<AuthenticationService>;
 
@@ -46,12 +42,11 @@ describe('AuthGuard', () => {
 				{ provide: AuthGuard }
 			]
 		});
-		// eslint-disable-next-line deprecation/deprecation
-		guard = TestBed.inject(AuthGuard);
-		sessionService = TestBed.inject(SessionService);
 	});
 
 	it('should be created', () => {
+		// eslint-disable-next-line deprecation/deprecation
+		const guard = TestBed.inject(AuthGuard);
 		expect(guard).toBeTruthy();
 	});
 
@@ -61,21 +56,26 @@ describe('AuthGuard', () => {
 				data: { requiresAuthentication: false }
 			} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(true);
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result).toBe(true);
+					done();
+				});
 			});
 		});
 
 		it('should redirect to login for unauthenticated user', (done) => {
 			const route = {} as unknown as ActivatedRouteSnapshot;
 
+			const sessionService: SessionService = TestBed.inject(SessionService);
 			spyOn(sessionService, 'getSession').and.returnValue(of({} as Session));
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result instanceof UrlTree).toBe(true);
-				expect(result.toString()).toBe('/signin');
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result instanceof UrlTree).toBe(true);
+					expect(result.toString()).toBe('/signin');
+					done();
+				});
 			});
 		});
 
@@ -89,10 +89,12 @@ describe('AuthGuard', () => {
 
 			const route = {} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result instanceof UrlTree).toBe(true);
-				expect(result.toString()).toBe('/unauthorized');
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result instanceof UrlTree).toBe(true);
+					expect(result.toString()).toBe('/unauthorized');
+					done();
+				});
 			});
 		});
 
@@ -107,9 +109,11 @@ describe('AuthGuard', () => {
 
 			const route = {} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(true);
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result).toBe(true);
+					done();
+				});
 			});
 		});
 
@@ -126,10 +130,12 @@ describe('AuthGuard', () => {
 				data: { roles: ['admin'] }
 			} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result instanceof UrlTree).toBe(true);
-				expect(result.toString()).toBe('/unauthorized');
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result instanceof UrlTree).toBe(true);
+					expect(result.toString()).toBe('/unauthorized');
+					done();
+				});
 			});
 		});
 
@@ -146,10 +152,12 @@ describe('AuthGuard', () => {
 				data: { roles: ['test', 'admin'], requireAllRoles: false }
 			} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result instanceof UrlTree).toBe(true);
-				expect(result.toString()).toBe('/unauthorized');
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result instanceof UrlTree).toBe(true);
+					expect(result.toString()).toBe('/unauthorized');
+					done();
+				});
 			});
 		});
 
@@ -166,9 +174,11 @@ describe('AuthGuard', () => {
 				data: { roles: ['user', 'admin'], requireAllRoles: false }
 			} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(true);
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result).toBe(true);
+					done();
+				});
 			});
 		});
 
@@ -185,9 +195,11 @@ describe('AuthGuard', () => {
 				data: { roles: ['user', 'admin'], requireAllRoles: true }
 			} as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result).toBe(true);
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result).toBe(true);
+					done();
+				});
 			});
 		});
 
@@ -203,10 +215,12 @@ describe('AuthGuard', () => {
 
 			const route = { data: { requiresEua: true } } as unknown as ActivatedRouteSnapshot;
 
-			guard.canActivate(route, {} as RouterStateSnapshot).subscribe((result) => {
-				expect(result instanceof UrlTree).toBe(true);
-				expect(result.toString()).toBe('/eua');
-				done();
+			TestBed.runInInjectionContext(() => {
+				authGuard()(route, {} as RouterStateSnapshot).subscribe((result) => {
+					expect(result instanceof UrlTree).toBe(true);
+					expect(result.toString()).toBe('/eua');
+					done();
+				});
 			});
 		});
 	});

--- a/src/app/core/core-routes.ts
+++ b/src/app/core/core-routes.ts
@@ -23,10 +23,7 @@ export const CORE_ROUTES: Routes = [
 	{
 		path: 'eua',
 		component: UserEuaComponent,
-		canActivate: [authGuard],
-		data: {
-			requiresEua: false
-		}
+		canActivate: [authGuard({ requiresEua: false })]
 	},
 	{
 		path: 'signin',
@@ -42,18 +39,12 @@ export const CORE_ROUTES: Routes = [
 	},
 	{
 		path: 'unauthorized',
-		component: UnauthorizedComponent,
-		canActivate: [authGuard],
-		data: {
-			roles: [], // no roles are needed to get to the "unauthorized" page
-			requiresEua: false
-		}
+		component: UnauthorizedComponent
 	},
 	{
 		path: 'messages',
 		component: ViewAllMessagesComponent,
-		canActivate: [authGuard],
-		data: { roles: ['user'] }
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'masquerade',

--- a/src/app/core/teams/teams-routes.ts
+++ b/src/app/core/teams/teams-routes.ts
@@ -11,20 +11,17 @@ export const TEAMS_ROUTES: Routes = [
 	{
 		path: '',
 		component: ListTeamsComponent,
-		canActivate: [authGuard],
-		data: { roles: ['user'] }
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'create',
 		component: CreateTeamComponent,
-		canActivate: [authGuard],
-		data: { roles: ['editor', 'admin'], requireAllRoles: false }
+		canActivate: [authGuard({ roles: ['editor', 'admin'], requireAllRoles: false })]
 	},
 	{
 		path: ':id',
 		component: ViewTeamComponent,
-		canActivate: [authGuard],
-		data: { roles: ['user'] },
+		canActivate: [authGuard()],
 		resolve: {
 			team: teamResolver
 		},

--- a/src/app/site/example/example-routes.ts
+++ b/src/app/site/example/example-routes.ts
@@ -21,48 +21,47 @@ export const EXAMPLE_ROUTES: Routes = [
 	{
 		path: 'welcome',
 		component: WelcomeComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'explore',
 		component: ExploreComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'search',
 		component: SearchComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'forms',
 		component: FormsComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'grid',
 		component: GridComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'modal',
 		component: ModalComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'loading-overlay',
 		component: ExampleLoadingOverlayComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'alerts',
 		component: AlertsComponent,
-		canActivate: [authGuard]
+		canActivate: [authGuard()]
 	},
 	{
 		path: 'admin',
 		component: AdminComponent,
-		canActivate: [authGuard],
-		data: { roles: ['admin'] },
+		canActivate: [authGuard('admin')],
 		children: [
 			{
 				path: 'example',


### PR DESCRIPTION
* With move to functional guards, configuration can passed directly to the guard vs. using route data.  This allows for strongly typing the guard config.
* Configuration via route data is still supported for compatibility/migration purposes.