### PR TITLE
refactor: Replace ngx-bootstrap dropdown w/ cdk menu and overlay

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,14 +4,9 @@ import { ApplicationConfig } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { TitleStrategy, provideRouter, withHashLocation } from '@angular/router';
 
-import { AlertModule } from 'ngx-bootstrap/alert';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { ModalModule } from 'ngx-bootstrap/modal';
 import { PopoverModule } from 'ngx-bootstrap/popover';
-import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 
 import { providerCdkDialog } from './common/dialog/provider';
 import { authInterceptor } from './core/auth/auth.interceptor';
@@ -25,14 +20,14 @@ import { provideExampleRoutes } from './site/example/provider';
 export const appConfig: ApplicationConfig = {
 	providers: [
 		importProvidersFrom(
-			AlertModule.forRoot(),
 			BsDatepickerModule.forRoot(),
-			BsDropdownModule.forRoot(),
-			ModalModule.forRoot(),
 			PopoverModule.forRoot(),
-			TabsModule.forRoot(),
-			TooltipModule.forRoot(),
-			TypeaheadModule.forRoot()
+			TooltipModule.forRoot()
+			// ngx-bootstrap modules - If still using uncomment imports below.
+			// AlertModule.forRoot(),
+			// BsDropdownModule.forRoot(),
+			// ModalModule.forRoot(),
+			// TypeaheadModule.forRoot()
 		),
 		provideAnimations(),
 		provideHttpClient(

--- a/src/app/common/cdk-menu-item-router-link.directive.ts
+++ b/src/app/common/cdk-menu-item-router-link.directive.ts
@@ -1,0 +1,20 @@
+import { CdkMenuItem } from '@angular/cdk/menu';
+import { Directive, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+/**
+ * Work around for bug where CdkMenuItems w/ RouterLink don't trigger properly when using keyboard navigation.
+ */
+@Directive({
+	selector: '[cdkMenuItem][routerLink]',
+	standalone: true
+})
+export class CdkMenuItemRouterLinkDirective {
+	menuItem = inject(CdkMenuItem);
+	routerLink = inject(RouterLink);
+	constructor() {
+		this.menuItem.triggered.subscribe(() => {
+			this.routerLink.onClick(0, false, false, false, false);
+		});
+	}
+}

--- a/src/app/common/search-input/search-input.component.spec.ts
+++ b/src/app/common/search-input/search-input.component.spec.ts
@@ -41,6 +41,7 @@ describe('SearchInputComponent', () => {
 	}));
 
 	it('should not apply the search if keyup is never triggered', fakeAsync(() => {
+		componentInstance.preferInputEvent = false;
 		inputElement.nativeElement.value = 'search value';
 		fixture.detectChanges();
 		// need to trigger input event here so ngModel will set `search` property correctly

--- a/src/app/common/search-input/search-input.component.ts
+++ b/src/app/common/search-input/search-input.component.ts
@@ -35,7 +35,7 @@ export class SearchInputComponent {
 	/**
 	 * If true, searches will be made on `input` events, otherwise searches will be made on `keyup` events
 	 */
-	@Input() preferInputEvent = false;
+	@Input() preferInputEvent = true;
 
 	/**
 	 * Specifies a minimum character count required to search.

--- a/src/app/common/system-alert/system-alert.component.ts
+++ b/src/app/common/system-alert/system-alert.component.ts
@@ -2,8 +2,6 @@ import { animate, style, transition, trigger } from '@angular/animations';
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
 
-import { AlertModule } from 'ngx-bootstrap/alert';
-
 import { SystemAlertService } from './system-alert.service';
 
 @Component({
@@ -24,7 +22,7 @@ import { SystemAlertService } from './system-alert.service';
 		])
 	],
 	standalone: true,
-	imports: [NgFor, AlertModule, NgIf, AsyncPipe]
+	imports: [NgFor, NgIf, AsyncPipe]
 })
 export class SystemAlertComponent {
 	alertService = inject(SystemAlertService);

--- a/src/app/common/table/filter/_shared.scss
+++ b/src/app/common/table/filter/_shared.scss
@@ -15,7 +15,7 @@ button.dropdown-toggle {
 
 .dropdown-menu {
 	font-size: $filter-dropdown-font-size;
-	margin-top: 0.5rem;
+	//margin-top: 0.5rem;
 	max-height: $filter-dropdown-max-height;
 
 	input {

--- a/src/app/common/table/filter/asy-abstract-header-filter.component.ts
+++ b/src/app/common/table/filter/asy-abstract-header-filter.component.ts
@@ -28,6 +28,8 @@ export abstract class AsyAbstractHeaderFilterComponent
 
 	isFiltered = false;
 
+	isOpen = false;
+
 	private storage = new SessionStorageService();
 
 	/**

--- a/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.html
+++ b/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.html
@@ -1,22 +1,34 @@
-<span class="dropdown" container="body" dropdown [insideClick]="true">
-	<button class="dropdown-toggle dropdown-toggle-hide-caret" dropdownToggle>
-		<span
-			class="filter fa-solid fa-list"
-			container="body"
-			placement="bottom"
-			tooltip="Apply Filters"
-			[hidden]="isFiltered"
-		></span>
-		<span
-			class="filter fa-solid fa-filter"
-			container="body"
-			placement="bottom"
-			tooltip="Edit Filters"
-			[hidden]="!isFiltered"
-		></span>
-	</button>
+<button
+	class="dropdown-toggle dropdown-toggle-hide-caret"
+	cdkOverlayOrigin
+	#trigger
+	(click)="isOpen = !isOpen"
+>
+	<span
+		class="filter fa-solid fa-list"
+		container="body"
+		placement="bottom"
+		tooltip="Apply Filters"
+		[hidden]="isFiltered"
+	></span>
+	<span
+		class="filter fa-solid fa-filter"
+		container="body"
+		placement="bottom"
+		tooltip="Edit Filters"
+		[hidden]="!isFiltered"
+	></span>
+</button>
 
-	<div class="dropdown-menu" [class.dropdown-menu-right]="dropdownMenuRight" *dropdownMenu>
+<ng-template
+	cdkConnectedOverlay
+	cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+	[cdkConnectedOverlayHasBackdrop]="true"
+	[cdkConnectedOverlayOpen]="isOpen"
+	[cdkConnectedOverlayOrigin]="trigger"
+	(backdropClick)="isOpen = false"
+>
+	<div class="dropdown-menu" cdkTrapFocus cdkTrapFocusAutoCapture>
 		<div class="form-check">
 			<input
 				class="form-check-input"
@@ -108,4 +120,4 @@
 			/>
 		</div>
 	</div>
-</span>
+</ng-template>

--- a/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.spec.ts
+++ b/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DateTime, Settings } from 'luxon';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 import { AsyFilterDirective } from '../asy-filter.directive';
 import { AsyHeaderDateFilterComponent } from './asy-header-date-filter.component';
@@ -36,7 +35,7 @@ describe('AsyHeaderDateFilter', () => {
 		filterSpy.deregister.and.callFake(() => {});
 
 		await TestBed.configureTestingModule({
-			imports: [BrowserAnimationsModule, BsDropdownModule, AsyHeaderDateFilterComponent],
+			imports: [BrowserAnimationsModule, AsyHeaderDateFilterComponent],
 			providers: [{ provide: AsyFilterDirective, useValue: filterSpy as AsyFilterDirective }]
 		}).compileComponents();
 

--- a/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.ts
+++ b/src/app/common/table/filter/asy-header-date-filter/asy-header-date-filter.component.ts
@@ -1,3 +1,5 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { CdkConnectedOverlay, CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
 import { TitleCasePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, Optional } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -5,7 +7,6 @@ import { FormsModule } from '@angular/forms';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { DateTime } from 'luxon';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import {
@@ -20,12 +21,15 @@ import {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
 	imports: [
-		BsDropdownModule,
 		FormsModule,
 		NgSelectModule,
 		BsDatepickerModule,
 		TitleCasePipe,
-		TooltipModule
+		TooltipModule,
+		CdkOverlayOrigin,
+		CdkConnectedOverlay,
+		A11yModule,
+		OverlayModule
 	]
 })
 export class AsyHeaderDateFilterComponent extends AsyAbstractHeaderFilterComponent {

--- a/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.html
+++ b/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.html
@@ -1,26 +1,34 @@
-<span class="dropdown" container="body" dropdown [insideClick]="true">
-	<button class="dropdown-toggle dropdown-toggle-hide-caret" dropdownToggle>
-		<span
-			class="filter fa-solid fa-list"
-			container="body"
-			placement="bottom"
-			tooltip="Apply Filters"
-			[hidden]="isFiltered"
-		></span>
-		<span
-			class="filter fa-solid fa-filter"
-			container="body"
-			placement="bottom"
-			tooltip="Edit Filters"
-			[hidden]="!isFiltered"
-		></span>
-	</button>
+<button
+	class="dropdown-toggle dropdown-toggle-hide-caret"
+	cdkOverlayOrigin
+	#trigger
+	(click)="isOpen = !isOpen"
+>
+	<span
+		class="filter fa-solid fa-list"
+		container="body"
+		placement="bottom"
+		tooltip="Apply Filters"
+		[hidden]="isFiltered"
+	></span>
+	<span
+		class="filter fa-solid fa-filter"
+		container="body"
+		placement="bottom"
+		tooltip="Edit Filters"
+		[hidden]="!isFiltered"
+	></span>
+</button>
 
-	<div
-		class="dropdown-menu d-flex flex-column"
-		[ngClass]="{ 'dropdown-menu-right': dropdownMenuRight }"
-		*dropdownMenu
-	>
+<ng-template
+	cdkConnectedOverlay
+	cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+	[cdkConnectedOverlayHasBackdrop]="true"
+	[cdkConnectedOverlayOpen]="isOpen"
+	[cdkConnectedOverlayOrigin]="trigger"
+	(backdropClick)="isOpen = false"
+>
+	<div class="dropdown-menu d-flex flex-column" cdkTrapFocus cdkTrapFocusAutoCapture>
 		<ng-container *ngIf="showSearch">
 			<div class="search mt-2">
 				<asy-search-input
@@ -86,4 +94,4 @@
 			</div>
 		</ng-container>
 	</div>
-</span>
+</ng-template>

--- a/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.ts
+++ b/src/app/common/table/filter/asy-header-list-filter/asy-header-list-filter.component.ts
@@ -1,8 +1,9 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { CdkConnectedOverlay, CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
 import { NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, Input, Optional, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { SearchInputComponent } from '../../../search-input/search-input.component';
@@ -27,14 +28,17 @@ export type ListFilterOption = {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
 	imports: [
-		BsDropdownModule,
 		NgClass,
 		NgIf,
 		SearchInputComponent,
 		NgFor,
 		FormsModule,
 		TitleCasePipe,
-		TooltipModule
+		TooltipModule,
+		CdkOverlayOrigin,
+		CdkConnectedOverlay,
+		A11yModule,
+		OverlayModule
 	],
 	providers: [TitleCasePipe]
 })

--- a/src/app/common/table/filter/asy-header-text-filter/asy-header-text-filter.component.html
+++ b/src/app/common/table/filter/asy-header-text-filter/asy-header-text-filter.component.html
@@ -1,26 +1,34 @@
-<span class="dropdown" container="body" dropdown [insideClick]="true">
-	<button class="dropdown-toggle dropdown-toggle-hide-caret" dropdownToggle>
-		<span
-			class="filter fa-solid fa-list"
-			container="body"
-			placement="bottom"
-			tooltip="Apply Filters"
-			[hidden]="isFiltered"
-		></span>
-		<span
-			class="filter fa-solid fa-filter"
-			container="body"
-			placement="bottom"
-			tooltip="Edit Filters"
-			[hidden]="!isFiltered"
-		></span>
-	</button>
+<button
+	class="dropdown-toggle dropdown-toggle-hide-caret"
+	cdkOverlayOrigin
+	#trigger
+	(click)="isOpen = !isOpen"
+>
+	<span
+		class="filter fa-solid fa-list"
+		container="body"
+		placement="bottom"
+		tooltip="Apply Filters"
+		[hidden]="isFiltered"
+	></span>
+	<span
+		class="filter fa-solid fa-filter"
+		container="body"
+		placement="bottom"
+		tooltip="Edit Filters"
+		[hidden]="!isFiltered"
+	></span>
+</button>
 
-	<div
-		class="dropdown-menu d-flex flex-column"
-		[ngClass]="{ 'dropdown-menu-right': dropdownMenuRight }"
-		*dropdownMenu
-	>
+<ng-template
+	cdkConnectedOverlay
+	cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+	[cdkConnectedOverlayHasBackdrop]="true"
+	[cdkConnectedOverlayOpen]="isOpen"
+	[cdkConnectedOverlayOrigin]="trigger"
+	(backdropClick)="isOpen = false"
+>
+	<div class="dropdown-menu d-flex flex-column" cdkTrapFocus cdkTrapFocusAutoCapture>
 		<div class="mt-3">
 			<ng-select
 				[(ngModel)]="option"
@@ -41,4 +49,4 @@
 			</asy-search-input>
 		</div>
 	</div>
-</span>
+</ng-template>

--- a/src/app/common/table/filter/asy-header-text-filter/asy-header-text-filter.component.ts
+++ b/src/app/common/table/filter/asy-header-text-filter/asy-header-text-filter.component.ts
@@ -1,10 +1,11 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { CdkConnectedOverlay, CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, Input, Optional } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NgSelectModule } from '@ng-select/ng-select';
 import escapeRegExp from 'lodash/escapeRegExp';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { SearchInputComponent } from '../../../search-input/search-input.component';
@@ -24,12 +25,15 @@ type BuildFilterFunction = (search: string, option: TextFilterOption) => any;
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
 	imports: [
-		BsDropdownModule,
 		NgClass,
 		NgSelectModule,
 		FormsModule,
 		SearchInputComponent,
-		TooltipModule
+		TooltipModule,
+		A11yModule,
+		OverlayModule,
+		CdkConnectedOverlay,
+		CdkOverlayOrigin
 	]
 })
 export class AsyHeaderTextFilterComponent extends AsyAbstractHeaderFilterComponent {

--- a/src/app/common/table/filter/asy-header-typeahead-filter/asy-header-typeahead-filter.component.html
+++ b/src/app/common/table/filter/asy-header-typeahead-filter/asy-header-typeahead-filter.component.html
@@ -1,26 +1,34 @@
-<span class="dropdown" container="body" dropdown [insideClick]="true">
-	<button class="dropdown-toggle dropdown-toggle-hide-caret" dropdownToggle>
-		<span
-			class="filter fa-solid fa-list"
-			container="body"
-			placement="bottom"
-			tooltip="Apply Filters"
-			[hidden]="isFiltered"
-		></span>
-		<span
-			class="filter fa-solid fa-filter"
-			container="body"
-			placement="bottom"
-			tooltip="Edit Filters"
-			[hidden]="!isFiltered"
-		></span>
-	</button>
+<button
+	class="dropdown-toggle dropdown-toggle-hide-caret"
+	cdkOverlayOrigin
+	#trigger
+	(click)="isOpen = !isOpen"
+>
+	<span
+		class="filter fa-solid fa-list"
+		container="body"
+		placement="bottom"
+		tooltip="Apply Filters"
+		[hidden]="isFiltered"
+	></span>
+	<span
+		class="filter fa-solid fa-filter"
+		container="body"
+		placement="bottom"
+		tooltip="Edit Filters"
+		[hidden]="!isFiltered"
+	></span>
+</button>
 
-	<div
-		class="dropdown-menu d-flex flex-column"
-		[ngClass]="{ 'dropdown-menu-right': dropdownMenuRight }"
-		*dropdownMenu
-	>
+<ng-template
+	cdkConnectedOverlay
+	cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+	[cdkConnectedOverlayHasBackdrop]="true"
+	[cdkConnectedOverlayOpen]="isOpen"
+	[cdkConnectedOverlayOrigin]="trigger"
+	(backdropClick)="isOpen = false"
+>
+	<div class="dropdown-menu d-flex flex-column" cdkTrapFocus cdkTrapFocusAutoCapture>
 		<div class="my-3">
 			<ng-select
 				name="teamAdmin"
@@ -36,4 +44,4 @@
 			</ng-select>
 		</div>
 	</div>
-</span>
+</ng-template>

--- a/src/app/common/table/filter/asy-header-typeahead-filter/asy-header-typeahead-filter.component.ts
+++ b/src/app/common/table/filter/asy-header-typeahead-filter/asy-header-typeahead-filter.component.ts
@@ -1,10 +1,11 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { CdkConnectedOverlay, CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
 import { AsyncPipe, NgClass } from '@angular/common';
 import { Component, Inject, Input, OnInit, Optional } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { NgSelectModule } from '@ng-select/ng-select';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable, Subject, concat, of } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
@@ -23,7 +24,17 @@ type BuildFilterFunction = (selectedValue: any | null) => any;
 	templateUrl: './asy-header-typeahead-filter.component.html',
 	styleUrls: ['./asy-header-typeahead-filter.component.scss'],
 	standalone: true,
-	imports: [BsDropdownModule, NgClass, NgSelectModule, FormsModule, AsyncPipe, TooltipModule]
+	imports: [
+		NgClass,
+		NgSelectModule,
+		FormsModule,
+		AsyncPipe,
+		TooltipModule,
+		CdkOverlayOrigin,
+		A11yModule,
+		OverlayModule,
+		CdkConnectedOverlay
+	]
 })
 export class AsyHeaderTypeaheadFilterComponent
 	extends AsyAbstractHeaderFilterComponent

--- a/src/app/common/table/sidebar/sidebar.component.html
+++ b/src/app/common/table/sidebar/sidebar.component.html
@@ -13,4 +13,3 @@
 <div class="sidebar-body" [class.card-body]="showInCard">
 	<ng-content></ng-content>
 </div>
-ß

--- a/src/app/core/admin/cache-entries/cache-entries.component.html
+++ b/src/app/core/admin/cache-entries/cache-entries.component.html
@@ -47,47 +47,47 @@
 			</ng-container>
 			<ng-container cdkColumnDef="actionsMenu" stickyEnd>
 				<th cdk-header-cell *cdkHeaderCellDef></th>
-				<td
-					cdk-cell
-					container="body"
-					dropdown
-					placement="bottom right"
-					*cdkCellDef="let entry; let i = index"
-				>
-					<div class="dropdown border-left pl-2">
-						<button
-							class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret"
-							id="cache-entry-{{ entry._id }}-action-menu-btn"
-							type="button"
-							attr.aria-controls="cache-entry-{{ entry._id }}-action-menu"
-							dropdownToggle
-						>
-							<span class="fa-solid fa-lg fa-ellipsis-v"></span>
-						</button>
-						<ul
-							class="dropdown-menu dropdown-menu-right"
+				<td cdk-cell *cdkCellDef="let entry; let i = index">
+					<button
+						class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret border-left py-0 pl-3"
+						id="cache-entry-{{ entry._id }}-action-menu-btn"
+						type="button"
+						attr.aria-controls="cache-entry-{{ entry._id }}-action-menu"
+						[cdkMenuTriggerFor]="actionsMenu"
+					>
+						<span class="fa-solid fa-lg fa-ellipsis-v"></span>
+					</button>
+
+					<ng-template #actionsMenu>
+						<div
+							class="dropdown-menu"
 							id="cache-entry-{{ entry._id }}-action-menu"
-							role="menu"
 							attr.aria-labelledby="cache-entry-{{ entry._id }}-action-menu-btn"
-							*dropdownMenu
+							cdkMenu
 						>
-							<li role="menuitem">
-								<button class="dropdown-item" (click)="viewCacheEntry(entry)">
-									View
-								</button>
-							</li>
-							<li role="menuitem">
-								<button class="dropdown-item" (click)="refreshCacheEntry(entry)">
-									Refresh
-								</button>
-							</li>
-							<li role="menuitem">
-								<button class="dropdown-item" (click)="confirmDeleteEntry(entry)">
-									Delete
-								</button>
-							</li>
-						</ul>
-					</div>
+							<button
+								class="dropdown-item"
+								cdkMenuItem
+								(cdkMenuItemTriggered)="viewCacheEntry(entry)"
+							>
+								View
+							</button>
+							<button
+								class="dropdown-item"
+								cdkMenuItem
+								(cdkMenuItemTriggered)="refreshCacheEntry(entry)"
+							>
+								Refresh
+							</button>
+							<button
+								class="dropdown-item"
+								cdkMenuItem
+								(cdkMenuItemTriggered)="confirmDeleteEntry(entry)"
+							>
+								Delete
+							</button>
+						</div>
+					</ng-template>
 				</td>
 			</ng-container>
 			<tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/core/admin/cache-entries/cache-entries.component.ts
+++ b/src/app/core/admin/cache-entries/cache-entries.component.ts
@@ -1,10 +1,10 @@
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { CdkTableModule } from '@angular/cdk/table';
 import { JsonPipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable } from 'rxjs';
 import { filter, first, switchMap } from 'rxjs/operators';
@@ -42,12 +42,14 @@ import { CacheEntry } from './cache-entry.model';
 		AsyFilterDirective,
 		AsySortHeaderComponent,
 		TooltipModule,
-		BsDropdownModule,
 		AsyTableEmptyStateComponent,
 		PaginatorComponent,
 		JsonPipe,
 		AgoDatePipe,
-		UtcDatePipe
+		UtcDatePipe,
+		CdkMenu,
+		CdkMenuTrigger,
+		CdkMenuItem
 	]
 })
 export class CacheEntriesComponent implements OnDestroy, OnInit {

--- a/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.html
+++ b/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.html
@@ -92,51 +92,48 @@
 						placement="bottom right"
 						*cdkCellDef="let eua"
 					>
-						<div class="dropdown border-left pl-2">
-							<button
-								class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret"
-								id="eua-{{ eua._id }}-action-menu-btn"
-								type="button"
-								attr.aria-controls="eua-{{ eua._id }}-action-menu"
-								dropdownToggle
-							>
-								<span class="fa-solid fa-lg fa-ellipsis-v"></span>
-							</button>
-							<ul
-								class="dropdown-menu dropdown-menu-right"
+						<button
+							class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret border-left py-0 pl-3"
+							id="eua-{{ eua._id }}-action-menu-btn"
+							type="button"
+							attr.aria-controls="eua-{{ eua._id }}-action-menu"
+							[cdkMenuTriggerFor]="actionsMenu"
+						>
+							<span class="fa-solid fa-lg fa-ellipsis-v"></span>
+						</button>
+						<ng-template #actionsMenu>
+							<div
+								class="dropdown-menu"
 								id="eua-{{ eua._id }}-action-menu"
-								role="menu"
 								attr.aria-labelledby="eua-{{ eua._id }}-action-menu-btn"
-								*dropdownMenu
+								cdkMenu
 							>
-								<li role="menuitem">
-									<button
-										class="dropdown-item"
-										(click)="previewEndUserAgreement(eua)"
-									>
-										Preview
-									</button>
-								</li>
-								<li role="menuitem">
-									<button
-										class="dropdown-item"
-										[routerLink]="['/admin/eua', eua._id]"
-									>
-										Edit
-									</button>
-								</li>
-								<li role="menuitem">
-									<button class="dropdown-item" (click)="publishEua(eua)">
-										Publish
-									</button>
-								</li>
-								<li role="menuitem">
-									<button class="dropdown-item" (click)="confirmDeleteEua(eua)">
-										Delete
-									</button>
-								</li>
-							</ul>
-						</div>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
+									(click)="previewEndUserAgreement(eua)"
+								>
+									Preview
+								</button>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
+									[routerLink]="['/admin/eua', eua._id]"
+								>
+									Edit
+								</button>
+								<button class="dropdown-item" cdkMenuItem (click)="publishEua(eua)">
+									Publish
+								</button>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
+									(click)="confirmDeleteEua(eua)"
+								>
+									Delete
+								</button>
+							</div>
+						</ng-template>
 					</td>
 				</ng-container>
 

--- a/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.ts
+++ b/src/app/core/admin/end-user-agreement/list-euas/admin-list-euas.component.ts
@@ -1,9 +1,9 @@
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { CdkTableModule } from '@angular/cdk/table';
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable } from 'rxjs';
 import { filter, first, switchMap } from 'rxjs/operators';
@@ -41,13 +41,15 @@ import { EuaService } from '../eua.service';
 		AsySortDirective,
 		AsyFilterDirective,
 		AsySortHeaderComponent,
-		BsDropdownModule,
 		AsyTableEmptyStateComponent,
 		SidebarComponent,
 		ColumnChooserComponent,
 		PaginatorComponent,
 		UtcDatePipe,
-		TooltipModule
+		TooltipModule,
+		CdkMenuTrigger,
+		CdkMenu,
+		CdkMenuItem
 	]
 })
 export class AdminListEuasComponent implements OnDestroy, OnInit {

--- a/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.html
+++ b/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.html
@@ -130,107 +130,93 @@
 						></asy-header-filter>
 					</th>
 					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="btn-group" container="body" dropdown placement="bottom right">
-							<button
-								class="dropdown-toggle feedback-status-button"
-								[class.feedback-status-closed]="
-									feedback.status === feedbackStatusOptions.CLOSED
-								"
-								[class.feedback-status-new]="
-									feedback.status === feedbackStatusOptions.NEW
-								"
-								[class.feedback-status-open]="
+						<button
+							class="dropdown-toggle feedback-status-button"
+							[ngClass]="{
+								'feedback-status-closed':
+									feedback.status === feedbackStatusOptions.CLOSED,
+								'feedback-status-new':
+									feedback.status === feedbackStatusOptions.NEW,
+								'feedback-status-open':
 									feedback.status === feedbackStatusOptions.OPEN
-								"
-								id="feedback-{{ feedback._id }}-status-menu-btn"
-								type="button"
-								attr.aria-controls="feedback-{{ feedback._id }}-status-menu"
-								dropdownToggle
-							>
-								{{ feedback.status }}
-							</button>
-							<ul
-								class="dropdown-menu dropdown-menu-right"
+							}"
+							id="feedback-{{ feedback._id }}-status-menu-btn"
+							type="button"
+							attr.aria-controls="feedback-{{ feedback._id }}-status-menu"
+							[cdkMenuTriggerFor]="statusMenu"
+						>
+							{{ feedback.status }}
+						</button>
+						<ng-template #statusMenu>
+							<div
+								class="dropdown-menu"
 								id="feedback-{{ feedback._id }}-status-menu"
-								role="menu"
 								attr.aria-labelledby="feedback-{{ feedback._id }}-status-menu-btn"
-								*dropdownMenu
+								cdkMenu
 							>
-								<li
-									role="menuitem"
+								<button
+									class="dropdown-item"
+									cdkMenuItem
 									*ngIf="feedback.status !== feedbackStatusOptions.OPEN"
+									(cdkMenuItemTriggered)="
+										updateFeedbackStatus(feedback, feedbackStatusOptions.OPEN)
+									"
 								>
-									<button
-										class="dropdown-item"
-										(click)="
-											updateFeedbackStatus(
-												feedback,
-												feedbackStatusOptions.OPEN
-											)
-										"
-									>
-										Open
-									</button>
-								</li>
-								<li
-									role="menuitem"
+									Open
+								</button>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
 									*ngIf="feedback.status !== feedbackStatusOptions.CLOSED"
+									(cdkMenuItemTriggered)="
+										updateFeedbackStatus(feedback, feedbackStatusOptions.CLOSED)
+									"
 								>
-									<button
-										class="dropdown-item"
-										(click)="
-											updateFeedbackStatus(
-												feedback,
-												feedbackStatusOptions.CLOSED
-											)
-										"
-									>
-										Close
-									</button>
-								</li>
-							</ul>
-						</div>
+									Close
+								</button>
+							</div>
+						</ng-template>
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="assignee">
 					<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Assignee</th>
 					<td cdk-cell *cdkCellDef="let feedback">
-						<div class="btn-group" container="body" dropdown placement="bottom right">
-							<button
-								class="dropdown-toggle feedback-status-button"
-								[class.feedback-status-open]="!!feedback.assignee"
-								id="feedback-{{ feedback._id }}-assignee-menu-btn"
-								type="button"
-								attr.aria-controls="feedback-{{ feedback._id }}-status-menu"
-								dropdownToggle
-							>
-								{{ feedback.assignee ?? 'None' }}
-							</button>
-							<ul
-								class="dropdown-menu dropdown-menu-right"
+						<button
+							class="dropdown-toggle feedback-status-button"
+							[class.feedback-status-open]="!!feedback.assignee"
+							id="feedback-{{ feedback._id }}-assignee-menu-btn"
+							type="button"
+							attr.aria-controls="feedback-{{ feedback._id }}-assignee-menu"
+							[cdkMenuTriggerFor]="assigneeMenu"
+						>
+							{{ feedback.assignee ?? 'None' }}
+						</button>
+						<ng-template #assigneeMenu>
+							<div
+								class="dropdown-menu"
 								id="feedback-{{ feedback._id }}-assignee-menu"
-								role="menu"
-								attr.aria-labelledby="feedback-{{ feedback._id }}-status-menu-btn"
-								*dropdownMenu
+								attr.aria-labelledby="feedback-{{ feedback._id }}-assignee-menu-btn"
+								cdkMenu
 							>
-								<li role="menuitem">
-									<button
-										class="dropdown-item"
-										(click)="updateFeedbackAssignee(feedback)"
-									>
-										None
-									</button>
-								</li>
-								<li role="menuitem" *ngFor="let username of assigneeUsernames">
-									<button
-										class="dropdown-item"
-										(click)="updateFeedbackAssignee(feedback, username)"
-									>
-										{{ username }}
-									</button>
-								</li>
-							</ul>
-						</div>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
+									(cdkMenuItemTriggered)="updateFeedbackAssignee(feedback)"
+								>
+									None
+								</button>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
+									*ngFor="let username of assigneeUsernames"
+									(cdkMenuItemTriggered)="
+										updateFeedbackAssignee(feedback, username)
+									"
+								>
+									{{ username }}
+								</button>
+							</div>
+						</ng-template>
 					</td>
 				</ng-container>
 				<tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.ts
+++ b/src/app/core/admin/feedback/list-feedback/admin-list-feedback.component.ts
@@ -1,10 +1,11 @@
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
+import { OverlayModule } from '@angular/cdk/overlay';
 import { CdkTableModule } from '@angular/cdk/table';
-import { NgFor, NgIf, TitleCasePipe } from '@angular/common';
+import { NgClass, NgFor, NgIf, TitleCasePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable } from 'rxjs';
 
@@ -40,11 +41,11 @@ import { AdminUsersService } from '../../user-management/admin-users.service';
 		SearchInputComponent,
 		TooltipModule,
 		CdkTableModule,
+		OverlayModule,
 		AsySortDirective,
 		AsyFilterDirective,
 		AsySortHeaderComponent,
 		AsyHeaderListFilterComponent,
-		BsDropdownModule,
 		NgIf,
 		NgFor,
 		AsyTableEmptyStateComponent,
@@ -54,7 +55,11 @@ import { AdminUsersService } from '../../user-management/admin-users.service';
 		TitleCasePipe,
 		AgoDatePipe,
 		UtcDatePipe,
-		SkipToDirective
+		SkipToDirective,
+		NgClass,
+		CdkMenuTrigger,
+		CdkMenu,
+		CdkMenuItem
 	]
 })
 export class AdminListFeedbackComponent implements OnDestroy, OnInit {

--- a/src/app/core/admin/messages/list-messages/list-messages.component.html
+++ b/src/app/core/admin/messages/list-messages/list-messages.component.html
@@ -38,7 +38,11 @@
 			<ng-container cdkColumnDef="title">
 				<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Title</th>
 				<td cdk-cell *cdkCellDef="let message">
-					{{ message.title }}
+					<a
+						class="text-decoration-underline"
+						[routerLink]="['/admin/message', message._id]"
+						>{{ message.title }}</a
+					>
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="type">
@@ -61,49 +65,43 @@
 			</ng-container>
 			<ng-container cdkColumnDef="actionsMenu" stickyEnd>
 				<th cdk-header-cell *cdkHeaderCellDef></th>
-				<td
-					cdk-cell
-					container="body"
-					dropdown
-					placement="bottom right"
-					*cdkCellDef="let message"
-				>
-					<div class="dropdown border-left pl-2">
-						<button
-							class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret"
-							id="message-{{ message._id }}-action-menu-btn"
-							type="button"
-							attr.aria-controls="message-{{ message._id }}-action-menu"
-							dropdownToggle
-						>
-							<span class="fa-solid fa-lg fa-ellipsis-v"></span>
-						</button>
-						<ul
-							class="dropdown-menu dropdown-menu-right"
+				<td cdk-cell *cdkCellDef="let message">
+					<button
+						class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret"
+						id="message-{{ message._id }}-action-menu-btn"
+						type="button"
+						attr.aria-controls="message-{{ message._id }}-action-menu"
+						[cdkMenuTriggerFor]="actionsMenu"
+					>
+						<span class="fa-solid fa-lg fa-ellipsis-v"></span>
+					</button>
+					<ng-template #actionsMenu>
+						<div
+							class="dropdown-menu"
 							id="message-{{ message._id }}-action-menu"
-							role="menu"
 							attr.aria-labelledby="message-{{ message._id }}-action-menu-btn"
-							*dropdownMenu
+							cdkMenu
 						>
-							<li role="menuitem">
-								<a class="dropdown-item" (click)="previewMessage(message)"
-									>Preview</a
-								>
-							</li>
-							<li role="menuitem">
-								<a
-									class="dropdown-item"
-									[routerLink]="['/admin/message', message._id]"
-									>Edit</a
-								>
-							</li>
-							<li role="menuitem">
-								<a class="dropdown-item" (click)="confirmDeleteMessage(message)"
-									>Delete</a
-								>
-							</li>
-						</ul>
-					</div>
+							<a
+								class="dropdown-item"
+								cdkMenuItem
+								[routerLink]="['/admin/message', message._id]"
+								>Edit</a
+							>
+							<a
+								class="dropdown-item"
+								cdkMenuItem
+								(cdkMenuItemTriggered)="previewMessage(message)"
+								>Preview</a
+							>
+							<a
+								class="dropdown-item"
+								cdkMenuItem
+								(cdkMenuItemTriggered)="confirmDeleteMessage(message)"
+								>Delete</a
+							>
+						</div>
+					</ng-template>
 				</td>
 			</ng-container>
 			<tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/core/admin/messages/list-messages/list-messages.component.ts
+++ b/src/app/core/admin/messages/list-messages/list-messages.component.ts
@@ -1,12 +1,13 @@
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { CdkTableModule } from '@angular/cdk/table';
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { Observable } from 'rxjs';
 import { filter, first, switchMap } from 'rxjs/operators';
 
+import { CdkMenuItemRouterLinkDirective } from '../../../../common/cdk-menu-item-router-link.directive';
 import { DialogAction, DialogService } from '../../../../common/dialog';
 import { SkipToDirective } from '../../../../common/directives/skip-to.directive';
 import { PagingOptions, PagingResults } from '../../../../common/paging.model';
@@ -38,10 +39,13 @@ import { MessageService } from '../../../messages/message.service';
 		AsySortDirective,
 		AsyFilterDirective,
 		AsySortHeaderComponent,
-		BsDropdownModule,
 		AsyTableEmptyStateComponent,
 		PaginatorComponent,
-		UtcDatePipe
+		UtcDatePipe,
+		CdkMenuTrigger,
+		CdkMenu,
+		CdkMenuItem,
+		CdkMenuItemRouterLinkDirective
 	]
 })
 export class ListMessagesComponent implements OnDestroy, OnInit {

--- a/src/app/core/admin/user-management/list-users/admin-list-users.component.html
+++ b/src/app/core/admin/user-management/list-users/admin-list-users.component.html
@@ -63,8 +63,12 @@
 				</ng-container>
 				<ng-container cdkColumnDef="name">
 					<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Name</th>
-					<td cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.name }}
+					<td class="text-nowrap" cdk-cell *cdkCellDef="let user">
+						<a
+							class="text-decoration-underline"
+							[routerLink]="['/admin/user', user.userModel._id]"
+							>{{ user.userModel.name }}</a
+						>
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="username">
@@ -163,56 +167,53 @@
 				<ng-container cdkColumnDef="teams">
 					<th cdk-header-cell *cdkHeaderCellDef>Teams</th>
 					<td cdk-cell *cdkCellDef="let user">
-						<div class="text-nowrap" *ngFor="let team of user.userModel.teams">
-							<a
-								class="text-decoration-underline"
-								[routerLink]="['/team', team._id]"
-								>{{ team.team.name }}</a
-							>
+						<div class="cdk-cell-collapsible">
+							<div class="text-nowrap" *ngFor="let team of user.userModel.teams">
+								<a
+									class="text-decoration-underline"
+									[routerLink]="['/team', team._id]"
+									>{{ team.team.name }}</a
+								>
+							</div>
 						</div>
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="actionsMenu" stickyEnd>
 					<th cdk-header-cell *cdkHeaderCellDef></th>
-					<td
-						cdk-cell
-						container="body"
-						dropdown
-						placement="bottom right"
-						*cdkCellDef="let user"
-					>
-						<div class="dropdown border-left pl-2">
-							<button
-								class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret"
-								id="user-{{ user._id }}-action-menu-btn"
-								type="button"
-								attr.aria-controls="user-{{ user._id }}-action-menu"
-								dropdownToggle
-							>
-								<span class="fa-solid fa-lg fa-ellipsis-v"></span>
-							</button>
-							<ul
-								class="dropdown-menu dropdown-menu-right"
+					<td cdk-cell *cdkCellDef="let user">
+						<button
+							class="btn btn-sm dropdown-toggle dropdown-toggle-hide-caret border-left py-0 pl-3"
+							id="user-{{ user._id }}-action-menu-btn"
+							type="button"
+							attr.aria-controls="user-{{ user._id }}-action-menu"
+							[cdkMenuTriggerFor]="actionsMenu"
+						>
+							<span class="fa-solid fa-lg fa-ellipsis-v"></span>
+						</button>
+						<ng-template #actionsMenu>
+							<div
+								class="dropdown-menu"
 								id="user-{{ user._id }}-action-menu"
-								role="menu"
 								attr.aria-labelledby="user-{{ user._id }}-action-menu-btn"
-								*dropdownMenu
+								cdkMenu
 							>
-								<li role="menuitem">
-									<button
-										class="dropdown-item"
-										[routerLink]="['/admin/user', user.userModel._id]"
-									>
-										Edit
-									</button>
-								</li>
-								<li role="menuitem" *ngIf="allowDeleteUser$ | async">
-									<button class="dropdown-item" (click)="confirmDeleteUser(user)">
-										Delete
-									</button>
-								</li>
-							</ul>
-						</div>
+								<a
+									class="dropdown-item"
+									cdkMenuItem
+									[routerLink]="['/admin/user', user.userModel._id]"
+								>
+									Edit
+								</a>
+								<button
+									class="dropdown-item"
+									cdkMenuItem
+									*ngIf="allowDeleteUser$ | async"
+									(cdkMenuItemTriggered)="confirmDeleteUser(user)"
+								>
+									Delete
+								</button>
+							</div>
+						</ng-template>
 					</td>
 				</ng-container>
 				<tr cdk-header-row *cdkHeaderRowDef="displayedColumns; sticky: true"></tr>

--- a/src/app/core/admin/user-management/list-users/admin-list-users.component.scss
+++ b/src/app/core/admin/user-management/list-users/admin-list-users.component.scss
@@ -14,3 +14,7 @@
 .user-role-external::after {
 	content: '(external)';
 }
+
+.dropdown-menu {
+	//margin-top: 46px;
+}

--- a/src/app/core/admin/user-management/list-users/admin-list-users.component.ts
+++ b/src/app/core/admin/user-management/list-users/admin-list-users.component.ts
@@ -1,3 +1,5 @@
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
+import { OverlayModule } from '@angular/cdk/overlay';
 import { CdkTableModule } from '@angular/cdk/table';
 import { AsyncPipe, NgClass, NgFor, NgIf } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -5,11 +7,11 @@ import { Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable, of } from 'rxjs';
 import { catchError, filter, first, map, switchMap } from 'rxjs/operators';
 
+import { CdkMenuItemRouterLinkDirective } from '../../../../common/cdk-menu-item-router-link.directive';
 import { DialogAction, DialogService } from '../../../../common/dialog';
 import { SkipToDirective } from '../../../../common/directives/skip-to.directive';
 import { PagingOptions, PagingResults } from '../../../../common/paging.model';
@@ -48,6 +50,7 @@ import { UserRoleFilterDirective } from './user-role-filter.directive';
 		RouterLink,
 		TooltipModule,
 		CdkTableModule,
+		OverlayModule,
 		AsySortDirective,
 		AsyFilterDirective,
 		AsySortHeaderComponent,
@@ -56,7 +59,6 @@ import { UserRoleFilterDirective } from './user-role-filter.directive';
 		NgFor,
 		NgIf,
 		NgClass,
-		BsDropdownModule,
 		AsyTableEmptyStateComponent,
 		SidebarComponent,
 		ColumnChooserComponent,
@@ -64,7 +66,11 @@ import { UserRoleFilterDirective } from './user-role-filter.directive';
 		AsyncPipe,
 		AgoDatePipe,
 		JoinPipe,
-		UtcDatePipe
+		UtcDatePipe,
+		CdkMenuTrigger,
+		CdkMenu,
+		CdkMenuItem,
+		CdkMenuItemRouterLinkDirective
 	]
 })
 export class AdminListUsersComponent implements OnDestroy, OnInit {
@@ -160,7 +166,7 @@ export class AdminListUsersComponent implements OnDestroy, OnInit {
 	private dialogService = inject(DialogService);
 
 	constructor(
-		private router: Router,
+		public router: Router,
 		private route: ActivatedRoute,
 		private adminUsersService: AdminUsersService,
 		private exportConfigService: ExportConfigService,

--- a/src/app/core/audit/list-audit-entries/list-audit-entries.component.ts
+++ b/src/app/core/audit/list-audit-entries/list-audit-entries.component.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from '@angular/cdk/overlay';
+import { ComponentType, OverlayModule } from '@angular/cdk/overlay';
 import { CdkTableModule } from '@angular/cdk/table';
 import { NgIf } from '@angular/common';
 import { Component, OnDestroy, ViewChild, inject } from '@angular/core';
@@ -13,6 +13,7 @@ import { SkipToDirective } from '../../../common/directives/skip-to.directive';
 import { PagingOptions, PagingResults } from '../../../common/paging.model';
 import { UtcDatePipe } from '../../../common/pipes/utc-date-pipe/utc-date.pipe';
 import { SystemAlertComponent } from '../../../common/system-alert/system-alert.component';
+import { SystemAlertService } from '../../../common/system-alert/system-alert.service';
 import { AsyTableDataSource } from '../../../common/table/asy-table-data-source';
 import { AsyFilterDirective } from '../../../common/table/filter/asy-filter.directive';
 import { AsyHeaderDateFilterComponent } from '../../../common/table/filter/asy-header-date-filter/asy-header-date-filter.component';
@@ -39,6 +40,7 @@ import { AuditDistinctValueFilterDirective } from './audit-distinct-value-filter
 		SkipToDirective,
 		SystemAlertComponent,
 		CdkTableModule,
+		OverlayModule,
 		AsySortDirective,
 		AsyFilterDirective,
 		AsySortHeaderComponent,
@@ -81,9 +83,11 @@ export class ListAuditEntriesComponent implements OnDestroy {
 	private dialogService = inject(DialogService);
 
 	constructor(
+		private alertService: SystemAlertService,
 		private auditService: AuditService,
 		private configService: ConfigService
 	) {
+		this.alertService.clearAllAlerts();
 		this.configService
 			.getConfig()
 			.pipe(first(), untilDestroyed(this))

--- a/src/app/core/teams/add-members-modal/add-members-modal.component.html
+++ b/src/app/core/teams/add-members-modal/add-members-modal.component.html
@@ -41,21 +41,26 @@
 						{{ invited.username }}
 					</td>
 					<td>
-						<div class="dropdown dropdown-table-inline" container="body" dropdown>
-							<span class="dropdown-toggle" dropdownToggle>
-								<span class="mr-1">{{ invited.roleDisplay }}</span>
-							</span>
+						<button
+							class="btn btn-sm dropdown-toggle py-0"
+							[cdkMenuTriggerFor]="rolesMenu"
+						>
+							<span class="mr-1">{{ invited.roleDisplay }}</span>
+						</button>
 
-							<ul class="dropdown-menu" role="menu" *dropdownMenu>
-								<li
+						<ng-template #rolesMenu>
+							<div class="dropdown-menu" cdkMenu>
+								<button
+									class="dropdown-item"
 									[value]="role.role"
+									cdkMenuItem
 									*ngFor="let role of teamRoleOptions"
-									(click)="updateRoleSelection(invited, role.role)"
+									(cdkMenuItemTriggered)="updateRoleSelection(invited, role.role)"
 								>
-									<a class="dropdown-item">{{ role.label }}</a>
-								</li>
-							</ul>
-						</div>
+									{{ role.label }}
+								</button>
+							</div>
+						</ng-template>
 					</td>
 					<td>
 						<a

--- a/src/app/core/teams/add-members-modal/add-members-modal.component.ts
+++ b/src/app/core/teams/add-members-modal/add-members-modal.component.ts
@@ -1,10 +1,10 @@
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 
 import { NgSelectComponent, NgSelectModule } from '@ng-select/ng-select';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
@@ -36,9 +36,11 @@ export type AddMembersModalData = {
 		NgSelectModule,
 		NgIf,
 		NgFor,
-		BsDropdownModule,
 		TooltipModule,
-		AsyncPipe
+		AsyncPipe,
+		CdkMenu,
+		CdkMenuItem,
+		CdkMenuTrigger
 	]
 })
 export class AddMembersModalComponent implements OnInit {

--- a/src/app/core/teams/list-team-members/list-team-members.component.html
+++ b/src/app/core/teams/list-team-members/list-team-members.component.html
@@ -67,25 +67,34 @@
 					</asy-header-filter>
 				</th>
 				<td cdk-cell *cdkCellDef="let member">
-					<div
-						class="dropdown dropdown-table-inline"
-						container="body"
-						dropdown
+					<button
+						class="btn btn-sm dropdown-toggle p-0"
+						id="member-{{ member.userModel._id }}-role-menu-btn"
+						type="button"
+						attr.aria-controls="member-{{ member.userModel._id }}-role-menu"
 						*hasTeamRole="team; role: 'admin'; else: readOnlyRole"
+						[cdkMenuTriggerFor]="roleMenu"
 					>
-						<span class="dropdown-toggle" dropdownToggle>
-							<span class="mr-1">{{ member.roleDisplay }}</span>
-						</span>
-						<ul class="dropdown-menu" role="menu" *dropdownMenu>
-							<li
-								[value]="role.role"
+						<span class="mr-1">{{ member.roleDisplay }}</span>
+					</button>
+					<ng-template #roleMenu>
+						<div
+							class="dropdown-menu"
+							id="member-{{ member.userModel._id }}-role-menu"
+							attr.aria-labelledby="member-{{ member.userModel._id }}-role-menu-btn"
+							cdkMenu
+						>
+							<button
+								class="dropdown-item"
+								cdkMenuItem
 								*ngFor="let role of teamRoleOptions"
-								(click)="updateRole(member, role.role)"
+								(cdkMenuItemTriggered)="updateRole(member, role.role)"
 							>
-								<a class="dropdown-item">{{ role.label }}</a>
-							</li>
-						</ul>
-					</div>
+								{{ role.label }}
+							</button>
+						</div>
+					</ng-template>
+
 					<ng-template #readOnlyRole>
 						{{ member.roleDisplay }}
 					</ng-template>

--- a/src/app/core/teams/list-team-members/list-team-members.component.ts
+++ b/src/app/core/teams/list-team-members/list-team-members.component.ts
@@ -1,3 +1,4 @@
+import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { CdkTableModule } from '@angular/cdk/table';
 import { NgFor, NgIf } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -14,7 +15,6 @@ import {
 import { Router } from '@angular/router';
 
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { Observable, of } from 'rxjs';
 import { catchError, filter, first, switchMap } from 'rxjs/operators';
@@ -65,12 +65,14 @@ import { TeamsService } from '../teams.service';
 		AsySortHeaderComponent,
 		TooltipModule,
 		AsyHeaderListFilterComponent,
-		BsDropdownModule,
 		NgFor,
 		AsyTableEmptyStateComponent,
 		PaginatorComponent,
 		AgoDatePipe,
-		UtcDatePipe
+		UtcDatePipe,
+		CdkMenu,
+		CdkMenuTrigger,
+		CdkMenuItem
 	]
 })
 export class ListTeamMembersComponent implements OnChanges, OnDestroy, OnInit {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,8 @@
 @import 'styles/links';
 @import 'styles/selection';
 
+@import '@angular/cdk/overlay-prebuilt.css';
+
 /* You can add global styles to this file, and also import other style files */
 
 // Import the main ngx-bootstrap style file
@@ -13,6 +15,8 @@
 
 // Import the main ng-select style file
 @import 'styles/ng-select';
+@import 'styles/cdk-bootstrap';
+
 
 body {
 	@include font-normal();

--- a/src/styles/_cdk-bootstrap.scss
+++ b/src/styles/_cdk-bootstrap.scss
@@ -1,0 +1,13 @@
+.cdk-menu {
+	&.dropdown-menu {
+		display: block;
+		position: static;
+	}
+}
+
+.cdk-overlay-pane {
+	.dropdown-menu {
+		display: block;
+		position: static;
+	}
+}

--- a/src/styles/ngx-bootstrap/_dropdowns.scss
+++ b/src/styles/ngx-bootstrap/_dropdowns.scss
@@ -15,10 +15,6 @@ $dropdown-element-font-color: map.get($color-background, 'lightest-contrast') !d
 	&.open .dropdown-toggle::after {
 		transform: rotate(180deg);
 	}
-
-	.dropdown-item {
-		@include font-size($input-font-size);
-	}
 }
 
 .dropdown-toggle.dropdown-toggle-hide-caret {

--- a/src/styles/ngx-bootstrap/_variables.scss
+++ b/src/styles/ngx-bootstrap/_variables.scss
@@ -55,6 +55,7 @@ $dropdown-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3) !default;
 $dropdown-link-hover-bg: $ux-color-light-gray !default;
 $dropdown-link-active-color: $input-color !default;
 $dropdown-link-active-bg: $ux-color-light-gray !default;
+$dropdown-font-size: $input-font-size !default;
 
 $dropdown-item-padding-y: 8px !default;
 $dropdown-item-padding-x: 10px !default;


### PR DESCRIPTION
* Continues towards migrating away from the ngx-bootstrap library in favor of using cdk.  Cdk components have better a11y support and are style agnostic.  We can still apply bootstrap styles to them, but gives us the options to move away from bootstrap in the future.
* Still using bootstrap styling for visual consistency.
* Replaced all dropdown usages with menu and overlay