### PR TITLE
refactor: Replace ngx-bootstrap modals with cdk dialogs

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,8 +1,8 @@
+import { DialogModule } from '@angular/cdk/dialog';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 
-import { ModalModule } from 'ngx-bootstrap/modal';
 import { of } from 'rxjs';
 
 import { AppComponent } from './app.component';
@@ -16,7 +16,7 @@ describe('AppComponent', () => {
 		configServiceSpy.getConfig.and.returnValue(of({}));
 
 		TestBed.configureTestingModule({
-			imports: [ModalModule.forRoot(), AppComponent],
+			imports: [DialogModule, AppComponent],
 			providers: [
 				{ provide: ConfigService, useValue: configServiceSpy },
 				provideHttpClient(),

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -13,6 +13,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 
+import { providerCdkDialog } from './common/dialog/provider';
 import { authInterceptor } from './core/auth/auth.interceptor';
 import { euaInterceptor } from './core/auth/eua.interceptor';
 import { signinInterceptor } from './core/auth/signin.interceptor';
@@ -44,6 +45,7 @@ export const appConfig: ApplicationConfig = {
 			// Ensures any legacy class based interceptors are used.
 			withInterceptorsFromDi()
 		),
+		providerCdkDialog(),
 		provideRouter([], withHashLocation()),
 		provideCoreRoutes(),
 		provideExampleRoutes(),

--- a/src/app/common/dialog/bs-dialog-container/bs-dialog-container.component.html
+++ b/src/app/common/dialog/bs-dialog-container/bs-dialog-container.component.html
@@ -1,0 +1,5 @@
+<div class="modal-dialog modal-dialog-scrollable modal-lg">
+	<div class="modal-content">
+		<ng-template cdkPortalOutlet></ng-template>
+	</div>
+</div>

--- a/src/app/common/dialog/bs-dialog-container/bs-dialog-container.component.ts
+++ b/src/app/common/dialog/bs-dialog-container/bs-dialog-container.component.ts
@@ -1,0 +1,16 @@
+import { CdkDialogContainer, DialogConfig } from '@angular/cdk/dialog';
+import { PortalModule } from '@angular/cdk/portal';
+import { Component } from '@angular/core';
+
+/**
+ * Custom CDK Dialog Container to properly apply bootstrap modal styles
+ */
+@Component({
+	selector: 'bs-dialog-container',
+	standalone: true,
+	imports: [PortalModule],
+	templateUrl: './bs-dialog-container.component.html'
+})
+export class BsDialogContainerComponent<
+	C extends DialogConfig = DialogConfig
+> extends CdkDialogContainer<C> {}

--- a/src/app/common/dialog/configurable-dialog/configurable-dialog.component.html
+++ b/src/app/common/dialog/configurable-dialog/configurable-dialog.component.html
@@ -1,14 +1,14 @@
 <asy-modal
-	[title]="title"
-	[cancelText]="cancelText"
+	[title]="data.title"
+	[cancelText]="data.cancelText"
 	[disableOk]="!modalForm.form.valid"
-	[okText]="okText"
+	[okText]="data.okText"
 	(cancel)="cancel()"
 	(ok)="ok()"
 >
-	<p *ngIf="message" [innerHTML]="message"></p>
+	<p *ngIf="data.message" [innerHTML]="data.message"></p>
 	<form id="modalForm" #modalForm="ngForm">
-		<div class="form-group" *ngFor="let input of inputs; first as isFirst">
+		<div class="form-group" *ngFor="let input of data.inputs; first as isFirst">
 			<label [class.form-required]="input.required">{{ input.label }}</label>
 
 			<textarea

--- a/src/app/common/dialog/configurable-dialog/configurable-dialog.component.scss
+++ b/src/app/common/dialog/configurable-dialog/configurable-dialog.component.scss
@@ -1,0 +1,7 @@
+:host {
+  display: contents;
+}
+
+.text-area {
+  height: 4.5em;
+}

--- a/src/app/common/dialog/configurable-dialog/configurable-dialog.component.spec.ts
+++ b/src/app/common/dialog/configurable-dialog/configurable-dialog.component.spec.ts
@@ -1,0 +1,27 @@
+import { DIALOG_DATA, DialogModule, DialogRef } from '@angular/cdk/dialog';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfigurableDialogComponent } from './configurable-dialog.component';
+
+describe('ConfigurableDialogComponent', () => {
+	let component: ConfigurableDialogComponent;
+	let fixture: ComponentFixture<ConfigurableDialogComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [ConfigurableDialogComponent, DialogModule],
+			providers: [
+				{ provide: DIALOG_DATA, useValue: {} },
+				{ provide: DialogRef, useValue: {} }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(ConfigurableDialogComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/common/dialog/configurable-dialog/configurable-dialog.component.ts
+++ b/src/app/common/dialog/configurable-dialog/configurable-dialog.component.ts
@@ -1,0 +1,47 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { ModalComponent } from '../../modal/modal/modal.component';
+import { DialogAction, DialogReturn } from '../dialog.modal';
+
+export type DialogInput = {
+	type: 'textarea' | 'text';
+	label: string;
+	key: string;
+	required: boolean;
+};
+
+export class ConfigurableDialogData {
+	title: string;
+	okText: string;
+	cancelText?: string;
+	message: string;
+	inputs?: DialogInput[];
+}
+
+@Component({
+	standalone: true,
+	imports: [CommonModule, FormsModule, ReactiveFormsModule, ModalComponent],
+	templateUrl: './configurable-dialog.component.html',
+	styleUrls: ['./configurable-dialog.component.scss']
+})
+export class ConfigurableDialogComponent {
+	data: ConfigurableDialogData = inject(DIALOG_DATA);
+	dialogRef = inject(DialogRef);
+
+	formData: any = {};
+
+	cancel() {
+		this.dialogRef.close({ action: DialogAction.CANCEL });
+	}
+
+	ok() {
+		const event: DialogReturn<any> = { action: DialogAction.OK };
+		if (this.data.inputs) {
+			event.data = this.formData;
+		}
+		this.dialogRef.close(event);
+	}
+}

--- a/src/app/common/dialog/dialog.modal.ts
+++ b/src/app/common/dialog/dialog.modal.ts
@@ -1,0 +1,9 @@
+export enum DialogAction {
+	OK,
+	CANCEL
+}
+
+export class DialogReturn<T> {
+	action: DialogAction;
+	data?: T;
+}

--- a/src/app/common/dialog/dialog.service.ts
+++ b/src/app/common/dialog/dialog.service.ts
@@ -1,0 +1,91 @@
+import { Dialog, DialogConfig, DialogRef } from '@angular/cdk/dialog';
+import { ComponentType } from '@angular/cdk/overlay';
+import { Injectable, inject } from '@angular/core';
+
+import {
+	ConfigurableDialogComponent,
+	ConfigurableDialogData
+} from './configurable-dialog/configurable-dialog.component';
+import { DialogReturn } from './dialog.modal';
+
+@Injectable({
+	providedIn: 'root'
+})
+export class DialogService {
+	dialog = inject(Dialog);
+
+	alert(
+		title: string,
+		message: string,
+		okText = 'OK',
+		modalOptions?: DialogConfig
+	): DialogRef<DialogReturn<void>> {
+		return this.show(
+			{
+				title,
+				message,
+				okText
+			},
+			modalOptions
+		);
+	}
+
+	confirm(
+		title: string,
+		message: string,
+		okText = 'OK',
+		cancelText = 'Cancel',
+		modalOptions?: DialogConfig
+	): DialogRef<DialogReturn<void>> {
+		return this.show(
+			{
+				title,
+				message,
+				okText,
+				cancelText
+			},
+			modalOptions
+		);
+	}
+
+	prompt(
+		title: string,
+		message: string,
+		inputLabel: string,
+		okText = 'OK',
+		cancelText = 'Cancel',
+		modalOptions?: DialogConfig
+	): DialogRef<DialogReturn<{ prompt: string }>> {
+		return this.show(
+			{
+				title,
+				message,
+				okText,
+				cancelText,
+				inputs: [{ type: 'text', label: inputLabel, key: 'prompt', required: true }]
+			},
+			modalOptions
+		);
+	}
+
+	/**
+	 * The show method will display a modal that can include a message and a form
+	 */
+	show<R = unknown>(contentConfig: ConfigurableDialogData, modalOptions: DialogConfig = {}) {
+		const config = {
+			disableClose: true,
+			data: contentConfig,
+			...DialogConfig
+		};
+
+		return this.dialog.open<R>(ConfigurableDialogComponent, config);
+	}
+
+	// Pass through to Dialog.open.  This allows for standardizing on using DialogService everywhere.
+	open<R = unknown, D = unknown, C = unknown>(
+		component: ComponentType<C>,
+		config?: DialogConfig<D, DialogRef<R, C>>
+	): DialogRef<R, C> {
+		return this.dialog.open(component, config);
+	}
+}

--- a/src/app/common/dialog/index.ts
+++ b/src/app/common/dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './public-api';

--- a/src/app/common/dialog/provider.ts
+++ b/src/app/common/dialog/provider.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_DIALOG_CONFIG, DialogModule } from '@angular/cdk/dialog';
+import { importProvidersFrom, makeEnvironmentProviders } from '@angular/core';
+
+import { BsDialogContainerComponent } from './bs-dialog-container/bs-dialog-container.component';
+
+export function providerCdkDialog() {
+	return makeEnvironmentProviders([
+		importProvidersFrom(DialogModule),
+		{
+			provide: DEFAULT_DIALOG_CONFIG,
+			useValue: {
+				closeOnNavigation: true,
+				container: BsDialogContainerComponent,
+				panelClass: 'modal',
+				autoFocus: true,
+				hasBackdrop: true
+			}
+		}
+	]);
+}

--- a/src/app/common/dialog/public-api.ts
+++ b/src/app/common/dialog/public-api.ts
@@ -1,0 +1,4 @@
+export * from './dialog.modal';
+export * from './dialog.service';
+export * from './bs-dialog-container/bs-dialog-container.component';
+export * from './configurable-dialog/configurable-dialog.component';

--- a/src/app/common/modal/container-modal/container-modal.component.html
+++ b/src/app/common/modal/container-modal/container-modal.component.html
@@ -1,6 +1,5 @@
 <asy-modal
 	[title]="title"
-	[autoCaptureFocus]="isCdkFocusInitial"
 	[cancelText]="cancelText"
 	[disableOk]="isOkDisabled"
 	[okText]="okText"

--- a/src/app/common/modal/modal/modal.component.html
+++ b/src/app/common/modal/modal/modal.component.html
@@ -1,24 +1,22 @@
-<div cdkTrapFocus [cdkTrapFocusAutoCapture]="autoCaptureFocus">
-	<section class="modal-header">
-		<h2 class="modal-title">
-			{{ title }}
-		</h2>
+<section class="modal-header">
+	<h2 class="modal-title">
+		{{ title }}
+	</h2>
 
-		<button class="close" type="button" aria-label="Cancel" (click)="cancel.emit()">
-			<span class="fa-solid fa-remove" aria-hidden="true"></span>
-		</button>
-	</section>
+	<button class="close" type="button" aria-label="Cancel" (click)="cancel.emit()">
+		<span class="fa-solid fa-remove" aria-hidden="true"></span>
+	</button>
+</section>
 
-	<section class="modal-body">
-		<ng-content></ng-content>
-	</section>
+<section class="modal-body">
+	<ng-content></ng-content>
+</section>
 
-	<section class="modal-footer">
-		<button class="btn btn-outline-secondary mr-2" *ngIf="cancelText" (click)="cancel.emit()">
-			{{ cancelText }}
-		</button>
-		<button class="btn btn-primary" [disabled]="disableOk" (click)="ok.emit()">
-			{{ okText }}
-		</button>
-	</section>
-</div>
+<section class="modal-footer">
+	<button class="btn btn-outline-secondary mr-2" *ngIf="cancelText" (click)="cancel.emit()">
+		{{ cancelText }}
+	</button>
+	<button class="btn btn-primary" [disabled]="disableOk" (click)="ok.emit()">
+		{{ okText }}
+	</button>
+</section>

--- a/src/app/common/modal/modal/modal.component.scss
+++ b/src/app/common/modal/modal/modal.component.scss
@@ -1,4 +1,0 @@
-:host,
-div[cdkTrapFocus] {
-	display: contents;
-}

--- a/src/app/common/modal/modal/modal.component.ts
+++ b/src/app/common/modal/modal/modal.component.ts
@@ -27,13 +27,10 @@ export class ModalComponent {
 	 * Text to display on the modal 'cancel' button
 	 */
 	@Input()
-	cancelText = 'Cancel';
+	cancelText?: string = 'Cancel';
 
 	@Input()
 	disableOk = false;
-
-	@Input()
-	autoCaptureFocus = false;
 
 	@Output()
 	readonly ok = new EventEmitter<void>();

--- a/src/app/core/admin/cache-entries/cache-entry-modal.component.html
+++ b/src/app/core/admin/cache-entries/cache-entry-modal.component.html
@@ -2,19 +2,21 @@
 	title="Cache Entry Details"
 	cancelText=""
 	okText="Close"
-	(cancel)="modalRef.hide()"
-	(ok)="modalRef.hide()"
+	(cancel)="dialogRef.close()"
+	(ok)="dialogRef.close()"
 >
 	<div class="row">
 		<div class="col-md-12">
 			<label>Key</label>
-			<div>{{ cacheEntry.key }}</div>
+			<div>{{ data.cacheEntry.key }}</div>
 
 			<label>Last Updated</label>
-			<div>{{ cacheEntry.date | utcDate }} ({{ cacheEntry.date | agoDate: false }})</div>
+			<div>
+				{{ data.cacheEntry.date | utcDate }} ({{ data.cacheEntry.date | agoDate: false }})
+			</div>
 
 			<label>Value</label>
-			<pre>{{ cacheEntry.value | json }}</pre>
+			<pre>{{ data.cacheEntry.value | json }}</pre>
 		</div>
 	</div>
 </asy-modal>

--- a/src/app/core/admin/cache-entries/cache-entry-modal.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entry-modal.component.ts
@@ -1,13 +1,15 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { JsonPipe } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
-
-import { BsModalRef } from 'ngx-bootstrap/modal';
+import { Component, OnInit, inject } from '@angular/core';
 
 import { ModalComponent } from '../../../common/modal/modal/modal.component';
 import { AgoDatePipe } from '../../../common/pipes/ago-date.pipe';
 import { UtcDatePipe } from '../../../common/pipes/utc-date-pipe/utc-date.pipe';
 import { CacheEntry } from './cache-entry.model';
 
+export class CacheEntryModalData {
+	cacheEntry: CacheEntry;
+}
 @Component({
 	templateUrl: 'cache-entry-modal.component.html',
 	styles: [
@@ -21,13 +23,11 @@ import { CacheEntry } from './cache-entry.model';
 	imports: [ModalComponent, JsonPipe, AgoDatePipe, UtcDatePipe]
 })
 export class CacheEntryModalComponent implements OnInit {
-	@Input()
-	cacheEntry!: CacheEntry;
-
-	constructor(public modalRef: BsModalRef) {}
+	data: CacheEntryModalData = inject(DIALOG_DATA);
+	dialogRef = inject(DialogRef);
 
 	ngOnInit() {
-		if (!this.cacheEntry) {
+		if (!this.data.cacheEntry) {
 			throw new TypeError(`'CacheEntry' is required`);
 		}
 	}

--- a/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.spec.ts
+++ b/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.spec.ts
@@ -1,9 +1,10 @@
+import { DIALOG_DATA, DialogModule } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 
 import { of } from 'rxjs';
 
-import { ModalService } from '../../../../common/modal/modal.service';
+import { DialogService } from '../../../../common/dialog';
 import { SystemAlertService } from '../../../../common/system-alert/system-alert.service';
 import { EuaService } from '../eua.service';
 import { AdminListEuasComponent } from './admin-list-euas.component';
@@ -11,7 +12,7 @@ import { AdminListEuasComponent } from './admin-list-euas.component';
 describe('Admin List End User Agreements Component', () => {
 	let activatedRoute: any;
 	let endUserAgreementServiceSpy: any;
-	let modalServiceSpy: any;
+	let dialogServiceSpy: any;
 
 	let fixture: ComponentFixture<AdminListEuasComponent>;
 	let component: AdminListEuasComponent;
@@ -26,16 +27,17 @@ describe('Admin List End User Agreements Component', () => {
 			return of(void 0);
 		});
 		endUserAgreementServiceSpy.cache = {};
-		modalServiceSpy = jasmine.createSpyObj('ModalService', ['alert']);
-		modalServiceSpy.alert.and.callFake(() => {
+		dialogServiceSpy = jasmine.createSpyObj('DialogService', ['alert']);
+		dialogServiceSpy.alert.and.callFake(() => {
 			return of(void 0);
 		});
 		const testBed = TestBed.configureTestingModule({
-			imports: [AdminListEuasComponent],
+			imports: [AdminListEuasComponent, DialogModule],
 			providers: [
 				{ provide: ActivatedRoute, useValue: activatedRoute },
 				{ provide: EuaService, useValue: endUserAgreementServiceSpy },
-				{ provide: ModalService, useValue: modalServiceSpy },
+				{ provide: DialogService, useValue: dialogServiceSpy },
+				{ provide: DIALOG_DATA, useValue: {} },
 				SystemAlertService
 			]
 		});
@@ -50,8 +52,8 @@ describe('Admin List End User Agreements Component', () => {
 
 	it('Should Open a Modal When Preview End User Agreement', () => {
 		fixture.detectChanges();
-		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(0);
+		expect(dialogServiceSpy.alert).toHaveBeenCalledTimes(0);
 		component.previewEndUserAgreement({});
-		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(1);
+		expect(dialogServiceSpy.alert).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.ts
@@ -1,5 +1,5 @@
 import { CdkTableModule } from '@angular/cdk/table';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -8,9 +8,8 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable } from 'rxjs';
 import { filter, first, switchMap } from 'rxjs/operators';
 
+import { DialogAction, DialogService } from '../../../../common/dialog';
 import { SkipToDirective } from '../../../../common/directives/skip-to.directive';
-import { ModalAction } from '../../../../common/modal/modal.model';
-import { ModalService } from '../../../../common/modal/modal.service';
 import { PagingOptions, PagingResults } from '../../../../common/paging.model';
 import { UtcDatePipe } from '../../../../common/pipes/utc-date-pipe/utc-date.pipe';
 import { SearchInputComponent } from '../../../../common/search-input/search-input.component';
@@ -95,8 +94,9 @@ export class AdminListEuasComponent implements OnDestroy, OnInit {
 		}
 	);
 
+	private dialogService = inject(DialogService);
+
 	constructor(
-		private modalService: ModalService,
 		private euaService: EuaService,
 		private route: ActivatedRoute,
 		private alertService: SystemAlertService
@@ -120,15 +120,15 @@ export class AdminListEuasComponent implements OnDestroy, OnInit {
 	}
 
 	confirmDeleteEua(eua: EndUserAgreement) {
-		this.modalService
+		this.dialogService
 			.confirm(
 				'Delete End User Agreement?',
 				`Are you sure you want to delete eua: "${eua.title}" ?`,
 				'Delete'
 			)
-			.pipe(
+			.closed.pipe(
 				first(),
-				filter((action) => action === ModalAction.OK),
+				filter((result) => result?.action === DialogAction.OK),
 				switchMap(() => this.euaService.delete(eua)),
 				untilDestroyed(this)
 			)
@@ -163,6 +163,6 @@ export class AdminListEuasComponent implements OnDestroy, OnInit {
 	 */
 	previewEndUserAgreement(endUserAgreement: any) {
 		const { text, title } = endUserAgreement;
-		this.modalService.alert(title, text);
+		this.dialogService.alert(title, text);
 	}
 }

--- a/src/app/core/admin/end-user-agreement/manage-eua.component.ts
+++ b/src/app/core/admin/end-user-agreement/manage-eua.component.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { ModalService } from '../../../common/modal/modal.service';
+import { DialogService } from '../../../common/dialog';
 import { EndUserAgreement } from './eua.model';
 
 export abstract class ManageEuaComponent {
@@ -9,7 +9,7 @@ export abstract class ManageEuaComponent {
 	eua = new EndUserAgreement();
 
 	protected router = inject(Router);
-	protected modalService = inject(ModalService);
+	protected dialogService = inject(DialogService);
 
 	protected constructor(
 		public title: string,
@@ -20,6 +20,6 @@ export abstract class ManageEuaComponent {
 	abstract submitEua(): any;
 
 	previewEua() {
-		this.modalService.alert(this.eua.title, this.eua.text);
+		this.dialogService.alert(this.eua.title, this.eua.text);
 	}
 }

--- a/src/app/core/admin/messages/create-message.component.spec.ts
+++ b/src/app/core/admin/messages/create-message.component.spec.ts
@@ -1,9 +1,10 @@
+import { DialogModule } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { of } from 'rxjs';
 
-import { ModalService } from '../../../common/modal/modal.service';
+import { DialogService } from '../../../common/dialog';
 import { SystemAlertService } from '../../../common/system-alert/system-alert.service';
 import { ConfigService } from '../../config.service';
 import { Message, MessageType } from '../../messages/message.model';
@@ -13,7 +14,7 @@ import { CreateMessageComponent } from './create-message.component';
 describe('Create Message Component', () => {
 	let configServiceSpy: any;
 	let messageServiceSpy: any;
-	let modalServiceSpy: any;
+	let dialogServiceSpy: any;
 
 	let fixture: ComponentFixture<CreateMessageComponent>;
 	let rootHTMLElement: HTMLElement;
@@ -39,16 +40,16 @@ describe('Create Message Component', () => {
 		messageServiceSpy.create.and.callFake(() => {
 			return of(message);
 		});
-		modalServiceSpy = jasmine.createSpyObj('ModalService', ['alert']);
-		modalServiceSpy.alert.and.callFake(() => {
+		dialogServiceSpy = jasmine.createSpyObj('DialogService', ['alert']);
+		dialogServiceSpy.alert.and.callFake(() => {
 			return of();
 		});
 		const testBed = TestBed.configureTestingModule({
-			imports: [RouterTestingModule, CreateMessageComponent],
+			imports: [RouterTestingModule, CreateMessageComponent, DialogModule],
 			providers: [
 				{ provide: ConfigService, useValue: configServiceSpy },
 				{ provide: MessageService, useValue: messageServiceSpy },
-				{ provide: ModalService, useValue: modalServiceSpy },
+				{ provide: DialogService, useValue: dialogServiceSpy },
 				SystemAlertService
 			]
 		});
@@ -76,8 +77,8 @@ describe('Create Message Component', () => {
 
 	it('Should Open a Modal When Preview Message', () => {
 		fixture.detectChanges();
-		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(0);
+		expect(dialogServiceSpy.alert).toHaveBeenCalledTimes(0);
 		component.previewMessage();
-		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(1);
+		expect(dialogServiceSpy.alert).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/app/core/admin/messages/edit-message.component.spec.ts
+++ b/src/app/core/admin/messages/edit-message.component.spec.ts
@@ -3,7 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of } from 'rxjs';
 
-import { ModalService } from '../../../common/modal/modal.service';
+import { DialogService } from '../../../common/dialog';
 import { SystemAlertService } from '../../../common/system-alert/system-alert.service';
 import { ConfigService } from '../../config.service';
 import { Message, MessageType } from '../../messages/message.model';
@@ -13,7 +13,7 @@ import { UpdateMessageComponent } from './edit-message.component';
 describe('Update Message Component', () => {
 	let configServiceSpy: any;
 	let messageServiceSpy: any;
-	let modalServiceSpy: any;
+	let dialogServiceSpy: any;
 
 	let fixture: ComponentFixture<UpdateMessageComponent>;
 	let rootHTMLElement: HTMLElement;
@@ -42,8 +42,8 @@ describe('Update Message Component', () => {
 		messageServiceSpy.get.and.callFake(() => {
 			return of(message);
 		});
-		modalServiceSpy = jasmine.createSpyObj('ModalService', ['alert']);
-		modalServiceSpy.alert.and.callFake(() => {
+		dialogServiceSpy = jasmine.createSpyObj('DialogService', ['alert']);
+		dialogServiceSpy.alert.and.callFake(() => {
 			return of();
 		});
 		const testBed = TestBed.configureTestingModule({
@@ -51,7 +51,7 @@ describe('Update Message Component', () => {
 			providers: [
 				{ provide: ConfigService, useValue: configServiceSpy },
 				{ provide: MessageService, useValue: messageServiceSpy },
-				{ provide: ModalService, useValue: modalServiceSpy },
+				{ provide: DialogService, useValue: dialogServiceSpy },
 				SystemAlertService
 			]
 		});
@@ -79,8 +79,8 @@ describe('Update Message Component', () => {
 
 	it('Should Open a Modal When Preview Message', () => {
 		fixture.detectChanges();
-		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(0);
+		expect(dialogServiceSpy.alert).toHaveBeenCalledTimes(0);
 		component.previewMessage();
-		expect(modalServiceSpy.alert).toHaveBeenCalledTimes(1);
+		expect(dialogServiceSpy.alert).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/app/core/admin/messages/list-messages/list-messages.component.ts
+++ b/src/app/core/admin/messages/list-messages/list-messages.component.ts
@@ -1,5 +1,5 @@
 import { CdkTableModule } from '@angular/cdk/table';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -7,9 +7,8 @@ import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { Observable } from 'rxjs';
 import { filter, first, switchMap } from 'rxjs/operators';
 
+import { DialogAction, DialogService } from '../../../../common/dialog';
 import { SkipToDirective } from '../../../../common/directives/skip-to.directive';
-import { ModalAction } from '../../../../common/modal/modal.model';
-import { ModalService } from '../../../../common/modal/modal.service';
 import { PagingOptions, PagingResults } from '../../../../common/paging.model';
 import { UtcDatePipe } from '../../../../common/pipes/utc-date-pipe/utc-date.pipe';
 import { SearchInputComponent } from '../../../../common/search-input/search-input.component';
@@ -57,10 +56,11 @@ export class ListMessagesComponent implements OnDestroy, OnInit {
 		}
 	);
 
+	private dialogService = inject(DialogService);
+
 	constructor(
 		private messageService: MessageService,
-		public alertService: SystemAlertService,
-		private modalService: ModalService
+		public alertService: SystemAlertService
 	) {}
 
 	ngOnInit() {
@@ -84,15 +84,15 @@ export class ListMessagesComponent implements OnDestroy, OnInit {
 	}
 
 	confirmDeleteMessage(message: Message) {
-		this.modalService
+		this.dialogService
 			.confirm(
 				'Delete message?',
 				`Are you sure you want to delete message: "${message.title}" ?`,
 				'Delete'
 			)
-			.pipe(
+			.closed.pipe(
 				first(),
-				filter((action) => action === ModalAction.OK),
+				filter((result) => result?.action === DialogAction.OK),
 				switchMap(() => this.messageService.delete(message)),
 				untilDestroyed(this)
 			)
@@ -109,6 +109,6 @@ export class ListMessagesComponent implements OnDestroy, OnInit {
 	 */
 	previewMessage(message: Message) {
 		const { body, title } = message;
-		this.modalService.alert(title, body);
+		this.dialogService.alert(title, body);
 	}
 }

--- a/src/app/core/admin/messages/manage-message.component.ts
+++ b/src/app/core/admin/messages/manage-message.component.ts
@@ -5,7 +5,7 @@ import { untilDestroyed } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
-import { ModalService } from '../../../common/modal/modal.service';
+import { DialogService } from '../../../common/dialog';
 import { SystemAlertService } from '../../../common/system-alert/system-alert.service';
 import { ConfigService } from '../../config.service';
 import { Message } from '../../messages/message.model';
@@ -24,7 +24,7 @@ export abstract class ManageMessageComponent implements OnInit {
 
 	protected config: any;
 
-	protected modalService = inject(ModalService);
+	protected dialogService = inject(DialogService);
 	protected router = inject(Router);
 	protected configService = inject(ConfigService);
 	protected alertService = inject(SystemAlertService);
@@ -54,7 +54,7 @@ export abstract class ManageMessageComponent implements OnInit {
 
 	previewMessage() {
 		const { body, title } = this.message;
-		this.modalService.alert(title, body);
+		this.dialogService.alert(title, body);
 	}
 
 	submit() {

--- a/src/app/core/admin/user-management/list-users/admin-list-users.component.spec.ts
+++ b/src/app/core/admin/user-management/list-users/admin-list-users.component.spec.ts
@@ -1,8 +1,8 @@
+import { DialogModule } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { ModalModule } from 'ngx-bootstrap/modal';
 import { of } from 'rxjs';
 
 import { ModalService } from '../../../../common/modal/modal.service';
@@ -62,7 +62,7 @@ describe('Admin List Users Component Spec', () => {
 			imports: [
 				RouterTestingModule,
 				BrowserAnimationsModule,
-				ModalModule.forRoot(),
+				DialogModule,
 				AdminListUsersComponent
 			],
 			providers: [

--- a/src/app/core/audit/audit-view-change-modal/audit-view-change-modal.component.html
+++ b/src/app/core/audit/audit-view-change-modal/audit-view-change-modal.component.html
@@ -1,20 +1,20 @@
 <asy-modal
-	title="Changes to {{ auditEntry?.audit?.auditType }} by {{
-		auditEntry?.audit?.actor?.username
-	}} on {{ auditEntry?.created | utcDate }}"
+	title="Changes to {{ data.auditEntry?.audit?.auditType }} by {{
+		data.auditEntry?.audit?.actor?.username
+	}} on {{ data.auditEntry?.created | utcDate }}"
 	cancelText=""
 	okText="Close"
-	(cancel)="modalRef.hide()"
-	(ok)="modalRef.hide()"
+	(cancel)="dialogRef.close()"
+	(ok)="dialogRef.close()"
 >
 	<div class="row">
 		<div class="col-md-6">
 			<h4>Before</h4>
-			<pre>{{ auditEntry?.audit?.object?.before | sortObjectKeys | json }}</pre>
+			<pre>{{ data.auditEntry?.audit?.object?.before | sortObjectKeys | json }}</pre>
 		</div>
 		<div class="col-md-6">
 			<h4>After</h4>
-			<pre>{{ auditEntry?.audit?.object?.after | sortObjectKeys | json }}</pre>
+			<pre>{{ data.auditEntry?.audit?.object?.after | sortObjectKeys | json }}</pre>
 		</div>
 	</div>
 </asy-modal>

--- a/src/app/core/audit/audit-view-details-modal/audit-view-details-modal.component.html
+++ b/src/app/core/audit/audit-view-details-modal/audit-view-details-modal.component.html
@@ -1,16 +1,18 @@
 <asy-modal
-	title="{{ auditEntry?.audit?.auditType | titlecase }} {{
-		auditEntry?.audit?.action + 'd'
-	}} by {{ auditEntry?.audit?.actor?.username }} on {{ auditEntry?.created | utcDate }}"
+	title="{{ data.auditEntry?.audit?.auditType | titlecase }} {{
+		data.auditEntry?.audit?.action + 'd'
+	}} by {{ data.auditEntry?.audit?.actor?.username }} on {{ data.auditEntry?.created | utcDate }}"
 	cancelText=""
 	okText="Close"
-	(cancel)="modalRef.hide()"
-	(ok)="modalRef.hide()"
+	(cancel)="dialogRef.close()"
+	(ok)="dialogRef.close()"
 >
 	<div class="row">
 		<div class="col-md-12">
-			<h4 *ngIf="auditEntry?.audit?.object?.title">{{ auditEntry?.audit?.object?.title }}</h4>
-			<pre>{{ auditEntry?.audit?.object | json }}</pre>
+			<h4 *ngIf="data.auditEntry?.audit?.object?.title">
+				{{ data.auditEntry?.audit?.object?.title }}
+			</h4>
+			<pre>{{ data.auditEntry?.audit?.object | json }}</pre>
 		</div>
 	</div>
 </asy-modal>

--- a/src/app/core/audit/audit-view-details-modal/audit-view-details-modal.component.ts
+++ b/src/app/core/audit/audit-view-details-modal/audit-view-details-modal.component.ts
@@ -1,7 +1,6 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { JsonPipe, NgIf, TitleCasePipe } from '@angular/common';
-import { Component } from '@angular/core';
-
-import { BsModalRef } from 'ngx-bootstrap/modal';
+import { Component, inject } from '@angular/core';
 
 import { ModalComponent } from '../../../common/modal/modal/modal.component';
 import { UtcDatePipe } from '../../../common/pipes/utc-date-pipe/utc-date.pipe';
@@ -19,7 +18,6 @@ import { UtcDatePipe } from '../../../common/pipes/utc-date-pipe/utc-date.pipe';
 	imports: [ModalComponent, NgIf, JsonPipe, TitleCasePipe, UtcDatePipe]
 })
 export class AuditViewDetailsModalComponent {
-	auditEntry: any;
-
-	constructor(public modalRef: BsModalRef) {}
+	dialogRef = inject(DialogRef);
+	data = inject(DIALOG_DATA);
 }

--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.spec.ts
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.spec.ts
@@ -1,8 +1,8 @@
+import { DialogModule } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { ModalModule } from 'ngx-bootstrap/modal';
 import { of } from 'rxjs';
 
 import { PagingResults } from '../../../common/paging.model';
@@ -103,8 +103,8 @@ describe('Audit Component Spec', () => {
 
 		TestBed.configureTestingModule({
 			imports: [
-				ModalModule.forRoot(),
 				BrowserAnimationsModule,
+				DialogModule,
 				ListAuditEntriesComponent,
 				AuditObjectComponent,
 				UrlAuditObjectComponent,

--- a/src/app/core/feedback/feedback-modal/feedback-modal.component.html
+++ b/src/app/core/feedback/feedback-modal/feedback-modal.component.html
@@ -1,9 +1,8 @@
 <asy-modal
 	title="Give Feedback"
 	okText="Submit"
-	[autoCaptureFocus]="true"
 	[disableOk]="submitting || !submitFeedbackForm.form.valid"
-	(cancel)="modalRef.hide()"
+	(cancel)="dialogRef.close()"
 	(ok)="submit()"
 >
 	<form #submitFeedbackForm="ngForm">

--- a/src/app/core/feedback/feedback-modal/feedback-modal.component.ts
+++ b/src/app/core/feedback/feedback-modal/feedback-modal.component.ts
@@ -1,12 +1,12 @@
+import { DialogRef } from '@angular/cdk/dialog';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 
 import { NgSelectModule } from '@ng-select/ng-select';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import isEmpty from 'lodash/isEmpty';
-import { BsModalRef } from 'ngx-bootstrap/modal';
 import { first } from 'rxjs/operators';
 
 import { ModalComponent } from '../../../common/modal/modal/modal.component';
@@ -32,11 +32,12 @@ export class FeedbackModalComponent implements OnInit {
 
 	feedback: Feedback = new Feedback();
 
+	public dialogRef = inject(DialogRef);
+
 	constructor(
 		private router: Router,
 		private configService: ConfigService,
-		private feedbackService: FeedbackService,
-		public modalRef: BsModalRef
+		private feedbackService: FeedbackService
 	) {}
 
 	ngOnInit() {
@@ -67,7 +68,7 @@ export class FeedbackModalComponent implements OnInit {
 			.pipe(untilDestroyed(this))
 			.subscribe((feedback) => {
 				if (feedback) {
-					setTimeout(() => this.modalRef.hide(), 1500);
+					setTimeout(() => this.dialogRef.close(), 1500);
 				}
 			});
 	}

--- a/src/app/core/site-navbar/_shared.scss
+++ b/src/app/core/site-navbar/_shared.scss
@@ -29,7 +29,7 @@ $nav-element-logo-hover-color-bg: $ux-color-primary-medium !default;
 $nav-element-logo-img-margin: 4px !default;
 $nav-element-logo-img-height: 50px !default;
 
-$nav-z-index: 10000 !default;
+$nav-z-index: 1000 !default;
 $nav-popover-z-index: $nav-z-index + 1 !default;
 
 $nav-popover-width: 192px !default;

--- a/src/app/core/site-navbar/site-navbar.component.spec.ts
+++ b/src/app/core/site-navbar/site-navbar.component.spec.ts
@@ -1,9 +1,9 @@
+import { DialogModule } from '@angular/cdk/dialog';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { ModalModule } from 'ngx-bootstrap/modal';
 import { PopoverDirective } from 'ngx-bootstrap/popover';
 import { of } from 'rxjs';
 
@@ -77,7 +77,7 @@ describe('Site Navbar Component Spec', () => {
 
 		TestBed.configureTestingModule({
 			declarations: [PopoverDirective],
-			imports: [HttpClientTestingModule, ModalModule.forRoot(), RouterTestingModule],
+			imports: [HttpClientTestingModule, RouterTestingModule, DialogModule],
 			providers: [
 				{ provide: AuthorizationService, useValue: authorizationServiceSpy },
 				{ provide: ConfigService, useValue: configServiceSpy },

--- a/src/app/core/site-navbar/site-navbar.component.ts
+++ b/src/app/core/site-navbar/site-navbar.component.ts
@@ -1,13 +1,13 @@
 import { NgClass, NgFor, NgIf } from '@angular/common';
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsModalService } from 'ngx-bootstrap/modal';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { first } from 'rxjs/operators';
 
+import { DialogService } from '../../common/dialog';
 import { LinkAccessibilityDirective } from '../../common/directives/link-accessibility.directive';
 import { getAdminTopics } from '../admin/admin-topic.model';
 import { HasRoleDirective } from '../auth/directives/has-role.directive';
@@ -88,8 +88,9 @@ export class SiteNavbarComponent implements OnInit {
 		}
 	}
 
+	private dialogService = inject(DialogService);
+
 	constructor(
-		private modalService: BsModalService,
 		private configService: ConfigService,
 		private sessionService: SessionService,
 		private messageService: MessageService,
@@ -129,9 +130,6 @@ export class SiteNavbarComponent implements OnInit {
 	}
 
 	showFeedbackModal() {
-		this.modalService.show(FeedbackModalComponent, {
-			ignoreBackdropClick: true,
-			class: 'modal-dialog-scrollable modal-lg'
-		});
+		this.dialogService.open(FeedbackModalComponent);
 	}
 }

--- a/src/app/core/teams/add-members-modal/add-members-modal.component.html
+++ b/src/app/core/teams/add-members-modal/add-members-modal.component.html
@@ -1,9 +1,8 @@
 <asy-modal
 	title="Add Team Members"
 	okText="Add Users"
-	[autoCaptureFocus]="true"
 	[disableOk]="submitting || addedMembers.length === 0"
-	(cancel)="modalRef.hide()"
+	(cancel)="dialogRef.close()"
 	(ok)="submit()"
 >
 	<h3>Add users</h3>
@@ -17,7 +16,6 @@
 			#selectDropdown
 			[items]="(users$ | async) || []"
 			[loading]="usersLoading"
-			[tabIndex]="-1"
 			[typeahead]="usersInput$"
 			(change)="typeaheadOnSelect($event, selectDropdown)"
 		>
@@ -43,7 +41,7 @@
 						{{ invited.username }}
 					</td>
 					<td>
-						<div class="dropdown dropdown-table-inline" dropdown>
+						<div class="dropdown dropdown-table-inline" container="body" dropdown>
 							<span class="dropdown-toggle" dropdownToggle>
 								<span class="mr-1">{{ invited.roleDisplay }}</span>
 							</span>

--- a/src/app/core/teams/view-team/view-team.component.ts
+++ b/src/app/core/teams/view-team/view-team.component.ts
@@ -1,5 +1,5 @@
 import { NgFor, NgIf } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import {
 	ActivatedRoute,
 	Router,
@@ -11,8 +11,7 @@ import {
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { filter, first, map, switchMap } from 'rxjs/operators';
 
-import { ModalAction } from '../../../common/modal/modal.model';
-import { ModalService } from '../../../common/modal/modal.service';
+import { DialogAction, DialogService } from '../../../common/dialog';
 import { SystemAlertComponent } from '../../../common/system-alert/system-alert.component';
 import { SystemAlertService } from '../../../common/system-alert/system-alert.service';
 import { SessionService } from '../../auth/session.service';
@@ -41,10 +40,11 @@ export class ViewTeamComponent implements OnInit {
 	topics = getTeamTopics();
 	team?: Team;
 
+	private dialogService = inject(DialogService);
+
 	constructor(
 		private router: Router,
 		private route: ActivatedRoute,
-		private modalService: ModalService,
 		private teamsService: TeamsService,
 		private alertService: SystemAlertService,
 		private sessionService: SessionService
@@ -70,15 +70,15 @@ export class ViewTeamComponent implements OnInit {
 	}
 
 	remove(team: Team) {
-		this.modalService
+		this.dialogService
 			.confirm(
 				'Delete team?',
 				`Are you sure you want to delete the team: <strong>"${team.name}"</strong>?<br/>This action cannot be undone.`,
 				'Delete'
 			)
-			.pipe(
+			.closed.pipe(
 				first(),
-				filter((action) => action === ModalAction.OK),
+				filter((result) => result?.action === DialogAction.OK),
 				switchMap(() => this.teamsService.delete(team)),
 				switchMap(() => this.sessionService.reloadSession()),
 				untilDestroyed(this)

--- a/src/app/site/example/modal/modal.component.html
+++ b/src/app/site/example/modal/modal.component.html
@@ -1,6 +1,36 @@
 <form style="max-width: 800px">
 	<h1 class="pb-3">Common Modal Module Examples</h1>
 
+	<div class="form-group">
+		<label class="form-required">Modal creation type:</label>
+		<div class="form-check">
+			<input
+				class="form-check-input"
+				id="type-option-cdk"
+				name="type-option-radio"
+				type="radio"
+				value="cdk"
+				required
+				[(ngModel)]="modalType"
+			/>
+			<label class="form-check-label mb-2" for="type-option-cdk">CDK Dialog</label>
+		</div>
+		<div class="form-check">
+			<input
+				class="form-check-input"
+				id="type-option-ngx"
+				name="type-option-radio"
+				type="radio"
+				value="ngx"
+				required
+				[(ngModel)]="modalType"
+			/>
+			<label class="form-check-label mb-2" for="type-option-ngx"
+				>NGX-Bootstrap Modal (deprecated)</label
+			>
+		</div>
+	</div>
+
 	<h2>Alert</h2>
 	<div class="row">
 		<div class="form-group col-6">
@@ -11,6 +41,7 @@
 				name="alertTitle"
 				type="text"
 				placeholder="Enter title..."
+				required
 				[(ngModel)]="alertConfig.title"
 			/>
 		</div>
@@ -33,11 +64,13 @@
 				name="alertMessage"
 				type="text"
 				placeholder="Enter message..."
+				required
 				[(ngModel)]="alertConfig.message"
 			/>
 		</div>
 	</div>
 	<button class="mr-3 btn btn-primary" type="button" (click)="showAlert()">Show Alert</button>
+	Output: {{ alertOutput$ | async | json }}
 
 	<h2 class="pt-5">Confirm</h2>
 	<div class="row">
@@ -49,11 +82,12 @@
 				name="confirmTitle"
 				type="text"
 				placeholder="Enter title..."
+				required
 				[(ngModel)]="confirmConfig.title"
 			/>
 		</div>
 		<div class="form-group col-4">
-			<label class="form-required" for="confirmOK">OK Text</label>
+			<label for="confirmOK">OK Text</label>
 			<input
 				class="form-control"
 				id="confirmOK"
@@ -64,7 +98,7 @@
 			/>
 		</div>
 		<div class="form-group col-4">
-			<label class="form-required" for="confirmCancel">Cancel Text</label>
+			<label for="confirmCancel">Cancel Text</label>
 			<input
 				class="form-control"
 				id="confirmCancel"
@@ -82,11 +116,13 @@
 				name="confirmMessage"
 				type="text"
 				placeholder="Enter message..."
+				required
 				[(ngModel)]="confirmConfig.message"
 			/>
 		</div>
 	</div>
 	<button class="mr-3 btn btn-primary" type="button" (click)="showConfirm()">Show Confirm</button>
+	Output: {{ confirmOutput$ | async | json }}
 
 	<h2 class="pt-5">Prompt</h2>
 	<div class="row">
@@ -98,6 +134,7 @@
 				name="promptTitle"
 				type="text"
 				placeholder="Enter title..."
+				required
 				[(ngModel)]="promptConfig.title"
 			/>
 		</div>
@@ -109,11 +146,12 @@
 				name="promptLabel"
 				type="text"
 				placeholder="Enter input label..."
+				required
 				[(ngModel)]="promptConfig.inputLabel"
 			/>
 		</div>
 		<div class="form-group col-6">
-			<label class="form-required" for="promptOK">OK Text</label>
+			<label for="promptOK">OK Text</label>
 			<input
 				class="form-control"
 				id="promptOK"
@@ -124,7 +162,7 @@
 			/>
 		</div>
 		<div class="form-group col-6">
-			<label class="form-required" for="promptCancel">Cancel Text</label>
+			<label for="promptCancel">Cancel Text</label>
 			<input
 				class="form-control"
 				id="promptCancel"
@@ -142,11 +180,13 @@
 				name="promptMessage"
 				type="text"
 				placeholder="Enter message..."
+				required
 				[(ngModel)]="promptConfig.message"
 			/>
 		</div>
 	</div>
 	<button class="mr-3 btn btn-primary" type="button" (click)="showPrompt()">Show Prompt</button>
+	Output: {{ promptOutput$ | async | json }}
 
 	<h2 class="pt-5">Show</h2>
 	<div class="row">
@@ -158,11 +198,12 @@
 				name="showTitle"
 				type="text"
 				placeholder="Enter title..."
+				required
 				[(ngModel)]="showConfig.title"
 			/>
 		</div>
 		<div class="form-group col-6">
-			<label class="form-required" for="showOK">OK Text</label>
+			<label for="showOK">OK Text</label>
 			<input
 				class="form-control"
 				id="showOK"
@@ -173,7 +214,7 @@
 			/>
 		</div>
 		<div class="form-group col-6">
-			<label class="form-required" for="showCancel">Cancel Text</label>
+			<label for="showCancel">Cancel Text</label>
 			<input
 				class="form-control"
 				id="showCancel"
@@ -191,6 +232,7 @@
 				name="showMessage"
 				type="text"
 				placeholder="Enter message..."
+				required
 				[(ngModel)]="showConfig.message"
 			/>
 		</div>
@@ -202,12 +244,14 @@
 				name="showInput"
 				type="text"
 				placeholder="Enter input config..."
+				required
 				style="height: 6.5rem"
 				[(ngModel)]="showInputConfig"
 			></textarea>
 		</div>
 	</div>
 	<button class="mr-3 btn btn-primary" type="button" (click)="showModal()">Show Modal</button>
+	Output: {{ showOutput$ | async | json }}
 
 	<h2 class="pt-5">Show Modal with Component</h2>
 	<button class="mr-3 btn btn-primary" type="button" (click)="showComponentModal()">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,6 +8,9 @@
 // Import the main ngx-bootstrap style file
 @import 'styles/ngx-bootstrap';
 
+// Import the main cdk style file
+@import "styles/cdk";
+
 // Import the main ng-select style file
 @import 'styles/ng-select';
 

--- a/src/styles/_cdk.scss
+++ b/src/styles/_cdk.scss
@@ -1,0 +1,6 @@
+@import '@angular/cdk/overlay-prebuilt.css';
+
+// CDK Dialog
+.cdk-overlay-pane.modal {
+  display: block;
+}


### PR DESCRIPTION
* Initial steps towards migrating away from the ngx-bootstrap library in favor of using cdk.  Cdk components have better a11y support and are style agnostic.  We can still apply bootstrap styles to them, but gives us the options to move away from bootstrap in the future.
* Still using bootstrap styling for visual consistency.
* Replaced all modal usages in starter with dialog.
* Existing ngx-bootstrap modal components/services still available to ease migrations.  Will remove in the future.