### PR TITLE
fix: Add ViewportScroller implementation to properly handle scrolling on navigation events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/router": "^15.2.9",
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@ng-select/ng-select": "~10.0.4",
+        "@ng-web-apis/common": "^3.0.2",
         "@ngneat/until-destroy": "~9.0.0",
         "bootstrap": "4.6.1",
         "lodash": "~4.17.21",
@@ -3440,6 +3441,19 @@
         "@angular/common": "<16.0.0",
         "@angular/core": "<16.0.0",
         "@angular/forms": "<16.0.0"
+      }
+    },
+    "node_modules/@ng-web-apis/common": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ng-web-apis/common/-/common-3.0.2.tgz",
+      "integrity": "sha512-PWMegIsuxfmya8AgSx4fQR5mt4ozaSflJARN6I4W6kGKxX/MnHGt86+djN3P6KVoWjI+bcQt2UlF1jlW9DgWiQ==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=12.0.0",
+        "@angular/core": ">=12.0.0",
+        "rxjs": ">=6.4.0"
       }
     },
     "node_modules/@ngneat/until-destroy": {
@@ -19760,6 +19774,14 @@
       "integrity": "sha512-Vc/JIgcFkSgf47cX7+pQQo9HYhDktfqrY7o/ZPGMvu63P7E9d1MibVipqmcLbgms6Ac9lu621CDZPGHdxag7hA==",
       "requires": {
         "tslib": "^2.3.1"
+      }
+    },
+    "@ng-web-apis/common": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ng-web-apis/common/-/common-3.0.2.tgz",
+      "integrity": "sha512-PWMegIsuxfmya8AgSx4fQR5mt4ozaSflJARN6I4W6kGKxX/MnHGt86+djN3P6KVoWjI+bcQt2UlF1jlW9DgWiQ==",
+      "requires": {
+        "tslib": "^2.2.0"
       }
     },
     "@ngneat/until-destroy": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@angular/router": "^15.2.9",
     "@fortawesome/fontawesome-free": "^6.2.1",
     "@ng-select/ng-select": "~10.0.4",
+    "@ng-web-apis/common": "^3.0.2",
     "@ngneat/until-destroy": "~9.0.0",
     "bootstrap": "4.6.1",
     "lodash": "~4.17.21",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,7 +2,12 @@ import { provideHttpClient, withInterceptors, withInterceptorsFromDi } from '@an
 import { importProvidersFrom } from '@angular/core';
 import { ApplicationConfig } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { TitleStrategy, provideRouter, withHashLocation } from '@angular/router';
+import {
+	TitleStrategy,
+	provideRouter,
+	withHashLocation,
+	withInMemoryScrolling
+} from '@angular/router';
 
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { ModalModule } from 'ngx-bootstrap/modal';
@@ -14,7 +19,12 @@ import { euaInterceptor } from './core/auth/eua.interceptor';
 import { signinInterceptor } from './core/auth/signin.interceptor';
 import { masqueradeInterceptor } from './core/masquerade/masquerade.interceptor';
 import { PageTitleStrategy } from './core/page-title.strategy';
-import { provideAppConfig, provideCoreRoutes, provideNavigationService } from './core/provider';
+import {
+	provideAppConfig,
+	provideCoreRoutes,
+	provideNavigationService,
+	provideViewportScroller
+} from './core/provider';
 import { provideExampleRoutes } from './site/example/provider';
 
 export const appConfig: ApplicationConfig = {
@@ -42,7 +52,12 @@ export const appConfig: ApplicationConfig = {
 			withInterceptorsFromDi()
 		),
 		provideCdkDialog(),
-		provideRouter([], withHashLocation()),
+		provideRouter(
+			[],
+			withHashLocation(),
+			withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })
+		),
+		provideViewportScroller(),
 		provideCoreRoutes(),
 		provideExampleRoutes(),
 		provideAppConfig(),

--- a/src/app/core/custom_viewport_scroller.ts
+++ b/src/app/core/custom_viewport_scroller.ts
@@ -1,0 +1,165 @@
+import { DOCUMENT, ViewportScroller } from '@angular/common';
+import { InjectionToken, inject } from '@angular/core';
+
+import { WINDOW } from '@ng-web-apis/common';
+
+export const SCROLL_ELEMENT = new InjectionToken<string>('SCROLL_ELEMENT', {
+	providedIn: 'root',
+	factory: () => 'app-content'
+});
+
+/**
+ * Modified version of BrowserViewportScroller from @angular/common
+ * Manages the scroll position for scrollElement.
+ */
+export class CustomViewportScroller implements ViewportScroller {
+	private offset: () => [number, number] = () => [0, 0];
+
+	private scrollElementID = inject(SCROLL_ELEMENT);
+	private document = inject(DOCUMENT);
+	private window = inject(WINDOW);
+
+	/**
+	 * Configures the top offset used when scrolling to an anchor.
+	 * @param offset A position in screen coordinates (a tuple with x and y values)
+	 * or a function that returns the top offset position.
+	 *
+	 */
+	setOffset(offset: [number, number] | (() => [number, number])): void {
+		if (Array.isArray(offset)) {
+			this.offset = () => offset;
+		} else {
+			this.offset = offset;
+		}
+	}
+
+	/**
+	 * Retrieves the current scroll position.
+	 * @returns The position in screen coordinates.
+	 */
+	getScrollPosition(): [number, number] {
+		const scrollEl = this.getScrollElement();
+		if (scrollEl && this.supportsScrolling()) {
+			return [scrollEl.scrollLeft, scrollEl.scrollTop];
+		} else {
+			return [0, 0];
+		}
+	}
+
+	/**
+	 * Sets the scroll position.
+	 * @param position The new position in screen coordinates.
+	 */
+	scrollToPosition(position: [number, number]): void {
+		const scrollEl = this.getScrollElement();
+		if (scrollEl && this.supportsScrolling()) {
+			scrollEl.scrollTo(position[0], position[1]);
+		}
+	}
+
+	/**
+	 * Scrolls to an element and attempts to focus the element.
+	 *
+	 * Note that the function name here is misleading in that the target string may be an ID for a
+	 * non-anchor element.
+	 *
+	 * @param target The ID of an element or name of the anchor.
+	 *
+	 * @see https://html.spec.whatwg.org/#the-indicated-part-of-the-document
+	 * @see https://html.spec.whatwg.org/#scroll-to-fragid
+	 */
+	scrollToAnchor(target: string): void {
+		if (this.getScrollElement() && !this.supportsScrolling()) {
+			return;
+		}
+
+		const elSelected = findAnchorFromDocument(this.document, target);
+
+		if (elSelected) {
+			this.scrollToElement(elSelected);
+			// After scrolling to the element, the spec dictates that we follow the focus steps for the
+			// target. Rather than following the robust steps, simply attempt focus.
+			//
+			// @see https://html.spec.whatwg.org/#get-the-focusable-area
+			// @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus
+			// @see https://html.spec.whatwg.org/#focusable-area
+			elSelected.focus();
+		}
+	}
+
+	/**
+	 * Disables automatic scroll restoration provided by the browser.
+	 */
+	setHistoryScrollRestoration(scrollRestoration: 'auto' | 'manual'): void {
+		if (this.getScrollElement() && this.supportsScrolling()) {
+			this.window.history.scrollRestoration = scrollRestoration;
+		}
+	}
+
+	/**
+	 * Scrolls to an element using the native offset and the specified offset set on this scroller.
+	 *
+	 * The offset can be used when we know that there is a floating header and scrolling naively to an
+	 * element (ex: `scrollIntoView`) leaves the element hidden behind the floating header.
+	 */
+	private scrollToElement(el: HTMLElement): void {
+		const scrollEl = this.getScrollElement();
+		if (scrollEl) {
+			const rect = el.getBoundingClientRect();
+			const left = rect.left + this.window.scrollX;
+			const top = rect.top + this.window.scrollY;
+			const offset = this.offset();
+			scrollEl.scrollTo(left - offset[0], top - offset[1]);
+		}
+	}
+
+	private supportsScrolling(): boolean {
+		try {
+			return !!this.window && !!this.window.scrollTo && 'pageXOffset' in this.window;
+		} catch {
+			return false;
+		}
+	}
+
+	private getScrollElement(): Element | null {
+		return this.document.querySelector(`#${this.scrollElementID}`);
+	}
+}
+
+function findAnchorFromDocument(document: Document, target: string): HTMLElement | null {
+	const documentResult = document.getElementById(target) || document.getElementsByName(target)[0];
+
+	if (documentResult) {
+		return documentResult;
+	}
+
+	// `getElementById` and `getElementsByName` won't pierce through the shadow DOM so we
+	// have to traverse the DOM manually and do the lookup through the shadow roots.
+	if (
+		typeof document.createTreeWalker === 'function' &&
+		document.body &&
+		typeof document.body.attachShadow === 'function'
+	) {
+		const treeWalker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+		let currentNode = treeWalker.currentNode as HTMLElement | null;
+
+		while (currentNode) {
+			const shadowRoot = currentNode.shadowRoot;
+
+			if (shadowRoot) {
+				// Note that `ShadowRoot` doesn't support `getElementsByName`
+				// so we have to fall back to `querySelector`.
+				const result =
+					shadowRoot.getElementById(target) ||
+					shadowRoot.querySelector(`[name="${target}"]`);
+				if (result) {
+					return result;
+				}
+			}
+
+			currentNode = treeWalker.nextNode() as HTMLElement | null;
+		}
+	}
+
+	return null;
+}

--- a/src/app/core/provider.ts
+++ b/src/app/core/provider.ts
@@ -1,4 +1,5 @@
-import { APP_INITIALIZER, makeEnvironmentProviders } from '@angular/core';
+import { ViewportScroller } from '@angular/common';
+import { APP_INITIALIZER, Provider, makeEnvironmentProviders } from '@angular/core';
 import { ROUTES } from '@angular/router';
 
 import { firstValueFrom } from 'rxjs';
@@ -7,6 +8,7 @@ import { tap } from 'rxjs/operators';
 import { ADMIN_TOPICS } from './admin/admin-topic.model';
 import { ConfigService } from './config.service';
 import { CORE_ROUTES } from './core-routes';
+import { CustomViewportScroller, SCROLL_ELEMENT } from './custom_viewport_scroller';
 import { GettingStartedHelpComponent } from './help/getting-started/getting-started-help.component';
 import { HELP_TOPICS } from './help/help-topic.component';
 import { NavigationService } from './navigation.service';
@@ -118,4 +120,21 @@ export function provideNavigationService() {
 			multi: true
 		}
 	]);
+}
+
+export function provideViewportScroller(scrollElementID?: string) {
+	const providers: Provider[] = [
+		{
+			provide: ViewportScroller,
+			useClass: CustomViewportScroller
+		}
+	];
+	if (scrollElementID) {
+		providers.push({
+			provide: SCROLL_ELEMENT,
+			useValue: scrollElementID
+		});
+	}
+
+	return makeEnvironmentProviders(providers);
 }


### PR DESCRIPTION


Currently, scroll position doesn't always get reset properly when navigating routes. Default angular behavior assumes that scrolling applies to the entire page.  When the primary scrolling viewport is a subelement (as it is here), a custom viewport scroller is needed. Implementation is taking from the default `BrowserViewportScroller`, but operates on the configured element vs. the window. Provider function provided for simply configuration.