### PR TITLE
refactor: Refactor user.model for improved type safety

### DIFF
--- a/src/app/core/admin/user/admin-users.service.ts
+++ b/src/app/core/admin/user/admin-users.service.ts
@@ -44,8 +44,8 @@ export class AdminUsersService {
 			.pipe(
 				map((results: PagingResults) => {
 					if (null != results && Array.isArray(results.elements)) {
-						results.elements = results.elements.map((element: any) =>
-							new User().setFromUserModel(element)
+						results.elements = results.elements.map(
+							(element: any) => new User(element)
 						);
 					}
 					return results;
@@ -68,17 +68,17 @@ export class AdminUsersService {
 	}
 
 	create(user: User) {
-		return this.http.post('api/admin/user', user.userModel);
+		return this.http.post('api/admin/user', user);
 	}
 
 	read(userId: string) {
 		return this.http
 			.get(`api/admin/user/${userId}`)
-			.pipe(map((userRaw: any) => new User().setFromUserModel(userRaw)));
+			.pipe(map((userRaw: any) => new User(userRaw)));
 	}
 
 	update(user: User): Observable<any> {
-		return this.http.post(`api/admin/user/${user.userModel._id}`, user.userModel);
+		return this.http.post(`api/admin/user/${user._id}`, user);
 	}
 
 	redirectError(error: unknown) {

--- a/src/app/core/admin/user/list-users/admin-list-users.component.html
+++ b/src/app/core/admin/user/list-users/admin-list-users.component.html
@@ -58,7 +58,7 @@
 				<ng-container cdkColumnDef="id">
 					<th cdk-header-cell *cdkHeaderCellDef>ID</th>
 					<td cdk-cell *cdkCellDef="let user">
-						{{ user.userModel._id }}
+						{{ user._id }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="name">
@@ -66,33 +66,33 @@
 					<td class="text-nowrap" cdk-cell *cdkCellDef="let user">
 						<a
 							class="text-decoration-underline"
-							[routerLink]="['/admin/user', user.userModel._id]"
-							>{{ user.userModel.name }}</a
+							[routerLink]="['/admin/user', user._id]"
+							>{{ user.name }}</a
 						>
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="username">
 					<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Username</th>
 					<td class="text-nowrap" cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.username }}
+						{{ user.username }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="organization">
 					<th cdk-header-cell *cdkHeaderCellDef>Organization</th>
 					<td cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.organization }}
+						{{ user.organization }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="email">
 					<th cdk-header-cell *cdkHeaderCellDef>Email</th>
 					<td cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.email }}
+						{{ user.email }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="phone">
 					<th cdk-header-cell *cdkHeaderCellDef>Phone</th>
 					<td cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.phone }}
+						{{ user.phone }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="acceptedEua">
@@ -101,9 +101,9 @@
 						<div
 							class="text-nowrap"
 							container="body"
-							tooltip="{{ user.userModel.acceptedEua | utcDate }}"
+							tooltip="{{ user.acceptedEua | utcDate }}"
 						>
-							{{ user.userModel.acceptedEua | agoDate: false }}
+							{{ user.acceptedEua | agoDate: false }}
 						</div>
 					</td>
 				</ng-container>
@@ -113,34 +113,34 @@
 						<div
 							class="text-nowrap"
 							container="body"
-							tooltip="{{ user.userModel.lastLogin | utcDate }}"
+							tooltip="{{ user.lastLogin | utcDate }}"
 						>
-							{{ user.userModel.lastLogin | agoDate: false }}
+							{{ user.lastLogin | agoDate: false }}
 						</div>
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="created">
 					<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Created</th>
 					<td class="text-nowrap" cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.created | utcDate }}
+						{{ user.created | utcDate }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="updated">
 					<th cdk-header-cell *cdkHeaderCellDef>Updated</th>
 					<td class="text-nowrap" cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.updated | utcDate }}
+						{{ user.updated | utcDate }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="externalRoles">
 					<th cdk-header-cell *cdkHeaderCellDef>External Roles</th>
 					<td class="hide-overflow" cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.externalRoles | join: ', ' }}
+						{{ user.externalRoles | join: ', ' }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="externalGroups">
 					<th cdk-header-cell *cdkHeaderCellDef>External Groups</th>
 					<td class="hide-overflow" cdk-cell *cdkCellDef="let user">
-						{{ user.userModel.externalGroups | join: ', ' }}
+						{{ user.externalGroups | join: ', ' }}
 					</td>
 				</ng-container>
 				<ng-container cdkColumnDef="roles">
@@ -154,10 +154,9 @@
 								class="user-role text-nowrap"
 								[ngClass]="{
 									'user-role-external':
-										user.userModel.localRoles &&
-										!user.userModel.localRoles[role.role]
+										user.localRoles && !user.localRoles[role.role]
 								}"
-								*ngIf="user.userModel.roles?.[role.role]"
+								*ngIf="user.roles?.[role.role]"
 							>
 								{{ role.label }}
 							</div>
@@ -168,7 +167,7 @@
 					<th cdk-header-cell *cdkHeaderCellDef>Teams</th>
 					<td cdk-cell *cdkCellDef="let user">
 						<div class="cdk-cell-collapsible">
-							<div class="text-nowrap" *ngFor="let team of user.userModel.teams">
+							<div class="text-nowrap" *ngFor="let team of user.teams">
 								<a
 									class="text-decoration-underline"
 									[routerLink]="['/team', team._id]"
@@ -200,7 +199,7 @@
 								<a
 									class="dropdown-item"
 									cdkMenuItem
-									[routerLink]="['/admin/user', user.userModel._id]"
+									[routerLink]="['/admin/user', user._id]"
 								>
 									Edit
 								</a>

--- a/src/app/core/admin/user/list-users/admin-list-users.component.ts
+++ b/src/app/core/admin/user/list-users/admin-list-users.component.ts
@@ -207,13 +207,13 @@ export class AdminListUsersComponent implements OnDestroy, OnInit {
 		this.dialogService
 			.confirm(
 				'Delete user?',
-				`Are you sure you want to delete the user: <strong>"${user.userModel.name}"</strong>?<br/>This action cannot be undone.`,
+				`Are you sure you want to delete the user: <strong>"${user.name}"</strong>?<br/>This action cannot be undone.`,
 				'Delete'
 			)
 			.closed.pipe(
 				first(),
 				filter((result) => result?.action === DialogAction.OK),
-				switchMap(() => this.adminUsersService.removeUser(user.userModel._id)),
+				switchMap(() => this.adminUsersService.removeUser(user._id)),
 				catchError((error: unknown) => {
 					if (error instanceof HttpErrorResponse) {
 						this.alertService.addClientErrorAlert(error);

--- a/src/app/core/admin/user/manage-user/manage-user.component.html
+++ b/src/app/core/admin/user/manage-user/manage-user.component.html
@@ -1,4 +1,4 @@
-<section *ngIf="user?.userModel">
+<section>
 	<!-- Show a breadcrumb to the list users page -->
 	<a class="back-link" routerLink="/admin/users">
 		<span class="fa-solid fa-angle-double-left"></span> Back to Users
@@ -34,7 +34,7 @@
 				name="name"
 				type="text"
 				required
-				[(ngModel)]="user.userModel.name"
+				[(ngModel)]="user.name"
 				[disabled]="metadataLocked"
 			/>
 		</div>
@@ -48,7 +48,7 @@
 				name="username"
 				type="text"
 				required
-				[(ngModel)]="user.userModel.username"
+				[(ngModel)]="user.username"
 				[disabled]="metadataLocked"
 			/>
 		</div>
@@ -62,7 +62,7 @@
 				name="organization"
 				type="text"
 				required
-				[(ngModel)]="user.userModel.organization"
+				[(ngModel)]="user.organization"
 				[disabled]="metadataLocked"
 			/>
 		</div>
@@ -76,7 +76,7 @@
 				name="email"
 				type="email"
 				required
-				[(ngModel)]="user.userModel.email"
+				[(ngModel)]="user.email"
 				[disabled]="metadataLocked"
 			/>
 		</div>
@@ -99,7 +99,7 @@
 					name="password"
 					type="password"
 					autocomplete="off"
-					[(ngModel)]="user.userModel.password"
+					[(ngModel)]="user.password"
 				/>
 			</div>
 
@@ -113,7 +113,7 @@
 					name="password2"
 					type="password"
 					autocomplete="off"
-					[(ngModel)]="user.userModel.verifyPassword"
+					[(ngModel)]="user.verifyPassword"
 				/>
 			</div>
 		</ng-container>
@@ -129,7 +129,7 @@
 						id="bypassAC"
 						name="bypassAccessCheck"
 						type="checkbox"
-						[(ngModel)]="user.userModel.bypassAccessCheck"
+						[(ngModel)]="user.bypassAccessCheck"
 					/>
 					<label class="form-check-label" for="bypassAC">Bypass Access Check</label>
 				</div>
@@ -145,7 +145,7 @@
 					name="dn"
 					type="text"
 					disabled
-					[(ngModel)]="user.userModel.providerData.dn"
+					[(ngModel)]="user.providerData.dn"
 				/>
 			</div>
 
@@ -158,7 +158,7 @@
 					type="text"
 					disabled
 					rows="4"
-					>{{ user.userModel.externalRolesDisplay }}</textarea
+					>{{ user.externalRolesDisplay }}</textarea
 				>
 			</div>
 
@@ -171,7 +171,7 @@
 					type="text"
 					disabled
 					rows="4"
-					>{{ user.userModel.externalGroupsDisplay }}</textarea
+					>{{ user.externalGroupsDisplay }}</textarea
 				>
 			</div>
 		</ng-container>
@@ -190,7 +190,7 @@
 						id="role{{ role.role }}Cb"
 						name="role{{ role.role }}Cb"
 						type="checkbox"
-						[(ngModel)]="user.userModel.roles[role.role]"
+						[(ngModel)]="user.roles[role.role]"
 					/>
 					<label class="form-check-label" for="role{{ role.role }}Cb">{{
 						role.label

--- a/src/app/core/admin/user/manage-user/manage-user.component.ts
+++ b/src/app/core/admin/user/manage-user/manage-user.component.ts
@@ -11,7 +11,7 @@ import { first } from 'rxjs/operators';
 import { SystemAlertComponent } from '../../../../common/system-alert/system-alert.component';
 import { SystemAlertService } from '../../../../common/system-alert/system-alert.service';
 import { Role } from '../../../auth/role.model';
-import { User } from '../../../auth/user.model';
+import { EditUser } from '../../../auth/user.model';
 import { ConfigService } from '../../../config.service';
 import { AdminUsersService } from '../admin-users.service';
 
@@ -25,7 +25,7 @@ export class ManageUserComponent implements OnInit {
 	mode: 'create' | 'edit' = 'create';
 
 	@Input()
-	user: User;
+	user: EditUser;
 
 	proxyPki = false;
 	metadataLocked = false;
@@ -42,20 +42,11 @@ export class ManageUserComponent implements OnInit {
 
 		if (this.user) {
 			this.mode = 'edit';
-			if (null === this.user.userModel.roles) {
-				this.user.userModel.roles = {};
-			}
-			this.user.userModel.externalRolesDisplay =
-				this.user.userModel.externalRoles?.join('\n');
-			this.user.userModel.externalGroupsDisplay =
-				this.user.userModel.externalGroups?.join('\n');
-			this.user.userModel.providerData = {
-				dn: this.user.userModel.providerData?.dn
-			};
-			this.metadataLocked = this.proxyPki && !this.user.userModel.bypassAccessCheck;
+			this.user.externalRolesDisplay = this.user.externalRoles?.join('\n');
+			this.user.externalGroupsDisplay = this.user.externalGroups?.join('\n');
+			this.metadataLocked = this.proxyPki && !this.user.bypassAccessCheck;
 		} else {
-			this.user = new User();
-			this.user.userModel.roles = {};
+			this.user = new EditUser();
 		}
 
 		this.configService
@@ -86,7 +77,7 @@ export class ManageUserComponent implements OnInit {
 	}
 
 	private validatePassword(): boolean {
-		if (this.user.userModel.password === this.user.userModel.verifyPassword) {
+		if (this.user.password === this.user.verifyPassword) {
 			return true;
 		}
 

--- a/src/app/core/audit/audit.service.spec.ts
+++ b/src/app/core/audit/audit.service.spec.ts
@@ -76,7 +76,7 @@ describe('Audit Service', () => {
 			} as PagingResults;
 			const expectedResults = _cloneDeep(results);
 			expectedResults.elements = expectedResults.elements.map((element) => {
-				return new User().setFromUserModel(element);
+				return new User(element);
 			});
 			const paging = new PagingOptions();
 			paging.setPageNumber(2);

--- a/src/app/core/audit/audit.service.ts
+++ b/src/app/core/audit/audit.service.ts
@@ -51,7 +51,7 @@ export class AuditService {
 		search: string,
 		paging: PagingOptions,
 		options: any
-	): Observable<PagingResults> {
+	): Observable<PagingResults<User>> {
 		return this.http
 			.post<PagingResults>(
 				'api/users/match',
@@ -61,8 +61,8 @@ export class AuditService {
 			.pipe(
 				map((results: PagingResults) => {
 					if (null != results && Array.isArray(results.elements)) {
-						results.elements = results.elements.map((element: any) =>
-							new User().setFromUserModel(element)
+						results.elements = results.elements.map(
+							(element: any) => new User(element)
 						);
 					}
 					return results;

--- a/src/app/core/audit/list-audit-entries/audit-actor-filter.directive.ts
+++ b/src/app/core/audit/list-audit-entries/audit-actor-filter.directive.ts
@@ -22,7 +22,7 @@ export class AuditActorFilterDirective implements OnInit {
 		this.typeaheadFilter.buildFilterFunc = this.buildFilter;
 	}
 
-	typeaheadSearch(term: string): Observable<any> {
+	typeaheadSearch(term: string) {
 		return this.auditService
 			.matchUser({}, term, new PagingOptions(), {})
 			.pipe(map((pagingResult) => pagingResult.elements));
@@ -32,7 +32,7 @@ export class AuditActorFilterDirective implements OnInit {
 		if (selectedValue) {
 			return {
 				['audit.actor._id']: {
-					$obj: selectedValue.userModel._id
+					$obj: selectedValue._id
 				}
 			};
 		}

--- a/src/app/core/auth/authentication.service.ts
+++ b/src/app/core/auth/authentication.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs';
 
-import { User } from './user.model';
+import { EditUser } from './user.model';
 
 @Injectable({ providedIn: 'root' })
 export class AuthenticationService {
@@ -13,8 +13,8 @@ export class AuthenticationService {
 		return this.http.post('api/auth/signin', { username, password });
 	}
 
-	signup(user: User): Observable<any> {
-		return this.http.post('api/auth/signup', user.userModel);
+	signup(user: EditUser): Observable<any> {
+		return this.http.post('api/auth/signup', user);
 	}
 
 	reloadCurrentUser(): Observable<any> {

--- a/src/app/core/auth/authorization.service.spec.ts
+++ b/src/app/core/auth/authorization.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthorizationService } from './authorization.service';
 import { Role } from './role.model';
 import { Session } from './session.model';
 import { SessionService } from './session.service';
+import { User } from './user.model';
 
 class MockSessionService {
 	sessionSubject$ = new BehaviorSubject<Session | null>(null);
@@ -20,42 +21,36 @@ describe('AuthorizationService', () => {
 	let sessionService: SessionService;
 
 	const EMPTY_SESSION: Session | null = null;
-	const USER_SESSION: any = {
-		name: 'test',
-		user: {
-			userModel: {
-				roles: {
-					user: true,
-					admin: false
-				},
-				externalRoles: ['ROLE1']
-			}
-		}
-	};
-	const ADMIN_SESSION: any = {
-		name: 'test',
-		user: {
-			userModel: {
-				roles: {
-					user: true,
-					admin: true
-				},
-				externalRoles: ['ROLE1', 'ROLE2']
-			}
-		}
-	};
-	const INACTIVE_USER_SESSION: any = {
-		name: 'test',
-		user: {
-			userModel: {
-				roles: {
-					user: false,
-					admin: false
-				},
-				externalRoles: ['ROLE1']
-			}
-		}
-	};
+	const USER_SESSION = new Session(
+		new User({
+			name: 'test',
+			roles: {
+				user: true,
+				admin: false
+			},
+			externalRoles: ['ROLE1']
+		})
+	);
+	const ADMIN_SESSION = new Session(
+		new User({
+			name: 'test',
+			roles: {
+				user: true,
+				admin: true
+			},
+			externalRoles: ['ROLE1', 'ROLE2']
+		})
+	);
+	const INACTIVE_USER_SESSION = new Session(
+		new User({
+			name: 'test',
+			roles: {
+				user: false,
+				admin: false
+			},
+			externalRoles: ['ROLE1']
+		})
+	);
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({

--- a/src/app/core/auth/authorization.service.ts
+++ b/src/app/core/auth/authorization.service.ts
@@ -24,8 +24,8 @@ export class AuthorizationService {
 		const euaPublished: number = this.session?.user?.eua?.published
 			? new Date(this.session?.user?.eua?.published).getTime()
 			: 0;
-		const euaAccepted: number = this.session?.user?.userModel?.acceptedEua
-			? new Date(this.session?.user?.userModel?.acceptedEua).getTime()
+		const euaAccepted: number = this.session?.user?.acceptedEua
+			? new Date(this.session?.user?.acceptedEua).getTime()
 			: 0;
 
 		return euaAccepted >= euaPublished;
@@ -36,7 +36,7 @@ export class AuthorizationService {
 	}
 
 	public hasExternalRole(role: string): boolean {
-		const externalRoles = this.session?.user?.userModel?.externalRoles ?? [];
+		const externalRoles = this.session?.user?.externalRoles ?? [];
 
 		return externalRoles.indexOf(role) !== -1;
 	}
@@ -44,7 +44,7 @@ export class AuthorizationService {
 	public hasRole(role: string | Role): boolean {
 		role = this.roleToString(role);
 
-		const roles = this.session?.user?.userModel?.roles ?? {};
+		const roles = this.session?.user?.roles ?? {};
 		return null != roles[role] && roles[role];
 	}
 

--- a/src/app/core/auth/credentials.model.ts
+++ b/src/app/core/auth/credentials.model.ts
@@ -1,6 +1,0 @@
-export class Credentials {
-	constructor(
-		public username?: string,
-		public password?: string
-	) {}
-}

--- a/src/app/core/auth/directives/user-external-roles-select.directive.ts
+++ b/src/app/core/auth/directives/user-external-roles-select.directive.ts
@@ -22,7 +22,7 @@ export class UserExternalRolesSelectDirective implements OnInit {
 			.getSession()
 			.pipe(
 				isNotNullOrUndefined(),
-				map((session) => session.user.userModel.externalRoles),
+				map((session) => session.user.externalRoles),
 				takeUntilDestroyed(this.destroyRef)
 			)
 			.subscribe((externalRoles) => {

--- a/src/app/core/auth/session.model.ts
+++ b/src/app/core/auth/session.model.ts
@@ -1,6 +1,9 @@
 import { User } from './user.model';
 
 export class Session {
-	name: string;
-	user: User;
+	constructor(public user: User) {}
+
+	public get name() {
+		return this.user?.name;
+	}
 }

--- a/src/app/core/auth/session.service.ts
+++ b/src/app/core/auth/session.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { Injectable, inject } from '@angular/core';
 
 import { BehaviorSubject, Observable, of, pipe } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
@@ -12,6 +11,8 @@ import { User } from './user.model';
 	providedIn: 'root'
 })
 export class SessionService {
+	private authService = inject(AuthenticationService);
+
 	// The current session information
 	sessionSubject$ = new BehaviorSubject<Session | null>(null);
 
@@ -20,19 +21,9 @@ export class SessionService {
 			if (result == null) {
 				return result;
 			}
-			const user = new User();
-			user.setFromUserModel(result);
-			return {
-				name: result.name,
-				user
-			};
+			return new Session(new User(result));
 		})
 	);
-
-	constructor(
-		private authService: AuthenticationService,
-		private router: Router
-	) {}
 
 	reloadSession(): Observable<Session | null> {
 		return this.authService.reloadCurrentUser().pipe(

--- a/src/app/core/auth/user.model.ts
+++ b/src/app/core/auth/user.model.ts
@@ -1,23 +1,51 @@
-import { Credentials } from './credentials.model';
-
 export class User {
-	constructor(
-		public userModel: any = {}, // raw User model object,
-		public credentials: Credentials = new Credentials(),
-		public eua?: any
-	) {}
+	public _id: string;
+	public name: string;
+	public username: string;
+	public email: string;
+	public phone: string;
+	public organization: string;
+	public acceptedEua: string;
+	public lastLogin: string;
+	public created: string;
+	public updated: string;
+
+	public externalRoles: string[] = [];
+	public externalGroups: string[] = [];
+	public teams: any[] = [];
+	public canMasquerade = false;
+	public bypassAccessCheck = false;
+
+	public providerData: { dn?: string } & Record<string, unknown> = {};
+	public roles: Record<string, boolean> = {};
+
+	public eua?: any;
+
+	constructor(model?: unknown) {
+		if (model) {
+			this.setFromModel(model);
+		}
+	}
+
+	private setFromModel(model: unknown): User {
+		if (null == model) {
+			return this;
+		}
+
+		Object.assign(this, model);
+
+		return this;
+	}
 
 	public setEua(eua: any) {
 		this.eua = eua;
 	}
+}
 
-	public setFromUserModel(userModel: any): User {
-		if (null == userModel || null == userModel.username) {
-			userModel = null;
-		}
+export class EditUser extends User {
+	password: string;
+	verifyPassword: string;
 
-		this.userModel = userModel;
-
-		return this;
-	}
+	externalRolesDisplay: string;
+	externalGroupsDisplay: string;
 }

--- a/src/app/core/masquerade/masquerade.service.ts
+++ b/src/app/core/masquerade/masquerade.service.ts
@@ -31,10 +31,8 @@ export class MasqueradeService {
 	searchUsers(query: any = {}, search = '', options: any = {}): Observable<PagingResults<User>> {
 		return this.http.post<PagingResults>('api/users', { q: query, s: search, options }).pipe(
 			tap((results: PagingResults) => {
-				if (null != results && Array.isArray(results.elements)) {
-					results.elements = results.elements.map((element: any) =>
-						new User().setFromUserModel(element)
-					);
+				if (Array.isArray(results?.elements)) {
+					results.elements = results.elements.map((element: any) => new User(element));
 				}
 			}),
 			catchError(() => of(NULL_PAGING_RESULTS))

--- a/src/app/core/masquerade/masquerade/masquerade.component.html
+++ b/src/app/core/masquerade/masquerade/masquerade.component.html
@@ -32,7 +32,7 @@
 
 	<div class="form-group" *ngIf="!searchByDn">
 		<ng-select
-			bindValue="userModel.providerData.dn"
+			bindValue="providerData.dn"
 			placeholder="Search for user..."
 			style="width: 300px"
 			[(ngModel)]="selectedUserDn"
@@ -41,7 +41,7 @@
 			[typeahead]="usersInput$"
 		>
 			<ng-template let-item="item" ng-label-tmp ng-option-tmp>
-				{{ item.userModel.name }} [{{ item.userModel.username }}]
+				{{ item.name }} [{{ item.username }}]
 			</ng-template>
 		</ng-select>
 	</div>

--- a/src/app/core/masquerade/masquerade/masquerade.component.ts
+++ b/src/app/core/masquerade/masquerade/masquerade.component.ts
@@ -53,7 +53,7 @@ export class MasqueradeComponent implements OnInit {
 				.getSession()
 				.pipe(isNotNullOrUndefined(), takeUntilDestroyed(this.destroyRef))
 				.subscribe((session) => {
-					if (session.user.userModel.canMasquerade) {
+					if (session.user.canMasquerade) {
 						this.loadUsers();
 					} else {
 						window.location.href = '#/';

--- a/src/app/core/signup/signup.component.html
+++ b/src/app/core/signup/signup.component.html
@@ -1,4 +1,4 @@
-<section *ngIf="user?.userModel">
+<section>
 	<!-- Alert Notifications -->
 	<system-alert></system-alert>
 
@@ -28,7 +28,7 @@
 				name="name"
 				type="text"
 				required
-				[(ngModel)]="user.userModel.name"
+				[(ngModel)]="user.name"
 			/>
 		</div>
 
@@ -41,7 +41,7 @@
 				name="username"
 				type="text"
 				required
-				[(ngModel)]="user.userModel.username"
+				[(ngModel)]="user.username"
 			/>
 		</div>
 
@@ -54,7 +54,7 @@
 				name="organization"
 				type="text"
 				required
-				[(ngModel)]="user.userModel.organization"
+				[(ngModel)]="user.organization"
 			/>
 		</div>
 
@@ -67,7 +67,7 @@
 				name="email"
 				type="email"
 				required
-				[(ngModel)]="user.userModel.email"
+				[(ngModel)]="user.email"
 			/>
 		</div>
 
@@ -81,7 +81,7 @@
 				type="password"
 				autocomplete="off"
 				minlength="6"
-				[(ngModel)]="user.userModel.password"
+				[(ngModel)]="user.password"
 			/>
 		</div>
 
@@ -94,7 +94,7 @@
 				type="password"
 				autocomplete="off"
 				minlength="6"
-				[(ngModel)]="user.userModel.verifyPassword"
+				[(ngModel)]="user.verifyPassword"
 			/>
 		</div>
 

--- a/src/app/core/signup/signup.component.ts
+++ b/src/app/core/signup/signup.component.ts
@@ -10,7 +10,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { SystemAlertComponent } from '../../common/system-alert/system-alert.component';
 import { SystemAlertService } from '../../common/system-alert/system-alert.service';
 import { AuthenticationService } from '../auth/authentication.service';
-import { User } from '../auth/user.model';
+import { EditUser } from '../auth/user.model';
 
 @Component({
 	standalone: true,
@@ -26,7 +26,7 @@ import { User } from '../auth/user.model';
 	]
 })
 export class SignupComponent {
-	user = new User();
+	user = new EditUser();
 
 	private destroyRef = inject(DestroyRef);
 	private router = inject(Router);
@@ -50,7 +50,7 @@ export class SignupComponent {
 	}
 
 	private validatePassword(): boolean {
-		if (this.user.userModel.password === this.user.userModel.verifyPassword) {
+		if (this.user.password === this.user.verifyPassword) {
 			return true;
 		}
 		this.alertService.addAlert('Passwords must match', 'danger');

--- a/src/app/core/site-navbar/site-navbar.component.ts
+++ b/src/app/core/site-navbar/site-navbar.component.ts
@@ -122,7 +122,7 @@ export class SiteNavbarComponent implements OnInit {
 			.pipe(takeUntilDestroyed(this.destroyRef))
 			.subscribe((session) => {
 				this.session = session;
-				this.canMasquerade = session?.user?.userModel?.canMasquerade ?? false;
+				this.canMasquerade = session?.user?.canMasquerade ?? false;
 			});
 
 		this.configService

--- a/src/app/core/teams/add-members-modal/add-members-modal.component.ts
+++ b/src/app/core/teams/add-members-modal/add-members-modal.component.ts
@@ -94,8 +94,7 @@ export class AddMembersModalComponent implements OnInit {
 				),
 				map((result) =>
 					result.elements.filter(
-						(user: any) =>
-							!this.addedMembers.map((m) => m._id).includes(user?.userModel._id)
+						(user: any) => !this.addedMembers.map((m) => m._id).includes(user?._id)
 					)
 				),
 				tap(() => {
@@ -134,8 +133,8 @@ export class AddMembersModalComponent implements OnInit {
 	}
 
 	typeaheadOnSelect(user: User, comp: NgSelectComponent) {
-		const selectedUsername = user?.userModel?.username;
-		const selectedUserId = user?.userModel?._id;
+		const selectedUsername = user?.username;
+		const selectedUserId = user?._id;
 		if (null != selectedUsername) {
 			this.addedMembers.push({
 				username: selectedUsername,

--- a/src/app/core/teams/create-team/create-team.component.ts
+++ b/src/app/core/teams/create-team/create-team.component.ts
@@ -118,9 +118,7 @@ export class CreateTeamComponent implements OnInit {
 						this.teamsService.searchUsers({}, term, this.pagingOptions, {}, true)
 					),
 					map((result) =>
-						result.elements.filter(
-							(user: any) => user?.userModel._id !== this.teamAdmin?.userModel._id
-						)
+						result.elements.filter((user: any) => user?._id !== this.teamAdmin?._id)
 					),
 					tap(() => {
 						this.usersLoading = false;
@@ -138,7 +136,7 @@ export class CreateTeamComponent implements OnInit {
 	save() {
 		this.isSubmitting = true;
 		this.teamsService
-			.create(this.team, this?.teamAdmin?.userModel._id)
+			.create(this.team, this?.teamAdmin?._id)
 			.pipe(
 				switchMap(() => this.sessionService.reloadSession()),
 				takeUntilDestroyed(this.destroyRef)

--- a/src/app/core/teams/list-team-members/list-team-members.component.html
+++ b/src/app/core/teams/list-team-members/list-team-members.component.html
@@ -27,13 +27,13 @@
 			<ng-container cdkColumnDef="name">
 				<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Name</th>
 				<td cdk-cell *cdkCellDef="let member">
-					<div>{{ member.userModel.name }}</div>
+					<div>{{ member.name }}</div>
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="username">
 				<th asy-sort-header cdk-header-cell *cdkHeaderCellDef>Username</th>
 				<td cdk-cell *cdkCellDef="let member">
-					<div>{{ member.userModel.username }}</div>
+					<div>{{ member.username }}</div>
 				</td>
 			</ng-container>
 			<ng-container cdkColumnDef="lastLogin">
@@ -42,9 +42,9 @@
 					<div
 						class="hide-overflow"
 						container="body"
-						tooltip="{{ user.userModel.lastLogin | utcDate }}"
+						tooltip="{{ user.lastLogin | utcDate }}"
 					>
-						{{ user.userModel.lastLogin | agoDate: false }}
+						{{ user.lastLogin | agoDate: false }}
 					</div>
 				</td>
 			</ng-container>
@@ -69,9 +69,9 @@
 				<td cdk-cell *cdkCellDef="let member">
 					<button
 						class="btn btn-sm dropdown-toggle p-0"
-						id="member-{{ member.userModel._id }}-role-menu-btn"
+						id="member-{{ member._id }}-role-menu-btn"
 						type="button"
-						attr.aria-controls="member-{{ member.userModel._id }}-role-menu"
+						attr.aria-controls="member-{{ member._id }}-role-menu"
 						*hasTeamRole="team; role: 'admin'; else: readOnlyRole"
 						[cdkMenuTriggerFor]="roleMenu"
 					>
@@ -80,8 +80,8 @@
 					<ng-template #roleMenu>
 						<div
 							class="dropdown-menu"
-							id="member-{{ member.userModel._id }}-role-menu"
-							attr.aria-labelledby="member-{{ member.userModel._id }}-role-menu-btn"
+							id="member-{{ member._id }}-role-menu"
+							attr.aria-labelledby="member-{{ member._id }}-role-menu-btn"
 							cdkMenu
 						>
 							<button

--- a/src/app/core/teams/list-team-members/list-team-members.component.ts
+++ b/src/app/core/teams/list-team-members/list-team-members.component.ts
@@ -191,13 +191,13 @@ export class ListTeamMembersComponent implements OnChanges, OnDestroy, OnInit {
 		this.dialogService
 			.confirm(
 				'Remove member from team?',
-				`Are you sure you want to remove member: "${member.userModel.name}" from this team?`,
+				`Are you sure you want to remove member: "${member.name}" from this team?`,
 				'Remove Member'
 			)
 			.closed.pipe(
 				first(),
 				filter((result) => result?.action === DialogAction.OK),
-				switchMap(() => this.teamsService.removeMember(this.team, member.userModel._id)),
+				switchMap(() => this.teamsService.removeMember(this.team, member._id)),
 				switchMap(() => this.sessionService.reloadSession()),
 				catchError((error: unknown) => {
 					if (error instanceof HttpErrorResponse) {
@@ -217,11 +217,7 @@ export class ListTeamMembersComponent implements OnChanges, OnDestroy, OnInit {
 		}
 
 		// If user is removing their own admin, verify that they know what they're doing
-		if (
-			this?.user?.userModel._id === member.userModel._id &&
-			member.role === 'admin' &&
-			role !== 'admin'
-		) {
+		if (this.user?._id === member._id && member.role === 'admin' && role !== 'admin') {
 			this.dialogService
 				.confirm(
 					'Remove "Team Admin" role?',
@@ -270,7 +266,7 @@ export class ListTeamMembersComponent implements OnChanges, OnDestroy, OnInit {
 		}
 
 		this.teamsService
-			.addMember(this.team, member.userModel._id, role)
+			.addMember(this.team, member._id, role)
 			.pipe(
 				switchMap(() => this.sessionService.reloadSession()),
 				catchError((error: unknown) => {
@@ -291,7 +287,7 @@ export class ListTeamMembersComponent implements OnChanges, OnDestroy, OnInit {
 			return of(member);
 		}
 
-		return this.teamsService.updateMemberRole(this.team, member.userModel._id, role);
+		return this.teamsService.updateMemberRole(this.team, member._id, role);
 	}
 
 	private reloadTeamMembers() {

--- a/src/app/core/teams/team-authorization.service.ts
+++ b/src/app/core/teams/team-authorization.service.ts
@@ -19,18 +19,12 @@ export class TeamAuthorizationService {
 		this.sessionService
 			.getSession()
 			.pipe(
-				map((session) =>
-					new TeamMember().setFromTeamMemberModel(null, session?.user.userModel)
-				),
+				map((session) => new TeamMember(session?.user)),
 				untilDestroyed(this)
 			)
 			.subscribe((member: TeamMember) => {
 				this.member = member;
 			});
-	}
-
-	hasTeams(): boolean {
-		return this.member.userModel.teams.length > 0;
 	}
 
 	public hasRole(team: Pick<Team, '_id'>, role: string | TeamRole): boolean {

--- a/src/app/core/teams/team-member.model.ts
+++ b/src/app/core/teams/team-member.model.ts
@@ -9,45 +9,40 @@ export class TeamMember extends User {
 
 	public roleDisplay = TeamRole.getDisplay(this.role);
 
-	hasTeams(): boolean {
-		return this.userModel.teams.length > 0;
+	constructor(model: any, team?: Team) {
+		super();
+		if (model) {
+			this.setFromTeamMemberModel(team, model);
+		}
 	}
 
-	public getRoleInTeam(team: Pick<Team, '_id'>): string | null {
-		if (null != this.userModel && null != team) {
-			const teams = this?.userModel?.teams ?? [];
-			// Find the role of this user in the team
-			const ndx = teams.findIndex((t: any) => t._id === team._id);
-
-			if (-1 !== ndx) {
-				return teams[ndx].role;
-			}
+	private setFromTeamMemberModel(model: any, team?: Team): TeamMember {
+		if (null == model) {
+			return this;
 		}
 
-		return null;
-	}
+		// Determine if user is implicit/explicit and active/inactive
+		this.explicit = (model.teams?.length ?? 0) > 0;
 
-	public setFromTeamMemberModel(team: Team | null, userModel: any): TeamMember {
-		// Set the user model
-		super.setFromUserModel(userModel);
+		if (team) {
+			this.role = this.getRoleInTeam(team) ?? TeamRole.MEMBER.role;
+			this.roleDisplay = TeamRole.getDisplay(this.role);
 
-		if (null != this.userModel) {
-			// Initialize the teams array if needed
-			if (null == userModel.teams) {
-				this.userModel.teams = [];
-			}
-
-			// Determine if user is implicit/explicit and active/inactive
-			this.explicit = (userModel.teams?.length ?? 0) > 0;
-
-			if (null != team) {
-				this.role = this.getRoleInTeam(team) ?? TeamRole.MEMBER.role;
-				this.roleDisplay = TeamRole.getDisplay(this.role);
-
-				this.explicit = userModel.teams.map((t: any) => t._id).includes(team._id);
-			}
+			this.explicit = model.teams.map((t: any) => t._id).includes(team._id);
 		}
 
 		return this;
+	}
+
+	public getRoleInTeam(team: Pick<Team, '_id'>): string | null {
+		const teams = this?.teams ?? [];
+		// Find the role of this user in the team
+		const ndx = teams.findIndex((t: any) => t._id === team._id);
+
+		if (-1 !== ndx) {
+			return teams[ndx].role;
+		}
+
+		return null;
 	}
 }

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -150,8 +150,8 @@ export class TeamsService extends AbstractEntityService<Team> {
 			.pipe(
 				tap((results: PagingResults) => {
 					if (null != results && Array.isArray(results.elements)) {
-						results.elements = results.elements.map((element: any) =>
-							new User().setFromUserModel(element)
+						results.elements = results.elements.map(
+							(element: any) => new User(element)
 						);
 					}
 				}),
@@ -166,9 +166,7 @@ export class TeamsService extends AbstractEntityService<Team> {
 
 	private handleTeamMembers(result: any, team: Team): PagingResults<TeamMember> {
 		if (null != result && Array.isArray(result.elements)) {
-			result.elements = result.elements.map((element: any) =>
-				new TeamMember().setFromTeamMemberModel(team, element)
-			);
+			result.elements = result.elements.map((element: any) => new TeamMember(element, team));
 		}
 		return result;
 	}


### PR DESCRIPTION
Previously `User` instances had just had an object field named `userModel` that contained all user details with none of the inner fields defined. Removed the `userModel` field and explicitly defined the fields directly on `User`